### PR TITLE
series of Django 2.0 fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@
 import sys
 from os.path import abspath, dirname, join
 
+from tests.utils.compat import middleware_setting
+
 where_am_i = dirname(abspath(__file__))
 
 BASE_TEMPLATE_DIR = join(where_am_i, 'tests', 'contrib', 'django', 'testapp',
@@ -27,7 +29,7 @@ def pytest_configure(config):
         settings = None
     if settings is not None and not settings.configured:
         import django
-        settings.configure(
+        settings_dict = dict(
             DATABASES={
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',
@@ -63,11 +65,6 @@ def pytest_configure(config):
             TEMPLATE_DEBUG=False,
             TEMPLATE_DIRS=[BASE_TEMPLATE_DIR],
             ALLOWED_HOSTS=['*'],
-            MIDDLEWARE_CLASSES=[
-                'django.contrib.sessions.middleware.SessionMiddleware',
-                'django.contrib.auth.middleware.AuthenticationMiddleware',
-                'django.contrib.messages.middleware.MessageMiddleware',
-            ],
             TEMPLATES=[
                 {
                     'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -83,7 +80,12 @@ def pytest_configure(config):
                     },
                 },
             ]
-
         )
+        settings_dict.update(**middleware_setting(django.VERSION, [
+            'django.contrib.sessions.middleware.SessionMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+        ]))
+        settings.configure(**settings_dict)
         if hasattr(django, 'setup'):
             django.setup()

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -231,7 +231,7 @@ class Command(BaseCommand):
         self.write('')
 
         # check if middleware is set, and if it is at the first position
-        middleware = list(settings.MIDDLEWARE_CLASSES)
+        middleware = list(getattr(settings, 'MIDDLEWARE', getattr(settings, 'MIDDLEWARE_CLASSES', [])))
         try:
             pos = middleware.index(
                 'elasticapm.contrib.django.middleware.TracingMiddleware'

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -121,8 +121,10 @@ class TracingMiddleware(MiddlewareMixin):
                     TracingMiddleware._elasticapm_instrumented = True
 
     def instrument_middlewares(self):
-        if getattr(django_settings, 'MIDDLEWARE_CLASSES', None):
-            for middleware_path in django_settings.MIDDLEWARE_CLASSES:
+        middlewares = (getattr(django_settings, 'MIDDLEWARE', None) or
+                       getattr(django_settings, 'MIDDLEWARE_CLASSES', None))
+        if middlewares:
+            for middleware_path in middlewares:
                 module_path, class_name = middleware_path.rsplit('.', 1)
                 try:
                     module = import_module(module_path)

--- a/tests/contrib/django/testapp/middleware.py
+++ b/tests/contrib/django/testapp/middleware.py
@@ -1,19 +1,27 @@
-class BrokenRequestMiddleware(object):
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # no-op class for Django < 1.10
+    class MiddlewareMixin(object):
+        pass
+
+
+class BrokenRequestMiddleware(MiddlewareMixin):
     def process_request(self, request):
         raise ImportError('request')
 
 
-class BrokenResponseMiddleware(object):
+class BrokenResponseMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         raise ImportError('response')
 
 
-class BrokenViewMiddleware(object):
+class BrokenViewMiddleware(MiddlewareMixin):
     def process_view(self, request, func, args, kwargs):
         raise ImportError('view')
 
 
-class MetricsNameOverrideMiddleware(object):
+class MetricsNameOverrideMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         request._elasticapm_transaction_name = 'foobar'
         return response

--- a/tests/instrumentation/psycopg2_tests.py
+++ b/tests/instrumentation/psycopg2_tests.py
@@ -6,7 +6,7 @@ import pytest
 from elasticapm.instrumentation import control
 from elasticapm.instrumentation.packages.psycopg2 import (PGCursorProxy,
                                                           extract_signature)
-from tests.contrib.django.django_tests import get_client
+from tests.fixtures import test_client
 
 try:
     import psycopg2
@@ -210,34 +210,32 @@ def test_multi_statement_sql():
     assert "CREATE TABLE" == actual
 
 @pytest.mark.skipif(not has_postgres_configured, reason="PostgresSQL not configured")
-def test_psycopg2_register_type(postgres_connection):
+def test_psycopg2_register_type(postgres_connection, test_client):
     import psycopg2.extras
 
-    client = get_client()
     control.instrument()
 
     try:
-        client.begin_transaction("web.django")
+        test_client.begin_transaction("web.django")
         new_type = psycopg2.extras.register_uuid(None, postgres_connection)
-        client.end_transaction(None, "test-transaction")
+        test_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the traces for the other tests.
-        client.instrumentation_store.get_all()
+        test_client.instrumentation_store.get_all()
 
     assert new_type is not None
 
 
 @pytest.mark.skipif(not has_postgres_configured, reason="PostgresSQL not configured")
-def test_psycopg2_register_json(postgres_connection):
+def test_psycopg2_register_json(postgres_connection, test_client):
     # register_json bypasses register_type, so we have to test unwrapping
     # separately
     import psycopg2.extras
 
-    client = get_client()
     control.instrument()
 
     try:
-        client.begin_transaction("web.django")
+        test_client.begin_transaction("web.django")
         # as arg
         new_type = psycopg2.extras.register_json(postgres_connection,
                                                  loads=lambda x: x)
@@ -246,42 +244,40 @@ def test_psycopg2_register_json(postgres_connection):
         new_type = psycopg2.extras.register_json(conn_or_curs=postgres_connection,
                                                  loads=lambda x: x)
         assert new_type is not None
-        client.end_transaction(None, "test-transaction")
+        test_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the traces for the other tests.
-        client.instrumentation_store.get_all()
+        test_client.instrumentation_store.get_all()
 
 
 @pytest.mark.skipif(not has_postgres_configured, reason="PostgresSQL not configured")
-def test_psycopg2_tracing_outside_of_elasticapm_transaction(postgres_connection):
-    client = get_client()
+def test_psycopg2_tracing_outside_of_elasticapm_transaction(postgres_connection, test_client):
     control.instrument()
     cursor = postgres_connection.cursor()
     # check that the cursor is a proxy, even though we're not in an elasticapm
     # transaction
     assert isinstance(cursor, PGCursorProxy)
     cursor.execute('SELECT 1')
-    transactions = client.instrumentation_store.get_all()
+    transactions = test_client.instrumentation_store.get_all()
     assert transactions == []
 
 
 @pytest.mark.skipif(not has_postgres_configured, reason="PostgresSQL not configured")
-def test_psycopg2_select_LIKE(postgres_connection):
+def test_psycopg2_select_LIKE(postgres_connection, test_client):
     """
     Check that we pass queries with %-notation but without parameters
     properly to the dbapi backend
     """
-    client = get_client()
     control.instrument()
     cursor = postgres_connection.cursor()
 
     try:
-        client.begin_transaction("web.django")
+        test_client.begin_transaction("web.django")
         cursor.execute("SELECT * FROM test WHERE name LIKE 't%'")
         cursor.fetchall()
-        client.end_transaction(None, "test-transaction")
+        test_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the traces for the other tests.
-        transactions = client.instrumentation_store.get_all()
+        transactions = test_client.instrumentation_store.get_all()
         traces = transactions[0]['traces']
         assert traces[0]['name'] == 'SELECT FROM test'

--- a/tests/utils/compat.py
+++ b/tests/utils/compat.py
@@ -5,3 +5,10 @@ try:
 except ImportError:
     from unittest import TestCase
     from unittest import skipIf
+
+
+def middleware_setting(django_version, middleware_list):
+    if django_version < (1, 10):
+        return {'MIDDLEWARE_CLASSES': middleware_list}
+    else:
+        return {'MIDDLEWARE': middleware_list, 'MIDDLEWARE_CLASSES': None}


### PR DESCRIPTION
Main change is a different approach of `MIDDLEWARE_CLASSES` vs. `MIDDLEWARE`. Instead of duplicating the tests, we decide which configuration option to use at runtime.