### PR TITLE
removed Query event and camelCased client API methods

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -27,7 +27,6 @@ from elasticapm.traces import TransactionsStore, get_transaction
 from elasticapm.transport.base import TransportException
 from elasticapm.utils import json_encoder as json
 from elasticapm.utils import compat, is_master_process, stacks, varmap
-from elasticapm.utils.deprecation import deprecated
 from elasticapm.utils.encoding import shorten, transform
 from elasticapm.utils.module_import import import_string
 from elasticapm.utils.stacks import get_culprit, iter_stack_frames
@@ -483,19 +482,6 @@ class Client(object):
         """
         return self.capture('Message', message=message, **kwargs)
 
-    @deprecated(alternative="capture_message()")
-    def captureMessage(self, message, **kwargs):
-        """
-        Deprecated
-        :param message:
-        :type message:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
-        """
-        self.capture_message(message, **kwargs)
-
     def capture_exception(self, exc_info=None, **kwargs):
         """
         Creates an event from an exception.
@@ -511,29 +497,6 @@ class Client(object):
         for you.
         """
         return self.capture('Exception', exc_info=exc_info, **kwargs)
-
-    @deprecated(alternative="capture_exception()")
-    def captureException(self, exc_info=None, **kwargs):
-        """
-        Deprecated
-        """
-        self.capture_exception(exc_info, **kwargs)
-
-    def capture_query(self, query, params=(), engine=None, **kwargs):
-        """
-        Creates an event for a SQL query.
-
-        >>> client.capture_query('SELECT * FROM foo')
-        """
-        return self.capture('Query', query=query, params=params, engine=engine,
-                            **kwargs)
-
-    @deprecated(alternative="capture_query()")
-    def captureQuery(self, *args, **kwargs):
-        """
-        Deprecated
-        """
-        self.capture_query(*args, **kwargs)
 
     def begin_transaction(self, transaction_type):
         """Register the start of a transaction on the client

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -24,7 +24,6 @@ from elasticapm.contrib.flask.utils import get_data_from_request
 from elasticapm.handlers.logging import LoggingHandler
 from elasticapm.utils import (build_name_with_http_method_prefix,
                               disabled_due_to_debug)
-from elasticapm.utils.deprecation import deprecated
 
 logger = logging.getLogger('elasticapm.errors.client')
 
@@ -180,11 +179,3 @@ class ElasticAPM(object):
     def capture_message(self, *args, **kwargs):
         assert self.client, 'capture_message called before application configured'
         return self.client.capture_message(*args, **kwargs)
-
-    @deprecated(alternative="capture_exception()")
-    def captureException(self, *args, **kwargs):
-        return self.capture_exception(*args, **kwargs)
-
-    @deprecated(alternative="capture_message()")
-    def captureMessage(self, *args, **kwargs):
-        return self.capture_message(*args, **kwargs)

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -18,7 +18,7 @@ from elasticapm.utils.encoding import shorten, to_unicode
 from elasticapm.utils.stacks import (get_culprit, get_stack_info,
                                      iter_traceback_frames)
 
-__all__ = ('BaseEvent', 'Exception', 'Message', 'Query')
+__all__ = ('BaseEvent', 'Exception', 'Message')
 
 logger = logging.getLogger(__name__)
 
@@ -146,28 +146,3 @@ class Message(BaseEvent):
         if isinstance(data.get('stacktrace'), dict):
             message_data['log']['stacktrace'] = data['stacktrace']['frames']
         return message_data
-
-
-class Query(BaseEvent):
-    """
-    Messages store the following metadata:
-
-    - query: 'SELECT * FROM table'
-    - engine: 'postgesql_psycopg2'
-    """
-
-    def to_string(self, data):
-        sql = data['query']
-        return sql['query']
-
-    def get_hash(self, data):
-        sql = data['query']
-        return [sql['query'], sql['engine']]
-
-    def capture(self, query, engine, **kwargs):
-        return {
-            'query': {
-                'query': query,
-                'engine': engine,
-            }
-        }


### PR DESCRIPTION
this removes the long-deprecated camelCased API methods, as well as the `Query` event type, which AFAIK we never really supported.