### PR TITLE
never gather log stack trace for exceptions

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -273,9 +273,10 @@ class Client(object):
         :param extra: a dictionary of additional standard metadata
         :return: a 32-length string identifying this event
         """
-
-        data = self.build_msg_for_logging(event_type, data, date,
-                                          extra, stack, **kwargs)
+        if event_type == 'Exception':
+            # never gather log stack for exceptions
+            stack = False
+        data = self.build_msg_for_logging(event_type, data, date, extra, stack, **kwargs)
 
         if data:
             servers = [server + defaults.ERROR_API_PATH for server in self.config.servers]

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -370,6 +370,7 @@ def test_exception_event(test_client):
     assert frame['module'] == __name__
     assert frame['function'] == 'test_exception_event'
     assert 'timestamp' in event
+    assert 'log' not in event
 
 
 def test_message_event(test_client):


### PR DESCRIPTION
This caused a validation error because we'd add an otherwise empty `log`
object to the exception.