### PR TITLE
use urllib3-mock instead of our (very limited) self-built mock

### DIFF
--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -14,8 +14,8 @@ except ImportError:
     from urllib import parse as urlparse
 
 
-
 responses = Responses('urllib3')
+
 
 @responses.activate
 def test_send():


### PR DESCRIPTION
This gets rid of a lot of ugly warnings like 

    tests/instrumentation/requests_tests.py::InstrumentRequestsTest::test_requests_instrumentation_via_prepared_request
      /usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/cookiejar.py:1597: UserWarning: http.cookiejar bug!
      Traceback (most recent call last):
        File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/cookiejar.py", line 1595, in make_cookies
          split_header_words(rfc2965_hdrs), request)
        File "/usr/local/Cellar/python3/3.6.2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/http/cookiejar.py", line 384, in split_header_words
          for text in header_values:
      TypeError: 'Mock' object is not iterable