### PR TITLE
added tagging functionality (alternative API)

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -560,7 +560,7 @@ class Client(object):
             return
         if not _key:
             _key = 'extra'
-        transaction.extra[_key] = data
+        transaction._context[_key] = data
 
     def close(self):
         self._traces_collect()

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -1,7 +1,9 @@
+import logging
 import time
 
 from mock import Mock
 
+import elasticapm
 from elasticapm.traces import TransactionsStore, get_transaction, trace
 from tests.utils.compat import TestCase
 
@@ -128,3 +130,29 @@ def test_get_transaction_clear():
     t = requests_store.begin_transaction("test")
     assert t == get_transaction(clear=True)
     assert get_transaction() is None
+
+
+def test_tag_transaction():
+    requests_store = TransactionsStore(lambda: [], 99999)
+    t = requests_store.begin_transaction("test")
+    elasticapm.tag(foo='bar')
+    requests_store.end_transaction(200, 'test')
+
+    assert t._tags == {'foo': 'bar'}
+    transaction_dict = t.to_dict()
+    assert transaction_dict['context']['tags'] == {'foo': 'bar'}
+
+
+def test_tag_while_no_transaction(caplog):
+    elasticapm.tag(foo='bar')
+    record = caplog.records[0]
+    assert record.levelno == logging.WARNING
+    assert 'foo' in record.args
+
+
+def test_tag_with_non_string_value():
+    requests_store = TransactionsStore(lambda: [], 99999)
+    t = requests_store.begin_transaction("test")
+    elasticapm.tag(foo=1)
+    requests_store.end_transaction(200, 'test')
+    assert t._tags == {'foo': '1'}


### PR DESCRIPTION
To tag a transaction, the user only has to import `elasticapm`, then call
`elasticapm.tag(tag1=value1, tag2=value2)`:

    import elasticapm
    elasticapm.tag(foo='bar')

This is an alternative API to PR #27. It's IMO a nicer API, but due to the key being a keyword argument, it has stricter rules than what we enforce in the APM server (e.g. it can't have any whitespace).