### PR TITLE
added tagging functionality

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -560,7 +560,7 @@ class Client(object):
             return
         if not _key:
             _key = 'extra'
-        transaction.extra[_key] = data
+        transaction._context[_key] = data
 
     def close(self):
         self._traces_collect()

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -7,10 +7,10 @@ import time
 import uuid
 
 from elasticapm.conf import defaults
-from elasticapm.utils import get_name_from_func
+from elasticapm.utils import compat, get_name_from_func
 from elasticapm.utils.lru import LRUCache
 
-__all__ = ('trace', )
+__all__ = ('trace', 'add_tag')
 
 error_logger = logging.getLogger('elasticapm.errors')
 
@@ -19,6 +19,8 @@ thread_local.transaction = None
 
 
 _time_func = time.time
+
+TAG_RE = re.compile('^[^.*\"]+$')
 
 
 def get_transaction(clear=False):
@@ -50,7 +52,8 @@ class Transaction(object):
         self.traces = []
         self.trace_stack = []
         self.ignore_subtree = False
-        self.extra = {}
+        self._context = {}
+        self._tags = {}
 
         self._trace_counter = 0
 
@@ -96,6 +99,7 @@ class Transaction(object):
         return trace
 
     def to_dict(self):
+        self._context['tags'] = self._tags
         return {
             'id': str(self.id),
             'name': self.name,
@@ -103,7 +107,7 @@ class Transaction(object):
             'duration': self.duration * 1000,  # milliseconds
             'result': str(self.result),
             'timestamp': self.timestamp.strftime(defaults.TIMESTAMP_FORMAT),
-            'context': self.extra,
+            'context': self._context,
             'traces': [
                 trace_obj.to_dict() for trace_obj in self.traces
             ]
@@ -240,3 +244,21 @@ class trace(object):
 
         if transaction:
             transaction.end_trace(self.skip_frames)
+
+
+def add_tag(name, value):
+    """
+    Adds a tag to the current transaction. Both name and value should be strings
+
+    :param name: name of the tag
+    :param value: value of the tag
+    """
+    transaction = get_transaction()
+    if not transaction:
+        error_logger.warning("Ignored tag %s. No transaction currently active.", name)
+        return
+    name = compat.text_type(name)
+    if TAG_RE.match(name):
+        transaction._tags[compat.text_type(name)] = compat.text_type(value)
+    else:
+        error_logger.warning("Ignored tag %s. Tag names can't contain stars, dots or double quotes.", name)


### PR DESCRIPTION
To tag a transaction, the user only has to import `elasticapm`, then call
`elasticapm.add_tag()`:

    import elasticapm
    elasticapm.add_tag('foo', 'bar')