### PR TITLE
added `max-event-queue-length` setting

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -6,11 +6,13 @@
 [[changelog]]
 == Changelog
 
-//[[release-next]]
-//[float]
-//=== Unreleased
-//https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev3\...master[Check the HEAD diff]
 
+[[release-next]]
+[float]
+=== Unreleased
+https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev3\...master[Check the HEAD diff]
+
+ * added `max-event-queue-length` setting. ({pull}67[#67])
 
 [[release-v1.0.0.dev3]]
 [float]
@@ -27,6 +29,7 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev2\...v1.0.0.dev2[C
  * added normalization of HTTP status codes into classes for the `transaction.result` field. A HTTP status of `200`
    will be turned into `HTTP 2xx`. The unchanged status code is still available in `context.response.status_code`.
    ({pull}85[#85])
+
 
 [[release-v1.0.0.dev2]]
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -248,6 +248,23 @@ A lower value will increase the load on your APM server,
 while a higher value can increase the memory pressure of your app.
 A higher value also impacts the time until transactions are indexed and searchable in Elasticsearch.
 
+
+[float]
+[[config-max-event-queue-length]]
+==== `max_event_queue_length`
+
+|============
+| Environment                          | Django/Flask             | Default
+| `ELASTIC_APM_MAX_EVENT_QUEUE_LENGTH` | `MAX_EVENT_QUEUE_LENGTH` | `500`
+|============
+
+Maximum queue length of transactions before sending transactions to the APM server.
+A lower value will increase the load on your APM server,
+while a higher value can increase the memory pressure of your app.
+A higher value also impacts the time until transactions are indexed and searchable in Elasticsearch.
+
+This setting is useful to limit memory consumption if you experience a sudden spike of traffic.
+
 [float]
 [[config-processors]]
 ==== `processors`

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -129,6 +129,7 @@ class Client(object):
         self.instrumentation_store = TransactionsStore(
             lambda: self.get_stack_info_for_trace(iter_stack_frames(), False),
             self.config.traces_send_frequency,
+            self.config.max_event_queue_length,
             self.config.transactions_ignore_patterns
         )
         compat.atexit_register(self.close)

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -155,6 +155,7 @@ class Config(_ConfigBase):
         'elasticapm.processors.mark_in_app_frames',
     ])
     traces_send_frequency = _ConfigValue('TRACES_SEND_FREQ', type=int, default=60)
+    max_event_queue_length = _ConfigValue('MAX_EVENT_QUEUE_LENGTH', type=int, default=500)
     async_mode = _BoolConfigValue('ASYNC_MODE', default=True)
     instrument_django_middleware = _BoolConfigValue('INSTRUMENT_DJANGO_MIDDLEWARE', default=True)
     transactions_ignore_patterns = _ListConfigValue('TRANSACTIONS_IGNORE_PATTERNS', default=[])

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -151,9 +151,10 @@ class Trace(object):
 
 
 class TransactionsStore(object):
-    def __init__(self, get_frames, collect_frequency, ignore_patterns=None):
+    def __init__(self, get_frames, collect_frequency, max_queue_length=None, ignore_patterns=None):
         self.cond = threading.Condition()
         self.collect_frequency = collect_frequency
+        self.max_queue_length = max_queue_length
         self._get_frames = get_frames
         self._transactions = []
         self._last_collect = _time_func()
@@ -174,7 +175,8 @@ class TransactionsStore(object):
         return transactions
 
     def should_collect(self):
-        return (_time_func() - self._last_collect) >= self.collect_frequency
+        return ((self.max_queue_length and len(self._transactions) >= self.max_queue_length) or
+                (_time_func() - self._last_collect) >= self.collect_frequency)
 
     def __len__(self):
         with self.cond:

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -133,6 +133,35 @@ def test_get_transaction_clear():
     assert get_transaction() is None
 
 
+def test_should_collect_time():
+    requests_store = TransactionsStore(lambda: [], collect_frequency=5)
+    requests_store._last_collect -= 6
+
+    assert requests_store.should_collect()
+
+
+def test_should_not_collect_time():
+    requests_store = TransactionsStore(lambda: [], collect_frequency=5)
+    requests_store._last_collect -= 3
+
+    assert not requests_store.should_collect()
+
+
+def test_should_collect_count():
+    requests_store = TransactionsStore(lambda: [], collect_frequency=5, max_queue_length=5)
+    requests_store._transactions = 6 * [1]
+    requests_store._last_collect -= 3
+
+    assert requests_store.should_collect()
+
+
+def test_should_not_collect_count():
+    requests_store = TransactionsStore(lambda: [], collect_frequency=5, max_queue_length=5)
+    requests_store._transactions = 4 * [1]
+
+    assert not requests_store.should_collect()
+
+
 def test_tag_transaction():
     requests_store = TransactionsStore(lambda: [], 99999)
     t = requests_store.begin_transaction("test")


### PR DESCRIPTION
This allows to limit the total amount of transactions in the queue, e.g.
to limit the memory consumption with a sudden traffic spike