### PR TITLE
add response data to Django transactions

### DIFF
--- a/elasticapm/conf/defaults.py
+++ b/elasticapm/conf/defaults.py
@@ -67,7 +67,7 @@ AUTO_LOG_STACKS = False
 PROCESSORS = (
     'elasticapm.processors.sanitize_stacktrace_locals',
     'elasticapm.processors.sanitize_http_request_cookies',
-    'elasticapm.processors.sanitize_http_request_headers',
+    'elasticapm.processors.sanitize_http_headers',
     'elasticapm.processors.sanitize_http_wsgi_env',
     'elasticapm.processors.sanitize_http_request_querystring',
     'elasticapm.processors.sanitize_http_request_body',

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -179,6 +179,16 @@ class DjangoClient(Client):
             result['url'] = get_url_dict(url)
         return result
 
+    def get_data_from_response(self, response):
+        result = {'status_code': str(response.status_code)}
+
+        # Django does not expose a public API to iterate over the headers of a response.
+        # Unfortunately, we have to access the private _headers dictionary here, which is
+        # a mapping of the form lower-case-header: (Original-Header, value)
+        if getattr(response, '_headers', {}):
+            result['headers'] = {key: value[1] for key, value in response._headers.items()}
+        return result
+
     def capture(self, event_type, request=None, **kwargs):
         if 'data' not in kwargs:
             kwargs['data'] = data = {}

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -175,9 +175,11 @@ class TracingMiddleware(MiddlewareMixin):
                     transaction_name,
                     request
                 )
-                transaction_data = self.client.get_data_from_request(request)
-                self.client.set_transaction_extra_data(transaction_data,
-                                                       'request')
+                request_data = self.client.get_data_from_request(request)
+                response_data = self.client.get_data_from_response(response)
+                self.client.set_transaction_extra_data(request_data, 'request')
+                self.client.set_transaction_extra_data(response_data, 'response')
+
                 user_data = self.client.get_user_info(request)
                 if user_data:
                     self.client.set_transaction_extra_data(

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -98,19 +98,28 @@ def sanitize_http_request_cookies(client, event):
     return event
 
 
-def sanitize_http_request_headers(client, event):
+def sanitize_http_headers(client, event):
     """
-    Sanitizes http request headers
+    Sanitizes http request/response headers
 
     :param client: an ElasticAPM client
     :param event: a transaction or error event
     :return: The modified event
     """
+    # request headers
     try:
         headers = event['context']['request']['headers']
         event['context']['request']['headers'] = varmap(_sanitize, headers)
     except (KeyError, TypeError):
         pass
+
+    # response headers
+    try:
+        headers = event['context']['response']['headers']
+        event['context']['response']['headers'] = varmap(_sanitize, headers)
+    except (KeyError, TypeError):
+        pass
+
     return event
 
 

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -14,7 +14,9 @@ class IgnoredException(Exception):
 
 
 def no_error(request):
-    return HttpResponse('')
+    resp = HttpResponse('')
+    resp['My-Header'] = 'foo'
+    return resp
 
 
 def fake_login(request):

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -35,6 +35,15 @@ class SanitizePasswordsProcessorTest(TestCase):
                         'raw': 'http://example.com/bla?foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
                         'search': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765'
                     }
+                },
+                'response': {
+                    'status_code': '200',
+                    'headers': {
+                        'foo': 'bar',
+                        'password': 'hello',
+                        'the_secret': 'hello',
+                        'a_password_here': 'hello',
+                    }
                 }
             }
         }
@@ -96,15 +105,16 @@ class SanitizePasswordsProcessorTest(TestCase):
         assert (result['context']['request']['headers']['cookie'] ==
                 'foo=bar; password={0}; the_secret={0}; csrftoken={0}'.format(processors.MASK))
 
-    def test_sanitize_http_request_headers(self):
-        result = processors.sanitize_http_request_headers(None, self.http_test_data)
-
-        assert result['context']['request']['headers'] == {
+    def test_sanitize_http_headers(self):
+        result = processors.sanitize_http_headers(None, self.http_test_data)
+        expected = {
             'foo': 'bar',
             'password': processors.MASK,
             'the_secret': processors.MASK,
             'a_password_here': processors.MASK,
         }
+        assert result['context']['request']['headers'] == expected
+        assert result['context']['response']['headers'] == expected
 
     def test_sanitize_http_wgi_env(self):
         result = processors.sanitize_http_wsgi_env(None, self.http_test_data)


### PR DESCRIPTION
This adds `status_code` and `headers` to the transaction data.

Unfortunately, we can't do the same for exceptions, as we do not have access to the response object in the exception handler.