### PR TITLE
No longer set a default log level for errors.

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -273,12 +273,11 @@ class Client(object):
                 self.include_paths, self.exclude_paths
             )
 
-        if not log.get('level'):
-            log['level'] = 'error'
-
-        if isinstance(log['level'], six.integer_types):
+        if 'level' in log and isinstance(log['level'], six.integer_types):
             log['level'] = logging.getLevelName(log['level']).lower()
-        data['log'] = log
+
+        if log:
+            data['log'] = log
 
         if culprit:
             data['culprit'] = culprit

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -137,7 +137,7 @@ class Message(BaseEvent):
         message_data = {
             'id': str(uuid.uuid4()),
             'log': {
-                'level': data.get('level'),
+                'level': data.get('level', 'error'),
                 'logger_name': data.get('logger'),
                 'message': message,
                 'param_message': param_message['message'],

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -130,7 +130,6 @@ class DjangoClientTest(TestCase):
         self.assertTrue('exception' in event)
         exc = event['exception']
         self.assertEquals(exc['type'], 'Exception')
-        self.assertEquals(event['log']['level'], 'error')
         self.assertEquals(exc['message'], 'Exception: view exception')
         self.assertEquals(event['culprit'], 'tests.contrib.django.testapp.views.raise_exc')
 

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -32,7 +32,6 @@ class MiddlewareTest(TestCase):
         self.assertTrue('exception' in event)
         exc = event['exception']
         self.assertEquals(exc['type'], 'ValueError')
-        self.assertEquals(event['log']['level'], "error")
         self.assertEquals(exc['message'], 'ValueError: hello world')
 
         self.assertTrue('request' in event['context'])


### PR DESCRIPTION
Instead set it for messages specifically.