### PR TITLE
travis build stages [WIP]

### DIFF
--- a/.travis.old.yml
+++ b/.travis.old.yml
@@ -1,0 +1,87 @@
+sudo: false
+language: python
+python:
+- 2.7
+- 3.3
+- 3.4
+- 3.5
+- 3.6
+- nightly
+- pypy
+
+env:
+  matrix:
+    - WEBFRAMEWORK=django-1.8
+    - WEBFRAMEWORK=django-1.9
+    - WEBFRAMEWORK=django-1.10
+    - WEBFRAMEWORK=django-1.11
+    - WEBFRAMEWORK=django-master
+    - WEBFRAMEWORK=flask-0.10
+    - WEBFRAMEWORK=flask-0.11
+    - WEBFRAMEWORK=flask-0.12
+  global:
+  - PIP_CACHE="$HOME/.pip_cache"'
+  - RUN_SCRIPT="./travis/run_tests.sh"
+matrix:
+  exclude:
+  - python: 2.7
+    env: WEBFRAMEWORK=django-master
+  - python: 3.3
+    env: WEBFRAMEWORK=django-1.9
+  - python: 3.3
+    env: WEBFRAMEWORK=django-1.10
+  - python: 3.3
+    env: WEBFRAMEWORK=django-1.11
+  - python: 3.3
+    env: WEBFRAMEWORK=django-master
+  include:
+  - sudo: required
+    python: 3.4
+    services:
+    - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 RUN_SCRIPT=./travis/run_docker.sh
+  - sudo: required
+    python: 3.4
+    services:
+    - docker
+    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 RUN_SCRIPT=./travis/run_docker.sh
+      PRE_CMD=linux32
+  allow_failures:
+  - env: WEBFRAMEWORK=django-master
+  - python: nightly
+addons:
+  apt:
+    sources:
+     - mongodb-3.0-precise
+    packages:
+     - libevent-dev
+     - libzmq3-dev
+     - mongodb-org-server
+  postgresql: '9.4'
+cache:
+  directories:
+  - "$HOME/.pip_cache"
+script:
+- bash $RUN_SCRIPT
+notifications:
+  email: false
+  slack:
+    secure: LcTTbTj0Px0/9Bs/S/uwbhkdULlj1YVdHnU8F/kOa3bq2QdCTptqB719r6BnzHvW+QGyADvDZ25UncVXFuLuHY67ZYfmyZ/H2cj0nrRSuYdPct0avhVbT/3s50GlNWK5qkfZDuqw6szYTFrgFWJcr5dl7Zf6Vovcvd38uaYOdno=
+services:
+  - redis-server
+  - memcached
+  - mongodb
+  - mysql
+  - postgresql
+deploy:
+  provider: s3
+  access_key_id: AKIAIHY7VOHA6YNCCEYQ
+  secret_access_key:
+    secure: kb8Ho6JjTi3yTtdppw+fk6Zka0TLrFuEZU+O/b1YP4GEWUcf/aFKwtE8hi4SvsnjHGZxrAY9jRHKjVU02eEfbUTrCGu05ej9wEVC8IhevJMJljgInHWsG1PgPtNeD+uxWADXSXddjJ0U+N3Gh3I/PO530te2V2rQ1szJ2Hq79go=
+  bucket: wheels.opbeat.com
+  skip_cleanup: true
+  local_dir: wheelhouse
+  acl: public_read
+  on:
+    repo: opbeat/opbeat_python
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
     - stage: linters
       env: WEBFRAMEWORK=""
       python: 3.6
-      script: pip install isort && isort -c
+      script: pip install isort && isort -c -df && echo "OK"
 
     # python 2.7
     - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,258 @@
 sudo: false
 language: python
-python:
-- 2.7
-- 3.3
-- 3.4
-- 3.5
-- 3.6
-- nightly
-- pypy
+#python:
+#- 2.7
+#- 3.3
+#- 3.4
+#- 3.5
+#- 3.6
+#- nightly
+#- pypy
 
 env:
-  matrix:
-    - WEBFRAMEWORK=django-1.8
-    - WEBFRAMEWORK=django-1.9
-    - WEBFRAMEWORK=django-1.10
-    - WEBFRAMEWORK=django-1.11
-    - WEBFRAMEWORK=django-master
-    - WEBFRAMEWORK=flask-0.10
-    - WEBFRAMEWORK=flask-0.11
-    - WEBFRAMEWORK=flask-0.12
   global:
   - PIP_CACHE="$HOME/.pip_cache"'
   - RUN_SCRIPT="./travis/run_tests.sh"
-matrix:
+
+jobs:
+  include:
+    - stage: linters
+      env: WEBFRAMEWORK=""
+      python: 3.6
+      script: pip install isort && isort -c
+
+    # python 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: 2.7
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: 2.7
+
+    # python 3.3
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: 3.3
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: 3.3
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: 3.3
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: 3.3
+
+    # python 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-master
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: 3.4
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: 3.4  
+
+    # python 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-master
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: 3.5
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: 3.5
+
+    # python 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-master
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: 3.6
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: 3.6
+      
+      
+    # pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-master
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: pypy
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: pypy
+
+    # python nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.8
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.9
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.10
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-1.11
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=django-master
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.10
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.11
+      python: nightly
+    - stage: tests
+      script: bash $RUN_SCRIPT
+      env: WEBFRAMEWORK=flask-0.12
+      python: nightly
+
+    - stage: build
+      sudo: required
+      python: 3.4
+      services:
+      - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 RUN_SCRIPT=./travis/run_docker.sh
+    - stage: build
+      sudo: required
+      python: 3.4
+      services:
+      - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 RUN_SCRIPT=./travis/run_docker.sh
+        PRE_CMD=linux32
   exclude:
   - python: 2.7
     env: WEBFRAMEWORK=django-master
@@ -34,18 +264,7 @@ matrix:
     env: WEBFRAMEWORK=django-1.11
   - python: 3.3
     env: WEBFRAMEWORK=django-master
-  include:
-  - sudo: required
-    python: 3.4
-    services:
-    - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64 RUN_SCRIPT=./travis/run_docker.sh
-  - sudo: required
-    python: 3.4
-    services:
-    - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_i686 RUN_SCRIPT=./travis/run_docker.sh
-      PRE_CMD=linux32
+
   allow_failures:
   - env: WEBFRAMEWORK=django-master
   - python: nightly
@@ -61,8 +280,7 @@ addons:
 cache:
   directories:
   - "$HOME/.pip_cache"
-script:
-- bash $RUN_SCRIPT
+
 notifications:
   email: false
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,5 @@
 sudo: false
 language: python
-#python:
-#- 2.7
-#- 3.3
-#- 3.4
-#- 3.5
-#- 3.6
-#- nightly
-#- pypy
-
 env:
   global:
   - PIP_CACHE="$HOME/.pip_cache"'

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ isort:
 
 test:
 	if [ "$$TRAVIS_PYTHON_VERSION" != "3.5" ]; then \
-	py.test --isort --ignore=tests/asyncio; \
-	else py.test --isort; fi
+	py.test --ignore=tests/asyncio; \
+	else py.test; fi
 
 coverage:
 	coverage run runtests.py --include=elasticapm/* && \

--- a/elasticapm/utils/module_import.py
+++ b/elasticapm/utils/module_import.py
@@ -3,10 +3,8 @@ from importlib import import_module
 
 from elasticapm.utils import six
 
-
 # From Django
 # https://github.com/django/django/blob/master/django/utils/module_loading.py
-
 
 def import_string(dotted_path):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,6 @@ multi_line_output=0
 known_standard_library=importlib,types,asyncio
 known_django=django
 known_first_party=elasticapm,tests
-known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope
+known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope,urllib3,redis,jinja2,requests,certifi
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,6 @@ multi_line_output=0
 known_standard_library=importlib,types,asyncio
 known_django=django
 known_first_party=elasticapm,tests
-known_third_party=pytest,flask,aiohttp
+known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This splits our matrix into different build stages. First we run linters (only isort so far, but we'll probably add flake8 soonish), then the whole test matrix, then the manylinux1 wheel builds.

Unfortunately, this makes the `travis.yml` much larger due to the fact that we need to spell out the whole matrix manually. According to the travis IRC channel, and independently confirmed by @watson, the implicit build matrix isn't compatible with stages.