### PR TITLE
Add basic docs structure to agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+BUILD_DIR?=build
+
 isort:
 	isort -rc -vb .
 
@@ -10,4 +12,8 @@ coverage:
 	coverage run runtests.py --include=elasticapm/* && \
 	coverage html --omit=*/migrations/* -d cover
 
-.PHONY: isort test coverage
+docs:
+	sh ./script/build_docs.sh apm-agent-python ./docs ${BUILD_DIR}
+
+
+.PHONY: isort test coverage docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,6 @@
+= APM Python Agent Reference
+
+
+== APM Python Agent
+
+Welcome to the APM Python agent docs.

--- a/script/build_docs.sh
+++ b/script/build_docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+name=$1
+path=$2
+build_dir=$3
+
+docs_dir=$build_dir/docs
+html_dir=$build_dir/html_docs
+
+# Checks if docs clone already exists
+if [ ! -d $docs_dir ]; then
+    # Only head is cloned
+    git clone --depth=1 https://github.com/elastic/docs.git $docs_dir
+else
+    echo "$docs_dir already exists. Not cloning."
+fi
+
+
+index="${path}/index.asciidoc"
+
+echo "Building docs for ${name}..."
+echo "Index document: ${index}"
+
+dest_dir="$html_dir/${name}"
+mkdir -p "$dest_dir"
+params=""
+if [ "$PREVIEW" = "1" ]; then
+  params="--chunk=1 -open chunk=1 -open"
+fi
+$docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"


### PR DESCRIPTION
This is the basic doc structure needed for the elastic docs build. For convenience I added a script that can be executed with `make docs` to build the docs locally to see if the doc build passes and how the docs will look like.

As soon as we have Jenkins added as CI we should also add a build step for `make docs` to make sure we do not break the doc build.