### PR TITLE
make sure that content isn't preloaded in the urllib3 response

### DIFF
--- a/elasticapm/transport/http_urllib3.py
+++ b/elasticapm/transport/http_urllib3.py
@@ -34,7 +34,7 @@ class Urllib3Transport(HTTPTransport):
         try:
             try:
                 response = self.http.urlopen(
-                    'POST', self._url, body=data, headers=headers, timeout=timeout
+                    'POST', self._url, body=data, headers=headers, timeout=timeout, preload_content=False
                 )
             except Exception as e:
                 print_trace = True


### PR DESCRIPTION
This ensures that `response.read()` returns the response content.
Unfortunately, we can't really test this with urllib3-mock, since it
doesn't implement this behavior.