### PR TITLE
turns out that in Python2, the URL _also_ has to be binary.

### DIFF
--- a/elasticapm/transport/http_urllib3.py
+++ b/elasticapm/transport/http_urllib3.py
@@ -37,11 +37,14 @@ class Urllib3Transport(HTTPTransport):
         headers = {k.encode('ascii') if isinstance(k, compat.text_type) else k:
                    v.encode('ascii') if isinstance(v, compat.text_type) else v
                    for k, v in headers.items()}
-
+        if compat.PY2 and isinstance(self._url, compat.text_type):
+            url = self._url.encode('utf-8')
+        else:
+            url = self._url
         try:
             try:
                 response = self.http.urlopen(
-                    'POST', self._url, body=data, headers=headers, timeout=timeout, preload_content=False
+                    'POST', url, body=data, headers=headers, timeout=timeout, preload_content=False
                 )
             except Exception as e:
                 print_trace = True

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -97,6 +97,8 @@ def test_header_encodings():
         mock_urlopen.return_value = mock.Mock(status=202)
         transport.send('', headers)
     _, args, kwargs = mock_urlopen.mock_calls[0]
+    if compat.PY2:
+        assert isinstance(args[1], compat.binary_type)
     for k, v in kwargs['headers'].items():
         assert isinstance(k, compat.binary_type)
         assert isinstance(v, compat.binary_type)


### PR DESCRIPTION
But not in Python 3, that would be too easy.