### PR TITLE
rewrite all nosetests to py.test

### DIFF
--- a/elasticapm/contrib/django/apps.py
+++ b/elasticapm/contrib/django/apps.py
@@ -10,13 +10,17 @@ class ElasticAPMConfig(AppConfig):
     label = 'elasticapm.contrib.django'
     verbose_name = 'ElasticAPM'
 
+    def __init__(self, *args, **kwargs):
+        super(ElasticAPMConfig, self).__init__(*args, **kwargs)
+        self.client = None
+
     def ready(self):
-        client = get_client()
-        register_handlers(client)
-        if not client.config.disable_instrumentation:
-            instrument(client)
+        self.client = get_client()
+        register_handlers(self.client)
+        if not self.client.config.disable_instrumentation:
+            instrument(self.client)
         else:
-            client.logger.debug("Skipping instrumentation. DISABLE_INSTRUMENTATION is set.")
+            self.client.logger.debug("Skipping instrumentation. DISABLE_INSTRUMENTATION is set.")
 
 
 def register_handlers(client):

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -164,6 +164,8 @@ class Command(BaseCommand):
                     'Success! We tracked the error successfully! You should be'
                     ' able to see it in a few seconds at the above URL'
                 )
+        finally:
+            client.close()
 
     def handle_check(self, command, **options):
         """Check your settings for common misconfigurations"""

--- a/elasticapm/contrib/django/middleware/wsgi.py
+++ b/elasticapm/contrib/django/middleware/wsgi.py
@@ -8,7 +8,9 @@ Large portions are
 :copyright: (c) 2010 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+from django.apps import apps
 
+from elasticapm.contrib.django.client import get_client
 from elasticapm.middleware import ElasticAPM as ElasticAPMBase
 
 
@@ -25,5 +27,8 @@ class ElasticAPM(ElasticAPMBase):
 
     @property
     def client(self):
-        from elasticapm.contrib.django.client import client
-        return client
+        try:
+            app = apps.get_app_config('elasticapm.contrib.django')
+            return app.client
+        except LookupError:
+            return get_client()

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -10,7 +10,7 @@ from elasticapm.transport.base import Transport, TransportException
 from elasticapm.transport.http import HTTPTransport
 from elasticapm.utils import compat
 from elasticapm.utils.compat import urlparse
-from tests.fixtures import test_client  # noqa
+from tests.fixtures import elasticapm_client  # noqa
 
 
 def test_client_state_should_try_online():
@@ -58,17 +58,17 @@ class DummyTransport(Transport):
         pass
 
 
-def test_app_info(test_client):
-    app_info = test_client.get_app_info()
-    assert app_info['name'] == test_client.config.app_name
+def test_app_info(elasticapm_client):
+    app_info = elasticapm_client.get_app_info()
+    assert app_info['name'] == elasticapm_client.config.app_name
     assert app_info['language'] == {
         'name': 'python',
         'version': platform.python_version()
     }
 
 
-def test_system_info(test_client):
-    system_info = test_client.get_system_info()
+def test_system_info(elasticapm_client):
+    system_info = elasticapm_client.get_system_info()
     assert {'hostname', 'architecture', 'platform'} == set(system_info.keys())
 
 
@@ -322,42 +322,42 @@ def test_client_shutdown_async(mock_traces_collect, mock_send):
     assert mock_send.call_count == 1
 
 
-def test_encode_decode(test_client):
+def test_encode_decode(elasticapm_client):
     data = {'foo': 'bar'}
-    encoded = test_client.encode(data)
+    encoded = elasticapm_client.encode(data)
     assert isinstance(encoded, compat.binary_type)
-    assert data == test_client.decode(encoded)
+    assert data == elasticapm_client.decode(encoded)
 
 
-def test_explicit_message_on_message_event(test_client):
-    test_client.capture('Message', message='test', data={
+def test_explicit_message_on_message_event(elasticapm_client):
+    elasticapm_client.capture('Message', message='test', data={
         'message': 'foo'
     })
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
     assert event['message'] == 'foo'
 
 
-def test_explicit_message_on_exception_event(test_client):
+def test_explicit_message_on_exception_event(elasticapm_client):
     try:
         raise ValueError('foo')
     except ValueError:
-        test_client.capture('Exception', data={'message': 'foobar'})
+        elasticapm_client.capture('Exception', data={'message': 'foobar'})
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
     assert event['message'] == 'foobar'
 
 
-def test_exception_event(test_client):
+def test_exception_event(elasticapm_client):
     try:
         raise ValueError('foo')
     except ValueError:
-        test_client.capture('Exception')
+        elasticapm_client.capture('Exception')
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
     assert 'exception' in event
     exc = event['exception']
     assert exc['message'] == 'ValueError: foo'
@@ -375,21 +375,21 @@ def test_exception_event(test_client):
     assert 'log' not in event
 
 
-def test_message_event(test_client):
-    test_client.capture('Message', message='test')
+def test_message_event(elasticapm_client):
+    elasticapm_client.capture('Message', message='test')
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
     assert event['log']['message'] == 'test'
     assert 'stacktrace' not in event
     assert 'timestamp' in event
 
 
-def test_logger(test_client):
-    test_client.capture('Message', message='test', data={'logger': 'test'})
+def test_logger(elasticapm_client):
+    elasticapm_client.capture('Message', message='test', data={'logger': 'test'})
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
     assert event['logger'] == 'test'
     assert 'timestamp' in event
 
@@ -419,12 +419,12 @@ def test_metrics_collection(should_collect, mock_send):
 
 @mock.patch('elasticapm.base.Client.send')
 @mock.patch('elasticapm.base.TransactionsStore.should_collect')
-def test_call_end_twice(should_collect, mock_send, test_client):
+def test_call_end_twice(should_collect, mock_send, elasticapm_client):
     should_collect.return_value = False
-    test_client.begin_transaction("celery")
+    elasticapm_client.begin_transaction("celery")
 
-    test_client.end_transaction('test-transaction', 200)
-    test_client.end_transaction('test-transaction', 200)
+    elasticapm_client.end_transaction('test-transaction', 200)
+    elasticapm_client.end_transaction('test-transaction', 200)
 
 
 @mock.patch('elasticapm.utils.is_master_process')

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -11,44 +11,46 @@ from elasticapm.transport.http import HTTPTransport
 from elasticapm.utils import compat
 from elasticapm.utils.compat import urlparse
 from tests.fixtures import test_client  # noqa
-from tests.utils.compat import TestCase
 
 
-class ClientStateTest(TestCase):
-    def test_should_try_online(self):
-        state = ClientState()
-        assert state.should_try() == True
+def test_client_state_should_try_online():
+    state = ClientState()
+    assert state.should_try() is True
 
-    def test_should_try_new_error(self):
-        state = ClientState()
-        state.status = state.ERROR
-        state.last_check = time.time()
-        state.retry_number = 1
-        assert state.should_try() == False
 
-    def test_should_try_time_passed_error(self):
-        state = ClientState()
-        state.status = state.ERROR
-        state.last_check = time.time() - 10
-        state.retry_number = 1
-        assert state.should_try() == True
+def test_client_state_should_try_new_error():
+    state = ClientState()
+    state.status = state.ERROR
+    state.last_check = time.time()
+    state.retry_number = 1
+    assert state.should_try() is False
 
-    def test_set_fail(self):
-        state = ClientState()
-        state.set_fail()
-        assert state.status == state.ERROR
-        self.assertNotEquals(state.last_check, None)
-        assert state.retry_number == 1
 
-    def test_set_success(self):
-        state = ClientState()
-        state.status = state.ERROR
-        state.last_check = 'foo'
-        state.retry_number = 0
-        state.set_success()
-        assert state.status == state.ONLINE
-        assert state.last_check == None
-        assert state.retry_number == 0
+def test_client_state_should_try_time_passed_error():
+    state = ClientState()
+    state.status = state.ERROR
+    state.last_check = time.time() - 10
+    state.retry_number = 1
+    assert state.should_try() is True
+
+
+def test_client_state_set_fail():
+    state = ClientState()
+    state.set_fail()
+    assert state.status == state.ERROR
+    assert state.last_check is not None
+    assert state.retry_number == 1
+
+
+def test_client_state_set_success():
+    state = ClientState()
+    state.status = state.ERROR
+    state.last_check = 'foo'
+    state.retry_number = 0
+    state.set_success()
+    assert state.status == state.ONLINE
+    assert state.last_check is None
+    assert state.retry_number == 0
 
 
 class DummyTransport(Transport):

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -6,25 +6,24 @@ import mock
 
 from elasticapm.conf import (Config, _BoolConfigValue, _ConfigBase,
                              _ConfigValue, _ListConfigValue, setup_logging)
-from tests.utils.compat import TestCase
 
 
-class SetupLoggingTest(TestCase):
-    def test_basic_not_configured(self):
-        with mock.patch('logging.getLogger', spec=logging.getLogger) as getLogger:
-            logger = getLogger()
-            logger.handlers = []
-            handler = mock.Mock()
-            result = setup_logging(handler)
-            self.assertTrue(result)
+def test_basic_not_configured():
+    with mock.patch('logging.getLogger', spec=logging.getLogger) as getLogger:
+        logger = getLogger()
+        logger.handlers = []
+        handler = mock.Mock()
+        result = setup_logging(handler)
+        assert result
 
-    def test_basic_already_configured(self):
-        with mock.patch('logging.getLogger', spec=logging.getLogger) as getLogger:
-            handler = mock.Mock()
-            logger = getLogger()
-            logger.handlers = [handler]
-            result = setup_logging(handler)
-            self.assertFalse(result)
+
+def test_basic_already_configured():
+    with mock.patch('logging.getLogger', spec=logging.getLogger) as getLogger:
+        handler = mock.Mock()
+        logger = getLogger()
+        logger.handlers = [handler]
+        result = setup_logging(handler)
+        assert not result
 
 
 def test_config_dict():

--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -7,26 +7,26 @@ import mock
 from elasticapm.contrib.celery import (register_exception_tracking,
                                        register_instrumentation)
 from tests.contrib.django.testapp.tasks import failing_task, successful_task
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
-def test_failing_celery_task(test_client):
-    register_exception_tracking(test_client)
+def test_failing_celery_task(elasticapm_client):
+    register_exception_tracking(elasticapm_client)
     t = failing_task.delay()
     assert t.state == 'FAILURE'
-    assert len(test_client.events) == 1
-    error = test_client.events[0]['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    error = elasticapm_client.events[0]['errors'][0]
     assert error['culprit'] == 'tests.contrib.django.testapp.tasks.failing_task'
     assert error['exception']['message'] == 'ValueError: foo'
 
 
-def test_successful_celery_task_instrumentation(test_client):
-    register_instrumentation(test_client)
+def test_successful_celery_task_instrumentation(elasticapm_client):
+    register_instrumentation(elasticapm_client)
     with mock.patch('elasticapm.traces.TransactionsStore.should_collect') as should_collect_mock:
         should_collect_mock.return_value = True
         t = successful_task.delay()
     assert t.state == 'SUCCESS'
-    assert len(test_client.events[0]['transactions']) == 1
-    transaction = test_client.events[0]['transactions'][0]
+    assert len(elasticapm_client.events[0]['transactions']) == 1
+    transaction = elasticapm_client.events[0]['transactions'][0]
     assert transaction['name'] == 'tests.contrib.django.testapp.tasks.successful_task'
     assert transaction['type'] == 'celery'

--- a/tests/contrib/celery/flask_tests.py
+++ b/tests/contrib/celery/flask_tests.py
@@ -5,7 +5,7 @@ import mock
 
 from tests.contrib.flask.fixtures import (flask_apm_client, flask_app,
                                           flask_celery)
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 def test_task_failure(flask_celery):

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -16,7 +16,6 @@ from django.db import DatabaseError
 from django.http import QueryDict
 from django.http.cookie import SimpleCookie
 from django.template import TemplateSyntaxError
-from django.test import TestCase
 from django.test.client import Client as _TestClient
 from django.test.client import ClientHandler as _TestClientHandler
 from django.test.utils import override_settings
@@ -25,13 +24,14 @@ import mock
 
 from elasticapm.base import Client
 from elasticapm.contrib.django import DjangoClient
-from elasticapm.contrib.django.apps import register_handlers
 from elasticapm.contrib.django.client import client, get_client
 from elasticapm.contrib.django.handlers import LoggingHandler
 from elasticapm.contrib.django.middleware.wsgi import ElasticAPM
 from elasticapm.traces import Transaction
 from elasticapm.utils import compat
 from elasticapm.utils.lru import LRUCache
+from tests.contrib.django.fixtures import (elasticapm_client,
+                                           sending_elasticapm_client)
 from tests.contrib.django.testapp.views import IgnoredException
 from tests.utils.compat import middleware_setting
 
@@ -50,9 +50,6 @@ except ImportError:
     has_with_eager_tasks = False
 
 
-settings.ELASTIC_APM = {'CLIENT': 'tests.contrib.django.django_tests.TempStoreClient'}
-
-
 class MockClientHandler(_TestClientHandler):
     def __call__(self, environ, start_response=[]):
         # this pretends doesnt require start_response
@@ -65,805 +62,826 @@ class MockMiddleware(ElasticAPM):
         return list(super(MockMiddleware, self).__call__(environ, start_response))
 
 
-class TempStoreClient(DjangoClient):
-    def __init__(self, *args, **kwargs):
-        self.events = []
-        super(TempStoreClient, self).__init__(*args, **kwargs)
-
-    def send(self, **kwargs):
-        self.events.append(kwargs)
+def test_proxy_responds_as_client():
+    assert get_client() == client
 
 
-class ClientProxyTest(TestCase):
-    def test_proxy_responds_as_client(self):
-        assert get_client() == client
-
-    def test_basic(self):
-        config = {
-            'APP_ID': 'key',
-            'ORGANIZATION_ID': 'org',
-            'SECRET_TOKEN': '99'
-        }
-        config.update(settings.ELASTIC_APM)
-        event_count = len(client.events)
-        with self.settings(ELASTIC_APM=config):
-            client.capture('Message', message='foo')
-            assert len(client.events) == event_count + 1
-            client.events.pop(0)
+def test_basic(elasticapm_client):
+    config = {
+        'APP_ID': 'key',
+        'ORGANIZATION_ID': 'org',
+        'SECRET_TOKEN': '99'
+    }
+    event_count = len(elasticapm_client.events)
+    with override_settings(ELASTIC_APM=config):
+        elasticapm_client.capture('Message', message='foo')
+        assert len(elasticapm_client.events) == event_count + 1
+        elasticapm_client.events.pop(0)
 
 
-class DjangoClientTest(TestCase):
+def test_basic_django(elasticapm_client):
+    elasticapm_client.capture('Message', message='foo')
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    log = event['log']
+    assert 'message' in log
 
-    def setUp(self):
-        self.elasticapm_client = get_client()
-        register_handlers(self.elasticapm_client)
-        self.elasticapm_client.events = []
+    assert log['message'] == 'foo'
+    assert log['level'] == 'error'
+    assert log['param_message'] == 'foo'
 
-    def test_basic(self):
-        self.elasticapm_client.capture('Message', message='foo')
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        log = event['log']
-        assert 'message' in log
 
-        assert log['message'] == 'foo'
-        assert log['level'] == 'error'
-        assert log['param_message'] == 'foo'
+def test_signal_integration(elasticapm_client):
+    try:
+        int('hello')
+    except ValueError:
+        got_request_exception.send(sender=None, request=None)
 
-    def test_signal_integration(self):
-        try:
-            int('hello')
-        except:
-            got_request_exception.send(sender=self.__class__, request=None)
-        else:
-            self.fail('Expected an exception.')
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'exception' in event
+    exc = event['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == u"ValueError: invalid literal for int() with base 10: 'hello'"
+    assert event['culprit'] == 'tests.contrib.django.django_tests.test_signal_integration'
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert 'exception' in event
-        exc = event['exception']
-        assert exc['type'] == 'ValueError'
-        assert exc['message'] == u"ValueError: invalid literal for int() with base 10: 'hello'"
-        assert event['culprit'] == 'tests.contrib.django.django_tests.test_signal_integration'
 
-    def test_view_exception(self):
+def test_view_exception(elasticapm_client, client):
+    with pytest.raises(Exception):
+        client.get(reverse('elasticapm-raise-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'exception' in event
+    exc = event['exception']
+    assert exc['type'] == 'Exception'
+    assert exc['message'] == 'Exception: view exception'
+    assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
+
+
+def test_view_exception_debug(elasticapm_client, client):
+    elasticapm_client.config.debug = False
+    with override_settings(DEBUG=True):
         with pytest.raises(Exception):
-            self.client.get(reverse('elasticapm-raise-exc'))
+            client.get(reverse('elasticapm-raise-exc'))
+    assert len(elasticapm_client.events) == 0
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert 'exception' in event
-        exc = event['exception']
-        assert exc['type'] == 'Exception'
-        assert exc['message'] == 'Exception: view exception'
-        assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
 
-    def test_view_exception_debug(self):
-        self.elasticapm_client.config.debug = False
-        with self.settings(DEBUG=True):
-            with pytest.raises(Exception): self.client.get(reverse('elasticapm-raise-exc'))
-        assert len(self.elasticapm_client.events) == 0
+def test_view_exception_elasticapm_debug(elasticapm_client, client):
+    elasticapm_client.config.debug = True
+    with override_settings(DEBUG=True):
+        with pytest.raises(Exception): client.get(reverse('elasticapm-raise-exc'))
+    assert len(elasticapm_client.events) == 1
 
-    def test_view_exception_elasticapm_debug(self):
-        self.elasticapm_client.config.debug = True
-        with self.settings(DEBUG=True):
-            with pytest.raises(Exception): self.client.get(reverse('elasticapm-raise-exc'))
-        assert len(self.elasticapm_client.events) == 1
 
-    def test_user_info(self):
-        user = User(username='admin', email='admin@example.com')
+@pytest.mark.django_db
+def test_user_info(elasticapm_client, client):
+    user = User(username='admin', email='admin@example.com')
+    user.set_password('admin')
+    user.save()
+
+    with pytest.raises(Exception):
+        client.get(reverse('elasticapm-raise-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'user' in event['context']
+    user_info = event['context']['user']
+    assert 'is_authenticated' in user_info
+    assert not user_info['is_authenticated']
+    assert user_info['username'] == ''
+    assert 'email' not in user_info
+
+    assert client.login(username='admin', password='admin')
+
+    with pytest.raises(Exception):
+        client.get(reverse('elasticapm-raise-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'user' in event['context']
+    user_info = event['context']['user']
+    assert 'is_authenticated' in user_info
+    assert user_info['is_authenticated']
+    assert 'username' in user_info
+    assert user_info['username'] == 'admin'
+    assert 'email' in user_info
+    assert user_info['email'] == 'admin@example.com'
+
+
+@pytest.mark.django_db
+def test_user_info_raises_database_error(elasticapm_client, client):
+    user = User(username='admin', email='admin@example.com')
+    user.set_password('admin')
+    user.save()
+
+    assert client.login(username='admin', password='admin')
+
+    with mock.patch("django.contrib.auth.models.User.is_authenticated") as is_authenticated:
+        is_authenticated.side_effect = DatabaseError("Test Exception")
+        with pytest.raises(Exception):
+            client.get(reverse('elasticapm-raise-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'user' in event['context']
+    user_info = event['context']['user']
+    assert user_info == {}
+
+
+@pytest.mark.django_db
+def test_user_info_with_custom_user(elasticapm_client, client):
+    with override_settings(AUTH_USER_MODEL='testapp.MyUser'):
+        from django.contrib.auth import get_user_model
+        MyUser = get_user_model()
+        user = MyUser(my_username='admin')
         user.set_password('admin')
         user.save()
-
+        assert client.login(username='admin', password='admin')
         with pytest.raises(Exception):
-            self.client.get(reverse('elasticapm-raise-exc'))
+            client.get(reverse('elasticapm-raise-exc'))
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert 'user' in event['context']
-        user_info = event['context']['user']
-        assert 'is_authenticated' in user_info
-        assert not user_info['is_authenticated']
-        assert user_info['username'] == ''
-        assert 'email' not in user_info
-
-        assert self.client.login(username='admin', password='admin')
-
-        with pytest.raises(Exception):
-            self.client.get(reverse('elasticapm-raise-exc'))
-
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
         assert 'user' in event['context']
         user_info = event['context']['user']
         assert 'is_authenticated' in user_info
         assert user_info['is_authenticated']
         assert 'username' in user_info
         assert user_info['username'] == 'admin'
-        assert 'email' in user_info
-        assert user_info['email'] == 'admin@example.com'
+        assert 'email' not in user_info
 
-    def test_user_info_raises_database_error(self):
-        user = User(username='admin', email='admin@example.com')
-        user.set_password('admin')
-        user.save()
 
-        assert self.client.login(username='admin', password='admin')
-
-        with mock.patch("django.contrib.auth.models.User.is_authenticated") as is_authenticated:
-            is_authenticated.side_effect = DatabaseError("Test Exception")
-            with pytest.raises(Exception):
-                self.client.get(reverse('elasticapm-raise-exc'))
-
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert 'user' in event['context']
-        user_info = event['context']['user']
-        assert user_info == {}
-
-    @pytest.mark.skipif(django.VERSION < (1, 5),
-                        reason='Custom user model was introduced with Django 1.5')
-    def test_user_info_with_custom_user(self):
-        with self.settings(AUTH_USER_MODEL='testapp.MyUser'):
-            from django.contrib.auth import get_user_model
-            MyUser = get_user_model()
-            user = MyUser(my_username='admin')
-            user.set_password('admin')
-            user.save()
-            assert self.client.login(username='admin', password='admin')
-            with pytest.raises(Exception):
-                self.client.get(reverse('elasticapm-raise-exc'))
-
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-            assert 'user' in event['context']
-            user_info = event['context']['user']
-            assert 'is_authenticated' in user_info
-            assert user_info['is_authenticated']
-            assert 'username' in user_info
-            assert user_info['username'] == 'admin'
-            assert 'email' not in user_info
-
-    @pytest.mark.skipif(django.VERSION > (1, 9),
-                        reason='MIDDLEWARE_CLASSES removed in Django 2.0')
-    def test_user_info_with_non_django_auth(self):
-        with self.settings(INSTALLED_APPS=[
-            app for app in settings.INSTALLED_APPS
-            if app != 'django.contrib.auth'
-        ]) and self.settings(MIDDLEWARE_CLASSES=[
-            m for m in settings.MIDDLEWARE_CLASSES
-            if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
-        ]):
-            with pytest.raises(Exception):
-                resp = self.client.get(reverse('elasticapm-raise-exc'))
-
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['user'] == {}
-
-    @pytest.mark.skipif(django.VERSION < (1, 10),
-                        reason='MIDDLEWARE new in Django 1.10')
-    def test_user_info_with_non_django_auth_django_2(self):
-        with self.settings(INSTALLED_APPS=[
-            app for app in settings.INSTALLED_APPS
-            if app != 'django.contrib.auth'
-        ]) and self.settings(MIDDLEWARE_CLASSES=None, MIDDLEWARE=[
-            m for m in settings.MIDDLEWARE
-            if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
-        ]):
-            with pytest.raises(Exception):
-                resp = self.client.get(reverse('elasticapm-raise-exc'))
-
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['user'] == {}
-
-    @pytest.mark.skipif(django.VERSION > (1, 9),
-                        reason='MIDDLEWARE_CLASSES removed in Django 2.0')
-    def test_user_info_without_auth_middleware(self):
-        with self.settings(MIDDLEWARE_CLASSES=[
-            m for m in settings.MIDDLEWARE_CLASSES
-            if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
-        ]):
-            with pytest.raises(Exception):
-                self.client.get(reverse('elasticapm-raise-exc'))
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['user'] == {}
-
-    @pytest.mark.skipif(django.VERSION < (1, 10),
-                        reason='MIDDLEWARE new in Django 1.10')
-    def test_user_info_without_auth_middleware_django_2(self):
-        with self.settings(MIDDLEWARE_CLASSES=None, MIDDLEWARE=[
-            m for m in settings.MIDDLEWARE
-            if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
-        ]):
-            with pytest.raises(Exception):
-                self.client.get(reverse('elasticapm-raise-exc'))
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['user'] == {}
-
-    def test_request_middleware_exception(self):
-        with self.settings(**middleware_setting(django.VERSION,
-                                                ['tests.contrib.django.testapp.middleware.BrokenRequestMiddleware'])):
-            with pytest.raises(ImportError):
-                self.client.get(reverse('elasticapm-raise-exc'))
-
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert 'exception' in event
-            exc = event['exception']
-            assert exc['type'] == 'ImportError'
-            assert exc['message'] == 'ImportError: request'
-            assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_request'
-
-    def test_response_middlware_exception(self):
-        if django.VERSION[:2] < (1, 3):
-            return
-        with self.settings(**middleware_setting(django.VERSION,
-                                                ['tests.contrib.django.testapp.middleware.BrokenResponseMiddleware'])):
-            with pytest.raises(ImportError):
-                self.client.get(reverse('elasticapm-no-error'))
-
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert 'exception' in event
-            exc = event['exception']
-            assert exc['type'] == 'ImportError'
-            assert exc['message'] == 'ImportError: response'
-            assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_response'
-
-    def test_broken_500_handler_with_middleware(self):
-        with self.settings(BREAK_THAT_500=True):
-            client = _TestClient(REMOTE_ADDR='127.0.0.1')
-            client.handler = MockMiddleware(MockClientHandler())
-
-            with self.settings(**middleware_setting(django.VERSION, [])):
-                with pytest.raises(Exception):
-                    client.get(reverse('elasticapm-raise-exc'))
-
-            assert len(self.elasticapm_client.events) == 2
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert 'exception' in event
-            exc = event['exception']
-            assert exc['type'] == 'Exception'
-            assert exc['message'] == 'Exception: view exception'
-            assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
-
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert 'exception' in event
-            exc = event['exception']
-            assert exc['type'] == 'ValueError'
-            assert exc['message'] == 'ValueError: handler500'
-            assert event['culprit'] == 'tests.contrib.django.testapp.urls.handler500'
-
-    def test_view_middleware_exception(self):
-        with self.settings(**middleware_setting(django.VERSION,
-                                                ['tests.contrib.django.testapp.middleware.BrokenViewMiddleware'])):
-            with pytest.raises(ImportError):
-                self.client.get(reverse('elasticapm-raise-exc'))
-
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert 'exception' in event
-            exc = event['exception']
-            assert exc['type'] == 'ImportError'
-            assert exc['message'] == 'ImportError: view'
-            assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_view'
-
-    def test_exclude_modules_view(self):
-        exclude_paths = self.elasticapm_client.config.exclude_paths
-        self.elasticapm_client.config.exclude_paths = ['tests.views.decorated_raise_exc']
+@pytest.mark.skipif(django.VERSION > (1, 9),
+                    reason='MIDDLEWARE_CLASSES removed in Django 2.0')
+def test_user_info_with_non_django_auth(elasticapm_client, client):
+    with override_settings(INSTALLED_APPS=[
+        app for app in settings.INSTALLED_APPS
+        if app != 'django.contrib.auth'
+    ]) and override_settings(MIDDLEWARE_CLASSES=[
+        m for m in settings.MIDDLEWARE_CLASSES
+        if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
+    ]):
         with pytest.raises(Exception):
-            self.client.get(reverse('elasticapm-raise-exc-decor'))
+            resp = client.get(reverse('elasticapm-raise-exc'))
 
-        assert len(self.elasticapm_client.events) == 1, self.elasticapm_client.events
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['user'] == {}
 
+
+@pytest.mark.skipif(django.VERSION < (1, 10),
+                    reason='MIDDLEWARE new in Django 1.10')
+def test_user_info_with_non_django_auth_django_2(elasticapm_client, client):
+    with override_settings(INSTALLED_APPS=[
+        app for app in settings.INSTALLED_APPS
+        if app != 'django.contrib.auth'
+    ]) and override_settings(MIDDLEWARE_CLASSES=None, MIDDLEWARE=[
+        m for m in settings.MIDDLEWARE
+        if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
+    ]):
+        with pytest.raises(Exception):
+            resp = client.get(reverse('elasticapm-raise-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['user'] == {}
+
+
+@pytest.mark.skipif(django.VERSION > (1, 9),
+                    reason='MIDDLEWARE_CLASSES removed in Django 2.0')
+def test_user_info_without_auth_middleware(elasticapm_client, client):
+    with override_settings(MIDDLEWARE_CLASSES=[
+        m for m in settings.MIDDLEWARE_CLASSES
+        if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
+    ]):
+        with pytest.raises(Exception):
+            client.get(reverse('elasticapm-raise-exc'))
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['user'] == {}
+
+
+@pytest.mark.skipif(django.VERSION < (1, 10),
+                    reason='MIDDLEWARE new in Django 1.10')
+def test_user_info_without_auth_middleware_django_2(elasticapm_client, client):
+    with override_settings(MIDDLEWARE_CLASSES=None, MIDDLEWARE=[
+        m for m in settings.MIDDLEWARE
+        if m != 'django.contrib.auth.middleware.AuthenticationMiddleware'
+    ]):
+        with pytest.raises(Exception):
+            client.get(reverse('elasticapm-raise-exc'))
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['user'] == {}
+
+
+def test_request_middleware_exception(elasticapm_client, client):
+    with override_settings(**middleware_setting(django.VERSION,
+                                            ['tests.contrib.django.testapp.middleware.BrokenRequestMiddleware'])):
+        with pytest.raises(ImportError):
+            client.get(reverse('elasticapm-raise-exc'))
+
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
+
+        assert 'exception' in event
+        exc = event['exception']
+        assert exc['type'] == 'ImportError'
+        assert exc['message'] == 'ImportError: request'
+        assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_request'
+
+
+def test_response_middlware_exception(elasticapm_client, client):
+    if django.VERSION[:2] < (1, 3):
+        return
+    with override_settings(**middleware_setting(django.VERSION,
+                                            ['tests.contrib.django.testapp.middleware.BrokenResponseMiddleware'])):
+        with pytest.raises(ImportError):
+            client.get(reverse('elasticapm-no-error'))
+
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
+
+        assert 'exception' in event
+        exc = event['exception']
+        assert exc['type'] == 'ImportError'
+        assert exc['message'] == 'ImportError: response'
+        assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_response'
+
+
+def test_broken_500_handler_with_middleware(elasticapm_client, client):
+    with override_settings(BREAK_THAT_500=True):
+        client.handler = MockMiddleware(MockClientHandler())
+
+        with override_settings(**middleware_setting(django.VERSION, [])):
+            with pytest.raises(Exception):
+                client.get(reverse('elasticapm-raise-exc'))
+
+        assert len(elasticapm_client.events) == 2
+        event = elasticapm_client.events.pop(0)['errors'][0]
+
+        assert 'exception' in event
+        exc = event['exception']
+        assert exc['type'] == 'Exception'
+        assert exc['message'] == 'Exception: view exception'
         assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
-        self.elasticapm_client.config.exclude_paths = exclude_paths
 
-    def test_include_modules(self):
-        include_paths = self.elasticapm_client.config.include_paths
-        self.elasticapm_client.config.include_paths = ['django.shortcuts.get_object_or_404']
+        event = elasticapm_client.events.pop(0)['errors'][0]
 
-        with pytest.raises(Exception):
-            self.client.get(reverse('elasticapm-django-exc'))
+        assert 'exception' in event
+        exc = event['exception']
+        assert exc['type'] == 'ValueError'
+        assert exc['message'] == 'ValueError: handler500'
+        assert event['culprit'] == 'tests.contrib.django.testapp.urls.handler500'
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+def test_view_middleware_exception(elasticapm_client, client):
+    with override_settings(**middleware_setting(django.VERSION,
+                                            ['tests.contrib.django.testapp.middleware.BrokenViewMiddleware'])):
+        with pytest.raises(ImportError):
+            client.get(reverse('elasticapm-raise-exc'))
 
-        assert event['culprit'] == 'django.shortcuts.get_object_or_404'
-        self.elasticapm_client.config.include_paths = include_paths
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
 
-    def test_ignored_exception_is_ignored(self):
-        with pytest.raises(IgnoredException):
-            self.client.get(reverse('elasticapm-ignored-exception'))
-        assert len(self.elasticapm_client.events) == 0
+        assert 'exception' in event
+        exc = event['exception']
+        assert exc['type'] == 'ImportError'
+        assert exc['message'] == 'ImportError: view'
+        assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_view'
 
-    def test_template_name_as_view(self):
-        # TODO this test passes only with TEMPLATE_DEBUG=True
-        with override_settings(
-            TEMPLATE_DEBUG=True,
-            TEMPLATES=[
-                {
-                    'BACKEND': settings.TEMPLATES[0]['BACKEND'],
-                    'DIRS': settings.TEMPLATES[0]['DIRS'],
-                    'OPTIONS': {
-                        'context_processors': settings.TEMPLATES[0]['OPTIONS']['context_processors'],
-                        'loaders': settings.TEMPLATES[0]['OPTIONS']['loaders'],
-                        'debug': True,
-                    },
+
+def test_exclude_modules_view(elasticapm_client, client):
+    elasticapm_client.config.exclude_paths = ['tests.views.decorated_raise_exc']
+    with pytest.raises(Exception):
+        client.get(reverse('elasticapm-raise-exc-decor'))
+
+    assert len(elasticapm_client.events) == 1, elasticapm_client.events
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
+
+
+def test_include_modules(elasticapm_client, client):
+    elasticapm_client.config.include_paths = ['django.shortcuts.get_object_or_404']
+
+    with pytest.raises(Exception):
+        client.get(reverse('elasticapm-django-exc'))
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert event['culprit'] == 'django.shortcuts.get_object_or_404'
+
+
+def test_ignored_exception_is_ignored(elasticapm_client, client):
+    with pytest.raises(IgnoredException):
+        client.get(reverse('elasticapm-ignored-exception'))
+    assert len(elasticapm_client.events) == 0
+
+
+def test_template_name_as_view(elasticapm_client, client):
+    # TODO this test passes only with TEMPLATE_DEBUG=True
+    with override_settings(
+        TEMPLATE_DEBUG=True,
+        TEMPLATES=[
+            {
+                'BACKEND': settings.TEMPLATES[0]['BACKEND'],
+                'DIRS': settings.TEMPLATES[0]['DIRS'],
+                'OPTIONS': {
+                    'context_processors': settings.TEMPLATES[0]['OPTIONS']['context_processors'],
+                    'loaders': settings.TEMPLATES[0]['OPTIONS']['loaders'],
+                    'debug': True,
                 },
-            ]
-        ):
-            with pytest.raises(TemplateSyntaxError):
-                self.client.get(reverse('elasticapm-template-exc'))
+            },
+        ]
+    ):
+        with pytest.raises(TemplateSyntaxError):
+            client.get(reverse('elasticapm-template-exc'))
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
 
-        assert event['culprit'] == 'error.html'
+    assert event['culprit'] == 'error.html'
 
-        assert event['template']['context_line'] == '{% invalid template tag %}\n'
+    assert event['template']['context_line'] == '{% invalid template tag %}\n'
 
-    @pytest.mark.skipif(compat.PY3, reason='see Python bug #10805')
-    def test_record_none_exc_info(self):
-        # sys.exc_info can return (None, None, None) if no exception is being
-        # handled anywhere on the stack. See:
-        #  http://docs.python.org/library/sys.html#sys.exc_info
-        record = logging.LogRecord(
-            'foo',
-            logging.INFO,
-            pathname=None,
-            lineno=None,
-            msg='test',
-            args=(),
-            exc_info=(None, None, None),
-        )
-        handler = LoggingHandler()
-        handler.emit(record)
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+@pytest.mark.skipif(compat.PY3, reason='see Python bug #10805')
+def test_record_none_exc_info(elasticapm_client):
+    # sys.exc_info can return (None, None, None) if no exception is being
+    # handled anywhere on the stack. See:
+    #  http://docs.python.org/library/sys.html#sys.exc_info
+    record = logging.LogRecord(
+        'foo',
+        logging.INFO,
+        pathname=None,
+        lineno=None,
+        msg='test',
+        args=(),
+        exc_info=(None, None, None),
+    )
+    handler = LoggingHandler()
+    handler.emit(record)
 
-        assert event['log']['param_message'] == 'test'
-        assert event['log']['logger_name'] == 'foo'
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert event['log']['param_message'] == 'test'
+    assert event['log']['logger_name'] == 'foo'
+    assert event['log']['level'] == 'info'
+    assert 'exception' not in event
+
+
+def test_404_middleware(elasticapm_client, client):
+    with override_settings(**middleware_setting(django.VERSION,
+                                            ['elasticapm.contrib.django.middleware.Catch404Middleware'])):
+        resp = client.get('/non-existant-page')
+        assert resp.status_code == 404
+
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
+
         assert event['log']['level'] == 'info'
-        assert 'exception' not in event
-
-    def test_404_middleware(self):
-        with self.settings(**middleware_setting(django.VERSION,
-                                                ['elasticapm.contrib.django.middleware.Catch404Middleware'])):
-            resp = self.client.get('/non-existant-page')
-            assert resp.status_code == 404
-
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-
-            assert event['log']['level'] == 'info'
-            assert event['log']['logger_name'] == 'http404'
-
-            assert 'request' in event['context']
-            request = event['context']['request']
-            assert request['url']['raw'] == u'http://testserver/non-existant-page'
-            assert request['method'] == 'GET'
-            assert request['url']['search'] == ''
-            assert request['body'] == None
-
-    def test_404_middleware_with_debug(self):
-        self.elasticapm_client.config.debug = False
-        with self.settings(
-                DEBUG=True,
-                **middleware_setting(django.VERSION, [
-                    'elasticapm.contrib.django.middleware.Catch404Middleware'
-                ])
-        ):
-            resp = self.client.get('/non-existant-page')
-            assert resp.status_code == 404
-            assert len(self.elasticapm_client.events) == 0
-
-    def test_response_error_id_middleware(self):
-        with self.settings(**middleware_setting(django.VERSION, [
-                'elasticapm.contrib.django.middleware.ErrorIdMiddleware',
-                'elasticapm.contrib.django.middleware.Catch404Middleware'])):
-            resp = self.client.get('/non-existant-page')
-            assert resp.status_code == 404
-            headers = dict(resp.items())
-            assert 'X-ElasticAPM-ErrorId' in headers
-            assert len(self.elasticapm_client.events) == 1
-            event = self.elasticapm_client.events.pop(0)['errors'][0]
-            assert event['id'] == headers['X-ElasticAPM-ErrorId']
-
-    def test_get_client(self):
-        assert get_client() == get_client()
-        assert get_client('elasticapm.base.Client').__class__ == Client
-        assert get_client() == self.elasticapm_client
-
-        assert get_client('%s.%s' % (self.elasticapm_client.__class__.__module__, self.elasticapm_client.__class__.__name__)) == self.elasticapm_client
-        assert get_client() == self.elasticapm_client
-
-    # This test only applies to Django 1.3+
-    def test_raw_post_data_partial_read(self):
-        if django.VERSION[:2] < (1, 3):
-            return
-        v = compat.b('{"foo": "bar"}')
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(v + compat.b('\r\n\r\n')),
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'application/json',
-            'CONTENT_LENGTH': len(v),
-            'ACCEPT': 'application/json',
-        })
-        request.read(1)
-
-        self.elasticapm_client.capture('Message', message='foo', request=request)
-
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+        assert event['log']['logger_name'] == 'http404'
 
         assert 'request' in event['context']
         request = event['context']['request']
-        assert request['method'] == 'POST'
-        assert request['body'] == '<unavailable>'
+        assert request['url']['raw'] == u'http://testserver/non-existant-page'
+        assert request['method'] == 'GET'
+        assert request['url']['search'] == ''
+        assert request['body'] == None
 
-    def test_post_data(self):
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(),
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'application/json',
-            'ACCEPT': 'application/json',
-        })
-        request.POST = QueryDict("x=1&y=2")
-        self.elasticapm_client.capture('Message', message='foo', request=request)
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+def test_404_middleware_with_debug(elasticapm_client, client):
+    elasticapm_client.config.debug = False
+    with override_settings(
+            DEBUG=True,
+            **middleware_setting(django.VERSION, [
+                'elasticapm.contrib.django.middleware.Catch404Middleware'
+            ])
+    ):
+        resp = client.get('/non-existant-page')
+        assert resp.status_code == 404
+        assert len(elasticapm_client.events) == 0
 
-        assert 'request' in event['context']
-        request = event['context']['request']
-        assert request['method'] == 'POST'
-        assert request['body'] == {'x': '1', 'y': '2'}
 
-    def test_post_raw_data(self):
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(compat.b('foobar')),
-            'wsgi.url_scheme': 'http',
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'application/json',
-            'ACCEPT': 'application/json',
-            'CONTENT_LENGTH': '6',
-        })
-        self.elasticapm_client.capture('Message', message='foo', request=request)
+def test_response_error_id_middleware(elasticapm_client, client):
+    with override_settings(**middleware_setting(django.VERSION, [
+            'elasticapm.contrib.django.middleware.ErrorIdMiddleware',
+            'elasticapm.contrib.django.middleware.Catch404Middleware'])):
+        resp = client.get('/non-existant-page')
+        assert resp.status_code == 404
+        headers = dict(resp.items())
+        assert 'X-ElasticAPM-ErrorId' in headers
+        assert len(elasticapm_client.events) == 1
+        event = elasticapm_client.events.pop(0)['errors'][0]
+        assert event['id'] == headers['X-ElasticAPM-ErrorId']
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
 
-        assert 'request' in event['context']
-        request = event['context']['request']
-        assert request['method'] == 'POST'
-        assert request['body'] == compat.b('foobar')
+def test_get_client(elasticapm_client):
+    assert get_client() == get_client()
+    assert get_client('elasticapm.base.Client').__class__ == Client
 
-    @pytest.mark.skipif(django.VERSION < (1, 9),
-                        reason='get-raw-uri-not-available')
-    def test_disallowed_hosts_error_django_19(self):
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(),
-            'wsgi.url_scheme': 'http',
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'application/json',
-            'ACCEPT': 'application/json',
-        })
-        with self.settings(ALLOWED_HOSTS=['example.com']):
-            # this should not raise a DisallowedHost exception
-            self.elasticapm_client.capture('Message', message='foo', request=request)
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['request']['url']['raw'] == 'http://testserver/'
 
-    @pytest.mark.skipif(django.VERSION >= (1, 9),
-                        reason='get-raw-uri-available')
-    def test_disallowed_hosts_error_django_18(self):
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(),
-            'wsgi.url_scheme': 'http',
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'application/json',
-            'ACCEPT': 'application/json',
-        })
-        with self.settings(ALLOWED_HOSTS=['example.com']):
-            # this should not raise a DisallowedHost exception
-            self.elasticapm_client.capture('Message', message='foo', request=request)
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
-        assert event['context']['request']['url'] == {'raw': 'DisallowedHost'}
+def test_raw_post_data_partial_read(elasticapm_client):
+    v = compat.b('{"foo": "bar"}')
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(v + compat.b('\r\n\r\n')),
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'application/json',
+        'CONTENT_LENGTH': len(v),
+        'ACCEPT': 'application/json',
+    })
+    request.read(1)
 
-    # This test only applies to Django 1.3+
-    def test_request_capture(self):
-        if django.VERSION[:2] < (1, 3):
-            return
-        request = WSGIRequest(environ={
-            'wsgi.input': compat.BytesIO(),
-            'REQUEST_METHOD': 'POST',
-            'SERVER_NAME': 'testserver',
-            'SERVER_PORT': '80',
-            'CONTENT_TYPE': 'text/html',
-            'ACCEPT': 'text/html',
-        })
-        request.read(1)
+    elasticapm_client.capture('Message', message='foo', request=request)
 
-        self.elasticapm_client.capture('Message', message='foo', request=request)
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
 
-        assert len(self.elasticapm_client.events) == 1
-        event = self.elasticapm_client.events.pop(0)['errors'][0]
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['method'] == 'POST'
+    assert request['body'] == '<unavailable>'
 
-        assert 'request' in event['context']
-        request = event['context']['request']
-        assert request['method'] == 'POST'
-        assert request['body'] == '<unavailable>'
-        assert 'headers' in request
-        headers = request['headers']
-        assert 'content-type' in headers, headers.keys()
-        assert headers['content-type'] == 'text/html'
-        env = request['env']
-        assert 'SERVER_NAME' in env, env.keys()
-        assert env['SERVER_NAME'] == 'testserver'
-        assert 'SERVER_PORT' in env, env.keys()
-        assert env['SERVER_PORT'] == '80'
 
-    def test_transaction_request_response_data(self):
-        self.client.cookies = SimpleCookie({'foo': 'bar'})
-        self.elasticapm_client.instrumentation_store.get_all()
-        with self.settings(**middleware_setting(
-                django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware']
-        )):
-            self.client.get(reverse('elasticapm-no-error'))
-        assert len(self.elasticapm_client.instrumentation_store) == 1
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
+def test_post_data(elasticapm_client):
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(),
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'application/json',
+        'ACCEPT': 'application/json',
+    })
+    request.POST = QueryDict("x=1&y=2")
+    elasticapm_client.capture('Message', message='foo', request=request)
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['method'] == 'POST'
+    assert request['body'] == {'x': '1', 'y': '2'}
+
+
+def test_post_raw_data(elasticapm_client):
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(compat.b('foobar')),
+        'wsgi.url_scheme': 'http',
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'application/json',
+        'ACCEPT': 'application/json',
+        'CONTENT_LENGTH': '6',
+    })
+    elasticapm_client.capture('Message', message='foo', request=request)
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['method'] == 'POST'
+    assert request['body'] == compat.b('foobar')
+
+
+@pytest.mark.skipif(django.VERSION < (1, 9),
+                    reason='get-raw-uri-not-available')
+def test_disallowed_hosts_error_django_19(elasticapm_client):
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(),
+        'wsgi.url_scheme': 'http',
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'application/json',
+        'ACCEPT': 'application/json',
+    })
+    with override_settings(ALLOWED_HOSTS=['example.com']):
+        # this should not raise a DisallowedHost exception
+        elasticapm_client.capture('Message', message='foo', request=request)
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['request']['url']['raw'] == 'http://testserver/'
+
+
+@pytest.mark.skipif(django.VERSION >= (1, 9),
+                    reason='get-raw-uri-available')
+def test_disallowed_hosts_error_django_18(elasticapm_client):
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(),
+        'wsgi.url_scheme': 'http',
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'application/json',
+        'ACCEPT': 'application/json',
+    })
+    with override_settings(ALLOWED_HOSTS=['example.com']):
+        # this should not raise a DisallowedHost exception
+        elasticapm_client.capture('Message', message='foo', request=request)
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['context']['request']['url'] == {'raw': 'DisallowedHost'}
+
+
+def test_request_capture(elasticapm_client):
+    request = WSGIRequest(environ={
+        'wsgi.input': compat.BytesIO(),
+        'REQUEST_METHOD': 'POST',
+        'SERVER_NAME': 'testserver',
+        'SERVER_PORT': '80',
+        'CONTENT_TYPE': 'text/html',
+        'ACCEPT': 'text/html',
+    })
+    request.read(1)
+
+    elasticapm_client.capture('Message', message='foo', request=request)
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['method'] == 'POST'
+    assert request['body'] == '<unavailable>'
+    assert 'headers' in request
+    headers = request['headers']
+    assert 'content-type' in headers, headers.keys()
+    assert headers['content-type'] == 'text/html'
+    env = request['env']
+    assert 'SERVER_NAME' in env, env.keys()
+    assert env['SERVER_NAME'] == 'testserver'
+    assert 'SERVER_PORT' in env, env.keys()
+    assert env['SERVER_PORT'] == '80'
+
+
+def test_transaction_request_response_data(elasticapm_client, client):
+    client.cookies = SimpleCookie({'foo': 'bar'})
+    elasticapm_client.instrumentation_store.get_all()
+    with override_settings(**middleware_setting(
+            django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware']
+    )):
+        client.get(reverse('elasticapm-no-error'))
+    assert len(elasticapm_client.instrumentation_store) == 1
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert len(transactions) == 1
+    transaction = transactions[0]
+    assert 'request' in transaction['context']
+    request = transaction['context']['request']
+    assert request['method'] == 'GET'
+    assert 'headers' in request
+    headers = request['headers']
+    assert headers['cookie'] == ' foo=bar'
+    env = request['env']
+    assert 'SERVER_NAME' in env, env.keys()
+    assert env['SERVER_NAME'] == 'testserver'
+    assert 'SERVER_PORT' in env, env.keys()
+    assert env['SERVER_PORT'] == '80'
+
+    assert 'response' in transaction['context']
+    response = transaction['context']['response']
+    assert response['status_code'] == 200
+    assert response['headers']['my-header'] == 'foo'
+
+
+def test_transaction_metrics(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
+    with override_settings(**middleware_setting(
+            django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware']
+    )):
+        assert len(elasticapm_client.instrumentation_store) == 0
+        client.get(reverse('elasticapm-no-error'))
+        assert len(elasticapm_client.instrumentation_store) == 1
+
+        transactions = elasticapm_client.instrumentation_store.get_all()
+
         assert len(transactions) == 1
         transaction = transactions[0]
-        assert 'request' in transaction['context']
-        request = transaction['context']['request']
-        assert request['method'] == 'GET'
-        assert 'headers' in request
-        headers = request['headers']
-        assert headers['cookie'] == ' foo=bar'
-        env = request['env']
-        assert 'SERVER_NAME' in env, env.keys()
-        assert env['SERVER_NAME'] == 'testserver'
-        assert 'SERVER_PORT' in env, env.keys()
-        assert env['SERVER_PORT'] == '80'
-
-        assert 'response' in transaction['context']
-        response = transaction['context']['response']
-        assert response['status_code'] == 200
-        assert response['headers']['my-header'] == 'foo'
-
-    def test_transaction_metrics(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-        with self.settings(**middleware_setting(
-                django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware']
-        )):
-            assert len(self.elasticapm_client.instrumentation_store) == 0
-            self.client.get(reverse('elasticapm-no-error'))
-            assert len(self.elasticapm_client.instrumentation_store) == 1
-
-            transactions = self.elasticapm_client.instrumentation_store.get_all()
-
-            assert len(transactions) == 1
-            transaction = transactions[0]
-            assert transaction['duration'] > 0
-            assert transaction['result'] == '200'
-            assert transaction['name'] == 'GET tests.contrib.django.testapp.views.no_error'
-
-    def test_request_metrics_301_append_slash(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-
-        # enable middleware wrapping
-        client = get_client()
-        client.config.instrument_django_middleware = True
-
-        from elasticapm.contrib.django.middleware import TracingMiddleware
-        TracingMiddleware._elasticapm_instrumented = False
-
-        with self.settings(
-            APPEND_SLASH=True,
-            **middleware_setting(django.VERSION, [
-                'elasticapm.contrib.django.middleware.TracingMiddleware',
-                'django.middleware.common.CommonMiddleware',
-            ])
-        ):
-            self.client.get(reverse('elasticapm-no-error-slash')[:-1])
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
-        assert transactions[0]['name'] in (
-            # django <= 1.8
-            'GET django.middleware.common.CommonMiddleware.process_request',
-            # django 1.9+
-            'GET django.middleware.common.CommonMiddleware.process_response',
-        )
-
-    def test_request_metrics_301_prepend_www(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-
-        # enable middleware wrapping
-        client = get_client()
-        client.config.instrument_django_middleware = True
-
-        from elasticapm.contrib.django.middleware import TracingMiddleware
-        TracingMiddleware._elasticapm_instrumented = False
-
-        with self.settings(
-            PREPEND_WWW=True,
-            **middleware_setting(django.VERSION, [
-                'elasticapm.contrib.django.middleware.TracingMiddleware',
-                'django.middleware.common.CommonMiddleware',
-            ])
-        ):
-            self.client.get(reverse('elasticapm-no-error'))
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
-        assert transactions[0]['name'] == 'GET django.middleware.common.CommonMiddleware.process_request'
-
-    def test_request_metrics_contrib_redirect(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-
-        # enable middleware wrapping
-        client = get_client()
-        client.config.instrument_django_middleware = True
-        from elasticapm.contrib.django.middleware import TracingMiddleware
-        TracingMiddleware._elasticapm_instrumented = False
-
-        s = Site.objects.get(pk=1)
-        Redirect.objects.create(site=s, old_path='/redirect/me/', new_path='/here/')
-
-        with self.settings(
-            **middleware_setting(django.VERSION, [
-                'elasticapm.contrib.django.middleware.TracingMiddleware',
-                'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
-            ])
-        ):
-            response = self.client.get('/redirect/me/')
-
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
-        assert transactions[0]['name'] == 'GET django.contrib.redirects.middleware.RedirectFallbackMiddleware.process_response'
-
-    def test_request_metrics_name_override(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-        with self.settings(
-            **middleware_setting(django.VERSION, [
-                'elasticapm.contrib.django.middleware.TracingMiddleware',
-                'tests.contrib.django.testapp.middleware.MetricsNameOverrideMiddleware',
-            ])
-        ):
-            self.client.get(reverse('elasticapm-no-error'))
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
-        assert transactions[0]['name'] == 'GET foobar'
-
-    def test_request_metrics_404_resolve_error(self):
-        self.elasticapm_client.instrumentation_store.get_all()  # clear the store
-        with self.settings(
-            **middleware_setting(django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware'])
-        ):
-            self.client.get('/i-dont-exist/')
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
-        assert transactions[0]['name'] == ''
-
-    def test_get_app_info(self):
-        client = get_client()
-        app_info = client.get_app_info()
-        assert django.get_version() == app_info['framework']['version']
-        assert 'django' == app_info['framework']['name']
+        assert transaction['duration'] > 0
+        assert transaction['result'] == '200'
+        assert transaction['name'] == 'GET tests.contrib.django.testapp.views.no_error'
 
 
-class DjangoClientNoTempTest(TestCase):
-    def setUp(self):
-        self.client = DjangoClient(
-            server='http://example.com',
-            app_name='app',
-            secret_token='secret',
-            filter_exception_types=['KeyError', 'tests.contrib.django.fake1.FakeException']
-        )
+def test_request_metrics_301_append_slash(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
 
-    @mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
-    def test_filter_no_match(self, send_encoded):
-        try:
-            raise ValueError('foo')
-        except:
-            self.client.capture('Exception')
+    # enable middleware wrapping
+    elasticapm_client.config.instrument_django_middleware = True
 
-        assert send_encoded.call_count == 1
+    from elasticapm.contrib.django.middleware import TracingMiddleware
+    TracingMiddleware._elasticapm_instrumented = False
 
-    @mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
-    def test_filter_matches_type(self, send_encoded):
-        try:
-            raise KeyError('foo')
-        except:
-            self.client.capture('Exception')
-
-        assert send_encoded.call_count == 0
-
-    @mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
-    def test_filter_matches_type_but_not_module(self, send_encoded):
-        try:
-            from tests.contrib.django.fake2 import FakeException
-            raise FakeException('foo')
-        except:
-            self.client.capture('Exception')
-
-        assert send_encoded.call_count == 1
-
-    @mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
-    def test_filter_matches_type_and_module(self, send_encoded):
-        try:
-            from tests.contrib.django.fake1 import FakeException
-            raise FakeException('foo')
-        except:
-            self.client.capture('Exception')
-
-        assert send_encoded.call_count == 0
-
-    @mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
-    def test_filter_matches_module_only(self, send_encoded):
-        try:
-            from tests.contrib.django.fake1 import OtherFakeException
-            raise OtherFakeException('foo')
-        except:
-            self.client.capture('Exception')
-
-        assert send_encoded.call_count == 1
+    with override_settings(
+        APPEND_SLASH=True,
+        **middleware_setting(django.VERSION, [
+            'elasticapm.contrib.django.middleware.TracingMiddleware',
+            'django.middleware.common.CommonMiddleware',
+        ])
+    ):
+        client.get(reverse('elasticapm-no-error-slash')[:-1])
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['name'] in (
+        # django <= 1.8
+        'GET django.middleware.common.CommonMiddleware.process_request',
+        # django 1.9+
+        'GET django.middleware.common.CommonMiddleware.process_response',
+    )
 
 
-class DjangoLoggingTest(TestCase):
-    def setUp(self):
-        self.logger = logging.getLogger(__name__)
-        self.client = get_client()
+def test_request_metrics_301_prepend_www(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
 
-    def test_request_kwarg(self):
-        handler = LoggingHandler()
+    # enable middleware wrapping
+    elasticapm_client.config.instrument_django_middleware = True
 
-        logger = self.logger
-        logger.handlers = []
-        logger.addHandler(handler)
+    from elasticapm.contrib.django.middleware import TracingMiddleware
+    TracingMiddleware._elasticapm_instrumented = False
 
-        logger.error('This is a test error', extra={
-            'request': WSGIRequest(environ={
-                'wsgi.input': compat.StringIO(),
-                'REQUEST_METHOD': 'POST',
-                'SERVER_NAME': 'testserver',
-                'SERVER_PORT': '80',
-                'CONTENT_TYPE': 'application/json',
-                'ACCEPT': 'application/json',
-            })
+    with override_settings(
+        PREPEND_WWW=True,
+        **middleware_setting(django.VERSION, [
+            'elasticapm.contrib.django.middleware.TracingMiddleware',
+            'django.middleware.common.CommonMiddleware',
+        ])
+    ):
+        client.get(reverse('elasticapm-no-error'))
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['name'] == 'GET django.middleware.common.CommonMiddleware.process_request'
+
+
+@pytest.mark.django_db
+def test_request_metrics_contrib_redirect(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
+
+    # enable middleware wrapping
+    elasticapm_client.config.instrument_django_middleware = True
+    from elasticapm.contrib.django.middleware import TracingMiddleware
+    TracingMiddleware._elasticapm_instrumented = False
+
+    s = Site.objects.get(pk=1)
+    Redirect.objects.create(site=s, old_path='/redirect/me/', new_path='/here/')
+
+    with override_settings(
+        **middleware_setting(django.VERSION, [
+            'elasticapm.contrib.django.middleware.TracingMiddleware',
+            'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
+        ])
+    ):
+        response = client.get('/redirect/me/')
+
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['name'] == 'GET django.contrib.redirects.middleware.RedirectFallbackMiddleware.process_response'
+
+
+def test_request_metrics_name_override(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
+    with override_settings(
+        **middleware_setting(django.VERSION, [
+            'elasticapm.contrib.django.middleware.TracingMiddleware',
+            'tests.contrib.django.testapp.middleware.MetricsNameOverrideMiddleware',
+        ])
+    ):
+        client.get(reverse('elasticapm-no-error'))
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['name'] == 'GET foobar'
+
+
+def test_request_metrics_404_resolve_error(elasticapm_client, client):
+    elasticapm_client.instrumentation_store.get_all()  # clear the store
+    with override_settings(
+        **middleware_setting(django.VERSION, ['elasticapm.contrib.django.middleware.TracingMiddleware'])
+    ):
+        client.get('/i-dont-exist/')
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['name'] == ''
+
+
+def test_get_app_info(elasticapm_client):
+    client = get_client()
+    app_info = client.get_app_info()
+    assert django.get_version() == app_info['framework']['version']
+    assert 'django' == app_info['framework']['name']
+
+
+@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
+@pytest.mark.parametrize('sending_elasticapm_client', [{'filter_exception_types': [
+        'KeyError', 'tests.contrib.django.fake1.FakeException'
+    ]}], indirect=True)
+def test_filter_no_match(send_encoded, sending_elasticapm_client):
+    try:
+        raise ValueError('foo')
+    except:
+        sending_elasticapm_client.capture('Exception')
+
+    assert send_encoded.call_count == 1
+
+
+@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
+@pytest.mark.parametrize('sending_elasticapm_client', [{'filter_exception_types': [
+        'KeyError', 'tests.contrib.django.fake1.FakeException'
+    ]}], indirect=True)
+def test_filter_matches_type(send_encoded, sending_elasticapm_client):
+    try:
+        raise KeyError('foo')
+    except:
+        sending_elasticapm_client.capture('Exception')
+
+    assert send_encoded.call_count == 0
+
+
+@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
+@pytest.mark.parametrize('sending_elasticapm_client', [{'filter_exception_types': [
+        'KeyError', 'tests.contrib.django.fake1.FakeException'
+    ]}], indirect=True)
+def test_filter_matches_type_but_not_module(send_encoded, sending_elasticapm_client):
+    try:
+        from tests.contrib.django.fake2 import FakeException
+        raise FakeException('foo')
+    except:
+        sending_elasticapm_client.capture('Exception')
+
+    assert send_encoded.call_count == 1
+
+
+@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
+@pytest.mark.parametrize('sending_elasticapm_client', [{'filter_exception_types': [
+        'KeyError', 'tests.contrib.django.fake1.FakeException'
+    ]}], indirect=True)
+def test_filter_matches_type_and_module(send_encoded, sending_elasticapm_client):
+    try:
+        from tests.contrib.django.fake1 import FakeException
+        raise FakeException('foo')
+    except:
+        sending_elasticapm_client.capture('Exception')
+
+    assert send_encoded.call_count == 0
+
+
+@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
+@pytest.mark.parametrize('sending_elasticapm_client', [{'filter_exception_types': [
+        'KeyError', 'tests.contrib.django.fake1.FakeException'
+    ]}], indirect=True)
+def test_filter_matches_module_only(send_encoded, sending_elasticapm_client):
+    try:
+        from tests.contrib.django.fake1 import OtherFakeException
+        raise OtherFakeException('foo')
+    except OtherFakeException:
+        sending_elasticapm_client.capture('Exception')
+
+    assert send_encoded.call_count == 1
+
+
+def test_django_logging_request_kwarg(elasticapm_client):
+    handler = LoggingHandler()
+
+    logger = logging.getLogger(__name__)
+    logger.handlers = []
+    logger.addHandler(handler)
+
+    logger.error('This is a test error', extra={
+        'request': WSGIRequest(environ={
+            'wsgi.input': compat.StringIO(),
+            'REQUEST_METHOD': 'POST',
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': '80',
+            'CONTENT_TYPE': 'application/json',
+            'ACCEPT': 'application/json',
         })
+    })
 
-        assert len(self.client.events) == 1
-        event = self.client.events.pop(0)['errors'][0]
-        assert 'request' in event['context']
-        request = event['context']['request']
-        assert request['method'] == 'POST'
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['method'] == 'POST'
+
+
+def test_django_logging_middleware(elasticapm_client, client):
+    handler = LoggingHandler()
+
+    logger = logging.getLogger('logmiddleware')
+    logger.handlers = []
+    logger.addHandler(handler)
+
+    with override_settings(**middleware_setting(django.VERSION,
+                                                ['elasticapm.contrib.django.middleware.LogMiddleware'])):
+        client.get(reverse('elasticapm-logging'))
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert 'request' in event['context']
+    assert event['context']['request']['url']['pathname'] == reverse('elasticapm-logging')
 
 
 def client_get(client, url):
     return client.get(url)
 
 
-def test_stacktraces_have_templates():
-    client = _TestClient()
-    elasticapm_client = get_client()
-
+def test_stacktraces_have_templates(client, elasticapm_client):
     # Clear the LRU frame cache
     Transaction._lrucache = LRUCache(maxsize=5000)
 
@@ -908,10 +926,7 @@ def test_stacktraces_have_templates():
         assert False is True, "Template was not found"
 
 
-def test_stacktrace_filtered_for_elasticapm():
-    client = _TestClient()
-    elasticapm_client = get_client()
-
+def test_stacktrace_filtered_for_elasticapm(client, elasticapm_client):
     # Clear the LRU frame cache
     Transaction._lrucache = LRUCache(maxsize=5000)
 
@@ -935,9 +950,7 @@ def test_stacktrace_filtered_for_elasticapm():
     assert traces[1]['stacktrace'][0]['module'].startswith('django.template')
 
 
-def test_perf_template_render(benchmark):
-    client = _TestClient()
-    elasticapm_client = get_client()
+def test_perf_template_render(benchmark, client, elasticapm_client):
     responses = []
     with mock.patch("elasticapm.traces.TransactionsStore.should_collect") as should_collect:
         should_collect.return_value = False
@@ -958,9 +971,7 @@ def test_perf_template_render(benchmark):
         assert len(transaction['traces']) == 2
 
 
-def test_perf_template_render_no_middleware(benchmark):
-    client = _TestClient()
-    elasticapm_client = get_client()
+def test_perf_template_render_no_middleware(benchmark, client, elasticapm_client):
     responses = []
     with mock.patch(
             "elasticapm.traces.TransactionsStore.should_collect") as should_collect:
@@ -976,10 +987,7 @@ def test_perf_template_render_no_middleware(benchmark):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_perf_database_render(benchmark):
-    client = _TestClient()
-
-    elasticapm_client = get_client()
+def test_perf_database_render(benchmark, client, elasticapm_client):
     responses = []
     elasticapm_client.instrumentation_store.get_all()
 
@@ -1002,8 +1010,7 @@ def test_perf_database_render(benchmark):
 
 
 @pytest.mark.django_db
-def test_perf_database_render_no_instrumentation(benchmark):
-    elasticapm_client = get_client()
+def test_perf_database_render_no_instrumentation(benchmark, elasticapm_client):
     elasticapm_client.instrumentation_store.get_all()
     responses = []
     with mock.patch("elasticapm.traces.TransactionsStore.should_collect") as should_collect:
@@ -1022,8 +1029,7 @@ def test_perf_database_render_no_instrumentation(benchmark):
 
 
 @pytest.mark.django_db
-def test_perf_transaction_with_collection(benchmark):
-    elasticapm_client = get_client()
+def test_perf_transaction_with_collection(benchmark, elasticapm_client):
     elasticapm_client.instrumentation_store.get_all()
     with mock.patch("elasticapm.traces.TransactionsStore.should_collect") as should_collect:
         should_collect.return_value = False
@@ -1052,8 +1058,7 @@ def test_perf_transaction_with_collection(benchmark):
 
 
 @pytest.mark.django_db
-def test_perf_transaction_without_middleware(benchmark):
-    elasticapm_client = get_client()
+def test_perf_transaction_without_middleware(benchmark, elasticapm_client):
     elasticapm_client.instrumentation_store.get_all()
     with mock.patch("elasticapm.traces.TransactionsStore.should_collect") as should_collect:
         should_collect.return_value = False
@@ -1073,60 +1078,74 @@ def test_perf_transaction_without_middleware(benchmark):
         assert len(elasticapm_client.events) == 0
 
 
-class DjangoManagementCommandTest(TestCase):
-    @pytest.mark.skipif(django.VERSION > (1, 7),
-                        reason='argparse raises CommandError in this case')
-    @mock.patch('elasticapm.contrib.django.management.commands.elasticapm.Command._get_argv')
-    def test_subcommand_not_set(self, argv_mock):
-        stdout = compat.StringIO()
-        argv_mock.return_value = ['manage.py', 'elasticapm']
-        call_command('elasticapm', stdout=stdout)
-        output = stdout.getvalue()
-        assert 'No command specified' in output
+@pytest.mark.skipif(django.VERSION > (1, 7),
+                    reason='argparse raises CommandError in this case')
+@mock.patch('elasticapm.contrib.django.management.commands.elasticapm.Command._get_argv')
+def test_subcommand_not_set(argv_mock):
+    stdout = compat.StringIO()
+    argv_mock.return_value = ['manage.py', 'elasticapm']
+    call_command('elasticapm', stdout=stdout)
+    output = stdout.getvalue()
+    assert 'No command specified' in output
 
-    @mock.patch('elasticapm.contrib.django.management.commands.elasticapm.Command._get_argv')
-    def test_subcommand_not_known(self, argv_mock):
-        stdout = compat.StringIO()
-        argv_mock.return_value = ['manage.py', 'elasticapm']
-        call_command('elasticapm', 'foo', stdout=stdout)
-        output = stdout.getvalue()
-        assert 'No such command "foo"' in output
 
-    def test_settings_missing(self):
-        stdout = compat.StringIO()
-        with self.settings(ELASTIC_APM={}):
-            call_command('elasticapm', 'check', stdout=stdout)
-        output = stdout.getvalue()
-        assert 'Configuration errors detected' in output
-        assert 'APP_NAME not set' in output
-        assert 'SECRET_TOKEN not set' in output
+@mock.patch('elasticapm.contrib.django.management.commands.elasticapm.Command._get_argv')
+def test_subcommand_not_known(argv_mock):
+    stdout = compat.StringIO()
+    argv_mock.return_value = ['manage.py', 'elasticapm']
+    call_command('elasticapm', 'foo', stdout=stdout)
+    output = stdout.getvalue()
+    assert 'No such command "foo"' in output
 
-    def test_middleware_not_set(self):
-        stdout = compat.StringIO()
-        with self.settings(**middleware_setting(django.VERSION, ())):
-            call_command('elasticapm', 'check', stdout=stdout)
-        output = stdout.getvalue()
-        assert 'Tracing middleware not configured!' in output
 
-    def test_middleware_not_first(self):
-        stdout = compat.StringIO()
-        with self.settings(**middleware_setting(django.VERSION, (
-            'foo',
-            'elasticapm.contrib.django.middleware.TracingMiddleware'
-        ))):
-            call_command('elasticapm', 'check', stdout=stdout)
-        output = stdout.getvalue()
-        assert 'not at the first position' in output
+def test_settings_missing():
+    stdout = compat.StringIO()
+    with override_settings(ELASTIC_APM={}):
+        call_command('elasticapm', 'check', stdout=stdout)
+    output = stdout.getvalue()
+    assert 'Configuration errors detected' in output
+    assert 'APP_NAME not set' in output
+    assert 'SECRET_TOKEN not set' in output
 
-    @mock.patch('elasticapm.transport.http_urllib3.urllib3.PoolManager.urlopen')
-    def test_test_exception(self, urlopen_mock):
-        stdout = compat.StringIO()
-        resp = mock.Mock(status=200, getheader=lambda h: 'http://example.com')
-        urlopen_mock.return_value = resp
-        with self.settings(**middleware_setting(django.VERSION, [
-            'foo',
-            'elasticapm.contrib.django.middleware.TracingMiddleware'
-        ])):
-            call_command('elasticapm', 'test', stdout=stdout, stderr=stdout)
-        output = stdout.getvalue()
-        assert 'Success! We tracked the error successfully!' in output
+
+def test_middleware_not_set():
+    stdout = compat.StringIO()
+    with override_settings(**middleware_setting(django.VERSION, ())):
+        call_command('elasticapm', 'check', stdout=stdout)
+    output = stdout.getvalue()
+    assert 'Tracing middleware not configured!' in output
+
+
+def test_middleware_not_first():
+    stdout = compat.StringIO()
+    with override_settings(**middleware_setting(django.VERSION, (
+        'foo',
+        'elasticapm.contrib.django.middleware.TracingMiddleware'
+    ))):
+        call_command('elasticapm', 'check', stdout=stdout)
+    output = stdout.getvalue()
+    assert 'not at the first position' in output
+
+
+@mock.patch('elasticapm.transport.http_urllib3.urllib3.PoolManager.urlopen')
+def test_test_exception(urlopen_mock):
+    stdout = compat.StringIO()
+    resp = mock.Mock(status=200, getheader=lambda h: 'http://example.com')
+    urlopen_mock.return_value = resp
+    with override_settings(**middleware_setting(django.VERSION, [
+        'foo',
+        'elasticapm.contrib.django.middleware.TracingMiddleware'
+    ])):
+        call_command('elasticapm', 'test', stdout=stdout, stderr=stdout)
+    output = stdout.getvalue()
+    assert 'Success! We tracked the error successfully!' in output
+
+
+def test_tracing_middleware_uses_test_client(client, elasticapm_client):
+    with override_settings(**middleware_setting(django.VERSION, [
+        'elasticapm.contrib.django.middleware.TracingMiddleware'
+    ])):
+        client.get('/')
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    assert len(transactions) == 1
+    assert transactions[0]['context']['request']['url']['pathname'] == '/'

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -1,7 +1,9 @@
+from django.apps import apps
+
 import pytest
 
+from elasticapm.contrib.django.apps import instrument, register_handlers
 from elasticapm.contrib.django.client import DjangoClient
-from elasticapm.contrib.django.apps import register_handlers, instrument
 
 
 class TempStoreClient(DjangoClient):
@@ -14,8 +16,41 @@ class TempStoreClient(DjangoClient):
 
 
 @pytest.fixture()
-def elasticapm_client():
-    client = TempStoreClient()
+def elasticapm_client(request):
+    client_config = getattr(request, 'param', {})
+    app = apps.get_app_config('elasticapm.contrib.django')
+    old_client = app.client
+    client = TempStoreClient(**client_config)
     register_handlers(client)
     instrument(client)
+    app.client = client
     yield client
+
+    app.client = old_client
+
+    if old_client:
+        register_handlers(old_client)
+        instrument(old_client)
+
+
+@pytest.fixture()
+def sending_elasticapm_client(request):
+    client_config = getattr(request, 'param', {})
+    app = apps.get_app_config('elasticapm.contrib.django')
+    old_client = app.client
+    client = DjangoClient(
+        server='http://example.com',
+        app_name='app',
+        secret_token='secret',
+        **client_config
+    )
+    register_handlers(client)
+    instrument(client)
+    app.client = client
+    yield client
+
+    app.client = old_client
+
+    if old_client:
+        register_handlers(old_client)
+        instrument(old_client)

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -1,0 +1,21 @@
+import pytest
+
+from elasticapm.contrib.django.client import DjangoClient
+from elasticapm.contrib.django.apps import register_handlers, instrument
+
+
+class TempStoreClient(DjangoClient):
+    def __init__(self, *args, **kwargs):
+        self.events = []
+        super(TempStoreClient, self).__init__(*args, **kwargs)
+
+    def send(self, **kwargs):
+        self.events.append(kwargs)
+
+
+@pytest.fixture()
+def elasticapm_client():
+    client = TempStoreClient()
+    register_handlers(client)
+    instrument(client)
+    yield client

--- a/tests/contrib/django/testapp/urls.py
+++ b/tests/contrib/django/testapp/urls.py
@@ -19,6 +19,7 @@ urlpatterns = (
     url(r'^render-user-template$', views.render_user_view, name='render-user-template'),
     url(r'^no-error$', views.no_error, name='elasticapm-no-error'),
     url(r'^no-error-slash/$', views.no_error, name='elasticapm-no-error-slash'),
+    url(r'^logging$', views.logging_view, name='elasticapm-logging'),
     url(r'^ignored-exception/$', views.ignored_exception, name='elasticapm-ignored-exception'),
     url(r'^fake-login$', views.fake_login, name='elasticapm-fake-login'),
     url(r'^trigger-500$', views.raise_exc, name='elasticapm-raise-exc'),

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -56,6 +56,12 @@ def logging_request_exc(request):
     return HttpResponse('')
 
 
+def logging_view(request):
+    logger = logging.getLogger('logmiddleware')
+    logger.info("Just loggin'")
+    return HttpResponse('')
+
+
 def render_template_view(request):
     def something_expensive():
         with trace("something_expensive", "code"):

--- a/tests/contrib/flask/fixtures.py
+++ b/tests/contrib/flask/fixtures.py
@@ -24,8 +24,8 @@ def flask_app():
 
 
 @pytest.yield_fixture()
-def flask_apm_client(flask_app, test_client):
-    client = ElasticAPM(app=flask_app, client=test_client)
+def flask_apm_client(flask_app, elasticapm_client):
+    client = ElasticAPM(app=flask_app, client=elasticapm_client)
     yield client
     signals.request_started.disconnect(client.request_started)
     signals.request_finished.disconnect(client.request_finished)

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -5,7 +5,7 @@ import mock
 
 from elasticapm.contrib.flask import ElasticAPM
 from tests.contrib.flask.fixtures import flask_apm_client, flask_app
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 def test_error_handler(flask_apm_client):

--- a/tests/contrib/pylons/tests.py
+++ b/tests/contrib/pylons/tests.py
@@ -1,21 +1,16 @@
 from __future__ import absolute_import
 
 from elasticapm.contrib.pylons import ElasticAPM
-from tests.utils.compat import TestCase
 
 
 def example_app(environ, start_response):
     raise ValueError('hello world')
 
 
-class MiddlewareTest(TestCase):
-    def setUp(self):
-        self.app = example_app
-
-    def test_init(self):
-        config = {
-            'elasticapm.server': 'http://localhost/api/store',
-            'elasticapm.app_name': 'p' * 32,
-            'elasticapm.secret_token': 'a' * 32,
-        }
-        middleware = ElasticAPM(self.app, config)
+def test_init():
+    config = {
+        'elasticapm.server': 'http://localhost/api/store',
+        'elasticapm.app_name': 'p' * 32,
+        'elasticapm.secret_token': 'a' * 32,
+    }
+    middleware = ElasticAPM(example_app, config)

--- a/tests/contrib/twisted/tests.py
+++ b/tests/contrib/twisted/tests.py
@@ -3,22 +3,17 @@ from __future__ import absolute_import
 from twisted.python.failure import Failure
 
 from elasticapm.contrib.twisted import LogObserver
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-class TwistedLogObserverTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
+def test_twisted_log_observer(test_client):
+    observer = LogObserver(client=test_client)
+    try:
+        1 / 0
+    except ZeroDivisionError:
+        failure = Failure()
+    event = dict(log_failure=failure)
+    observer(event)
 
-    def test_observer(self):
-        observer = LogObserver(client=self.client)
-        try:
-            1 / 0
-        except ZeroDivisionError:
-            failure = Failure()
-        event = dict(log_failure=failure)
-        observer(event)
-
-        cli_event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(cli_event['exception']['type'], 'ZeroDivisionError')
+    cli_event = test_client.events.pop(0)['errors'][0]
+    assert cli_event['exception']['type'] == 'ZeroDivisionError'

--- a/tests/contrib/twisted/tests.py
+++ b/tests/contrib/twisted/tests.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 from twisted.python.failure import Failure
 
 from elasticapm.contrib.twisted import LogObserver
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
-def test_twisted_log_observer(test_client):
-    observer = LogObserver(client=test_client)
+def test_twisted_log_observer(elasticapm_client):
+    observer = LogObserver(client=elasticapm_client)
     try:
         1 / 0
     except ZeroDivisionError:
@@ -15,5 +15,5 @@ def test_twisted_log_observer(test_client):
     event = dict(log_failure=failure)
     observer(event)
 
-    cli_event = test_client.events.pop(0)['errors'][0]
+    cli_event = elasticapm_client.events.pop(0)['errors'][0]
     assert cli_event['exception']['type'] == 'ZeroDivisionError'

--- a/tests/contrib/zerorpc/zeropc_tests.py
+++ b/tests/contrib/zerorpc/zeropc_tests.py
@@ -7,8 +7,7 @@ import tempfile
 import pytest
 
 from elasticapm.contrib.zerorpc import Middleware
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 zerorpc = pytest.importorskip("zerorpc")
 gevent = pytest.importorskip("gevent")
@@ -19,41 +18,34 @@ has_unsupported_pypy = (hasattr(sys, 'pypy_version_info')
                         and sys.pypy_version_info < (2, 6))
 
 
-class ZeroRPCTest(TestCase):
-    def setUp(self):
-        self._socket_dir = tempfile.mkdtemp(prefix='elasticapmzerorpcunittest')
-        self._server_endpoint = 'ipc://{0}'.format(os.path.join(
-                    self._socket_dir, 'random_zeroserver'
-        ))
 
-        self._elasticapm_client = get_tempstoreclient()
+@pytest.mark.skipif(has_unsupported_pypy, reason='Failure with pypy < 2.6')
+def test_zerorpc_middleware_with_reqrep(test_client):
+    tmpdir = tempfile.mkdtemp()
+    server_endpoint = 'ipc://{0}'.format(os.path.join(tmpdir, 'random_zeroserver'))
+    try:
         zerorpc.Context.get_instance().register_middleware(Middleware(
-                    client=self._elasticapm_client
+            client=test_client
         ))
+        server = zerorpc.Server(random)
+        server.bind(server_endpoint)
+        gevent.spawn(server.run)
 
-    @pytest.mark.skipif(has_unsupported_pypy, reason='Failure with pypy < 2.6')
-    def test_zerorpc_middleware_with_reqrep(self):
-        self._server = zerorpc.Server(random)
-        self._server.bind(self._server_endpoint)
-        gevent.spawn(self._server.run)
+        client = zerorpc.Client()
+        client.connect(server_endpoint)
 
-        self._client = zerorpc.Client()
-        self._client.connect(self._server_endpoint)
+        with pytest.raises(zerorpc.exceptions.RemoteError) as excinfo:
+            client.choice([])
 
-        try:
-            self._client.choice([])
-        except zerorpc.exceptions.RemoteError as ex:
-            self.assertEqual(ex.name, 'IndexError')
-            self.assertEqual(len(self._elasticapm_client.events), 1)
-            exc = self._elasticapm_client.events[0]['errors'][0]['exception']
-            self.assertEqual(exc['type'], 'IndexError')
-            frames = exc['stacktrace']
-            self.assertEqual(frames[0]['function'], 'choice')
-            self.assertEqual(frames[0]['module'], 'random')
-            return
-        self.fail('An IndexError exception should have been raised an catched')
-
-    def tearDown(self):
-        self._client.close()
-        self._server.close()
-        shutil.rmtree(self._socket_dir, ignore_errors=True)
+        client.close()
+        server.close()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    ex = excinfo.value
+    assert ex.name == 'IndexError'
+    assert len(test_client.events) == 1
+    exc = test_client.events[0]['errors'][0]['exception']
+    assert exc['type'] == 'IndexError'
+    frames = exc['stacktrace']
+    assert frames[0]['function'] == 'choice'
+    assert frames[0]['module'] == 'random'

--- a/tests/contrib/zerorpc/zeropc_tests.py
+++ b/tests/contrib/zerorpc/zeropc_tests.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 
 from elasticapm.contrib.zerorpc import Middleware
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 zerorpc = pytest.importorskip("zerorpc")
 gevent = pytest.importorskip("gevent")
@@ -20,12 +20,12 @@ has_unsupported_pypy = (hasattr(sys, 'pypy_version_info')
 
 
 @pytest.mark.skipif(has_unsupported_pypy, reason='Failure with pypy < 2.6')
-def test_zerorpc_middleware_with_reqrep(test_client):
+def test_zerorpc_middleware_with_reqrep(elasticapm_client):
     tmpdir = tempfile.mkdtemp()
     server_endpoint = 'ipc://{0}'.format(os.path.join(tmpdir, 'random_zeroserver'))
     try:
         zerorpc.Context.get_instance().register_middleware(Middleware(
-            client=test_client
+            client=elasticapm_client
         ))
         server = zerorpc.Server(random)
         server.bind(server_endpoint)
@@ -43,8 +43,8 @@ def test_zerorpc_middleware_with_reqrep(test_client):
         shutil.rmtree(tmpdir, ignore_errors=True)
     ex = excinfo.value
     assert ex.name == 'IndexError'
-    assert len(test_client.events) == 1
-    exc = test_client.events[0]['errors'][0]['exception']
+    assert len(elasticapm_client.events) == 1
+    exc = elasticapm_client.events[0]['errors'][0]['exception']
     assert exc['type'] == 'IndexError'
     frames = exc['stacktrace']
     assert frames[0]['function'] == 'choice'

--- a/tests/events/tests.py
+++ b/tests/events/tests.py
@@ -4,21 +4,19 @@ from __future__ import absolute_import
 from mock import Mock
 
 from elasticapm.events import Message
-from tests.utils.compat import TestCase
 
 
-class MessageTest(TestCase):
-    def test_to_string(self):
-        unformatted_message = 'My message from %s about %s'
-        formatted_message = unformatted_message % (1, 2)
-        client = Mock()
-        message = Message()
-        message.logger = Mock()
-        data = {
-            'log': {
-                'message': unformatted_message % (1, 2),
-                'param_message': unformatted_message,
-            }
+def test_event_to_string():
+    unformatted_message = 'My message from %s about %s'
+    formatted_message = unformatted_message % (1, 2)
+    client = Mock()
+    message = Message()
+    message.logger = Mock()
+    data = {
+        'log': {
+            'message': unformatted_message % (1, 2),
+            'param_message': unformatted_message,
         }
+    }
 
-        self.assertEqual(message.to_string(client, data), formatted_message)
+    assert message.to_string(client, data) == formatted_message

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,5 +4,5 @@ from tests.helpers import get_tempstoreclient
 
 
 @pytest.fixture()
-def test_client():
+def elasticapm_client():
     return get_tempstoreclient()

--- a/tests/handlers/logbook/logbook_tests.py
+++ b/tests/handlers/logbook/logbook_tests.py
@@ -1,107 +1,121 @@
 import logbook
+import pytest
 
 from elasticapm.handlers.logbook import LogbookHandler
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-class LogbookHandlerTest(TestCase):
-    def setUp(self):
-        self.logger = logbook.Logger(__name__)
-        self.client = get_tempstoreclient(include_paths=['tests', 'elasticapm'])
-        self.handler = LogbookHandler(self.client)
+@pytest.fixture()
+def logbook_logger():
+    return logbook.Logger(__name__)
 
-    def test_logger_error_level(self):
-        with self.handler.applicationbound():
-            self.logger.error('This is a test error')
 
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        assert event['log']['logger_name'] == __name__
-        assert event['log']['level'] == "error"
-        assert event['log']['message'] == 'This is a test error'
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        assert event['log']['param_message'] == 'This is a test error'
+@pytest.fixture()
+def logbook_handler(test_client):
+    test_client.config.include_paths = ['tests', 'elasticapm']
+    return LogbookHandler(test_client)
 
-    def test_logger_warning_level(self):
-        with self.handler.applicationbound():
-            self.logger.warning('This is a test warning')
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        assert event['log']['logger_name'] == __name__
-        assert event['log']['level'] == "warning"
-        assert event['log']['message'] == 'This is a test warning'
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        assert event['log']['param_message'] == 'This is a test warning'
 
-    def test_logger_without_stacktrace(self):
-        self.client.config.auto_log_stacks = False
+def test_logbook_logger_error_level(logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        logbook_logger.error('This is a test error')
 
-        with self.handler.applicationbound():
-            self.logger.warning('This is a test warning')
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+    assert event['log']['logger_name'] == __name__
+    assert event['log']['level'] == "error"
+    assert event['log']['message'] == 'This is a test error'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test error'
 
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertFalse('stacktrace' in event['log'])
 
-    def test_logger_with_extra(self):
-        with self.handler.applicationbound():
-            self.logger.info('This is a test info with a url', extra=dict(
-                url='http://example.com',
-            ))
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['context']['custom']['url'], 'http://example.com')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test info with a url')
+def test_logger_warning_level(logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        logbook_logger.warning('This is a test warning')
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+    assert event['log']['logger_name'] == __name__
+    assert event['log']['level'] == "warning"
+    assert event['log']['message'] == 'This is a test warning'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test warning'
 
-    def test_logger_with_exc_info(self):
-        with self.handler.applicationbound():
-            try:
-                raise ValueError('This is a test ValueError')
-            except ValueError:
-                self.logger.info('This is a test info with an exception', exc_info=True)
 
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
+def test_logger_without_stacktrace(logbook_logger, logbook_handler):
+    logbook_handler.client.config.auto_log_stacks = False
 
-        self.assertEquals(event['log']['message'], 'This is a test info with an exception')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertTrue('exception' in event)
-        exc = event['exception']
-        self.assertEquals(exc['type'], 'ValueError')
-        self.assertEquals(exc['message'], 'ValueError: This is a test ValueError')
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test info with an exception')
+    with logbook_handler.applicationbound():
+        logbook_logger.warning('This is a test warning')
 
-    def test_logger_param_message(self):
-        with self.handler.applicationbound():
-            self.logger.info('This is a test of %s', 'args')
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['log']['message'], 'This is a test of args')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test of %s')
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+    assert 'stacktrace' not in event['log']
 
-    def test_client_arg(self):
-        client = get_tempstoreclient(include_paths=['tests'])
-        handler = LogbookHandler(client)
-        self.assertEquals(handler.client, client)
 
-    def test_client_kwarg(self):
-        client = get_tempstoreclient(include_paths=['tests'])
-        handler = LogbookHandler(client=client)
-        self.assertEquals(handler.client, client)
+def test_logger_with_extra(logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        logbook_logger.info('This is a test info with a url', extra=dict(
+            url='http://example.com',
+        ))
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+    assert event['context']['custom']['url'] == 'http://example.com'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test info with a url'
 
-    def test_invalid_first_arg_type(self):
-        self.assertRaises(ValueError, LogbookHandler, object)
 
-    def test_missing_client_arg(self):
-        self.assertRaises(TypeError, LogbookHandler)
+def test_logger_with_exc_info(logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        try:
+            raise ValueError('This is a test ValueError')
+        except ValueError:
+            logbook_logger.info('This is a test info with an exception', exc_info=True)
+
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+
+    assert event['log']['message'] == 'This is a test info with an exception'
+    assert 'stacktrace' in event['log']
+    assert 'exception' in event
+    exc = event['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == 'ValueError: This is a test ValueError'
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test info with an exception'
+
+
+def test_logger_param_message(logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        logbook_logger.info('This is a test of %s', 'args')
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)['errors'][0]
+    assert event['log']['message'] == 'This is a test of args'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test of %s'
+
+
+def test_client_arg(test_client):
+    handler = LogbookHandler(test_client)
+    assert handler.client == test_client
+
+
+def test_client_kwarg(test_client):
+    handler = LogbookHandler(client=test_client)
+    assert handler.client == test_client
+
+
+def test_invalid_first_arg_type():
+    with pytest.raises(ValueError):
+        LogbookHandler(object)
+
+
+def test_missing_client_arg():
+    with pytest.raises(TypeError):
+        LogbookHandler()

--- a/tests/handlers/logbook/logbook_tests.py
+++ b/tests/handlers/logbook/logbook_tests.py
@@ -2,7 +2,7 @@ import logbook
 import pytest
 
 from elasticapm.handlers.logbook import LogbookHandler
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 @pytest.fixture()
@@ -11,9 +11,9 @@ def logbook_logger():
 
 
 @pytest.fixture()
-def logbook_handler(test_client):
-    test_client.config.include_paths = ['tests', 'elasticapm']
-    return LogbookHandler(test_client)
+def logbook_handler(elasticapm_client):
+    elasticapm_client.config.include_paths = ['tests', 'elasticapm']
+    return LogbookHandler(elasticapm_client)
 
 
 def test_logbook_logger_error_level(logbook_logger, logbook_handler):
@@ -101,14 +101,14 @@ def test_logger_param_message(logbook_logger, logbook_handler):
     assert event['log']['param_message'] == 'This is a test of %s'
 
 
-def test_client_arg(test_client):
-    handler = LogbookHandler(test_client)
-    assert handler.client == test_client
+def test_client_arg(elasticapm_client):
+    handler = LogbookHandler(elasticapm_client)
+    assert handler.client == elasticapm_client
 
 
-def test_client_kwarg(test_client):
-    handler = LogbookHandler(client=test_client)
-    assert handler.client == test_client
+def test_client_kwarg(elasticapm_client):
+    handler = LogbookHandler(client=elasticapm_client)
+    assert handler.client == elasticapm_client
 
 
 def test_invalid_first_arg_type():

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -1,168 +1,182 @@
 import logging
 
+import pytest
+
 from elasticapm.handlers.logging import LoggingHandler
 from elasticapm.utils.stacks import iter_stack_frames
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-class LoggingIntegrationTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient(include_paths=['tests', 'elasticapm'])
-        self.handler = LoggingHandler(self.client)
-        self.logger = logging.getLogger(__name__)
-        self.logger.handlers = []
-        self.logger.addHandler(self.handler)
-
-    def test_logger_basic(self):
-        self.logger.error('This is a test error')
-
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['log']['logger_name'], __name__)
-        self.assertEquals(event['log']['level'], "error")
-        self.assertEquals(event['log']['message'], 'This is a test error')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test error')
-
-    def test_logger_warning(self):
-        self.logger.warning('This is a test warning')
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['log']['logger_name'], __name__)
-        self.assertEquals(event['log']['level'], "warning")
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test warning')
-
-    def test_logger_extra_data(self):
-        self.logger.info('This is a test info with a url', extra=dict(
-            data=dict(
-                url='http://example.com',
-            ),
-        ))
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['context']['custom']['url'], 'http://example.com')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test info with a url')
-
-    def test_logger_exc_info(self):
-        try:
-            raise ValueError('This is a test ValueError')
-        except ValueError:
-            self.logger.info('This is a test info with an exception', exc_info=True)
-
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-
-        # self.assertEquals(event['message'], 'This is a test info with an exception')
-        self.assertTrue('exception' in event)
-        self.assertTrue('stacktrace' in event['exception'])
-        exc = event['exception']
-        self.assertEquals(exc['type'], 'ValueError')
-        self.assertEquals(exc['message'], 'ValueError: This is a test ValueError')
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['message'], 'This is a test info with an exception')
-
-    def test_message_params(self):
-        self.logger.info('This is a test of %s', 'args')
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['message'], 'This is a test of args')
-        self.assertEquals(event['log']['param_message'], 'This is a test of %s')
-
-    def test_record_stack(self):
-        self.logger.info('This is a test of stacks', extra={'stack': True})
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        frames = event['log']['stacktrace']
-        self.assertNotEquals(len(frames), 1)
-        frame = frames[0]
-        self.assertEquals(frame['module'], __name__)
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test of stacks')
-        self.assertEquals(event['culprit'], 'tests.handlers.logging.logging_tests.test_record_stack')
-        self.assertEquals(event['log']['message'], 'This is a test of stacks')
-
-    def test_no_record_stack(self):
-        self.logger.info('This is a test of no stacks', extra={'stack': False})
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event.get('culprit'), None)
-        self.assertEquals(event['log']['message'], 'This is a test of no stacks')
-        self.assertFalse('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test of no stacks')
-
-    def test_no_record_stack_via_config(self):
-        self.client.config.auto_log_stacks = False
-        self.logger.info('This is a test of no stacks')
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event.get('culprit'), None)
-        self.assertEquals(event['log']['message'], 'This is a test of no stacks')
-        self.assertFalse('stacktrace' in event['log'])
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test of no stacks')
-
-    def test_explicit_stack(self):
-        self.logger.info('This is a test of stacks', extra={'stack': iter_stack_frames()})
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertTrue('culprit' in event, event)
-        self.assertEquals(event['culprit'], 'tests.handlers.logging.logging_tests.test_explicit_stack')
-        self.assertTrue('message' in event['log'], event)
-        self.assertEquals(event['log']['message'], 'This is a test of stacks')
-        self.assertFalse('exception' in event)
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['param_message'], 'This is a test of stacks')
-        self.assertTrue('stacktrace' in event['log'])
-
-    def test_extra_culprit(self):
-        self.logger.info('This is a test of stacks', extra={'culprit': 'foo.bar'})
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-        self.assertEquals(event['culprit'], 'foo.bar')
-
-    def test_logger_exception(self):
-        try:
-            raise ValueError('This is a test ValueError')
-        except ValueError:
-            self.logger.exception('This is a test with an exception', extra={'stack': True})
-
-        self.assertEquals(len(self.client.events), 1)
-        event = self.client.events.pop(0)['errors'][0]
-
-        self.assertEquals(event['log']['message'], 'This is a test with an exception')
-        self.assertTrue('stacktrace' in event['log'])
-        self.assertTrue('exception' in event)
-        exc = event['exception']
-        self.assertEquals(exc['type'], 'ValueError')
-        self.assertEquals(exc['message'], 'ValueError: This is a test ValueError')
-        self.assertTrue('param_message' in event['log'])
-        self.assertEquals(event['log']['message'], 'This is a test with an exception')
+@pytest.fixture()
+def logger(test_client):
+    test_client.config.include_paths = ['tests', 'elasticapm']
+    handler = LoggingHandler(test_client)
+    logger = logging.getLogger(__name__)
+    logger.handlers = []
+    logger.addHandler(handler)
+    logger.client = test_client
+    return logger
 
 
-class LoggingHandlerTest(TestCase):
-    def test_client_arg(self):
-        client = get_tempstoreclient(include_paths=['tests'])
-        handler = LoggingHandler(client)
-        self.assertEquals(handler.client, client)
+def test_logger_basic(logger):
+    logger.error('This is a test error')
 
-    def test_client_kwarg(self):
-        client = get_tempstoreclient(include_paths=['tests'])
-        handler = LoggingHandler(client=client)
-        self.assertEquals(handler.client, client)
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event['log']['logger_name'] == __name__
+    assert event['log']['level'] == "error"
+    assert event['log']['message'] == 'This is a test error'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test error'
 
-    def test_invalid_first_arg_type(self):
-        self.assertRaises(ValueError, LoggingHandler, object)
+
+def test_logger_warning(logger):
+    logger.warning('This is a test warning')
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event['log']['logger_name'] == __name__
+    assert event['log']['level'] == "warning"
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test warning'
+
+
+def test_logger_extra_data(logger):
+    logger.info('This is a test info with a url', extra=dict(
+        data=dict(
+            url='http://example.com',
+        ),
+    ))
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event['context']['custom']['url'] == 'http://example.com'
+    assert 'stacktrace' in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test info with a url'
+
+
+def test_logger_exc_info(logger):
+    try:
+        raise ValueError('This is a test ValueError')
+    except ValueError:
+        logger.info('This is a test info with an exception', exc_info=True)
+
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+
+    # assert event['message'] == 'This is a test info with an exception'
+    assert 'exception' in event
+    assert 'stacktrace' in event['exception']
+    exc = event['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == 'ValueError: This is a test ValueError'
+    assert 'param_message' in event['log']
+    assert event['log']['message'] == 'This is a test info with an exception'
+
+
+def test_message_params(logger):
+    logger.info('This is a test of %s', 'args')
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['message'] == 'This is a test of args'
+    assert event['log']['param_message'] == 'This is a test of %s'
+
+
+def test_record_stack(logger):
+    logger.info('This is a test of stacks', extra={'stack': True})
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    frames = event['log']['stacktrace']
+    assert len(frames) != 1
+    frame = frames[0]
+    assert frame['module'] == __name__
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test of stacks'
+    assert event['culprit'] == 'tests.handlers.logging.logging_tests.test_record_stack'
+    assert event['log']['message'] == 'This is a test of stacks'
+
+
+def test_no_record_stack(logger):
+    logger.info('This is a test of no stacks', extra={'stack': False})
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event.get('culprit') == None
+    assert event['log']['message'] == 'This is a test of no stacks'
+    assert 'stacktrace' not in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test of no stacks'
+
+
+def test_no_record_stack_via_config(logger):
+    logger.client.config.auto_log_stacks = False
+    logger.info('This is a test of no stacks')
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event.get('culprit') == None
+    assert event['log']['message'] == 'This is a test of no stacks'
+    assert 'stacktrace' not in event['log']
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test of no stacks'
+
+
+def test_explicit_stack(logger):
+    logger.info('This is a test of stacks', extra={'stack': iter_stack_frames()})
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert 'culprit' in event, event
+    assert event['culprit'] == 'tests.handlers.logging.logging_tests.test_explicit_stack'
+    assert 'message' in event['log'], event
+    assert event['log']['message'] == 'This is a test of stacks'
+    assert 'exception' not in event
+    assert 'param_message' in event['log']
+    assert event['log']['param_message'] == 'This is a test of stacks'
+    assert 'stacktrace' in event['log']
+
+
+def test_extra_culprit(logger):
+    logger.info('This is a test of stacks', extra={'culprit': 'foo.bar'})
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+    assert event['culprit'] == 'foo.bar'
+
+
+def test_logger_exception(logger):
+    try:
+        raise ValueError('This is a test ValueError')
+    except ValueError:
+        logger.exception('This is a test with an exception', extra={'stack': True})
+
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)['errors'][0]
+
+    assert event['log']['message'] == 'This is a test with an exception'
+    assert 'stacktrace' in event['log']
+    assert 'exception' in event
+    exc = event['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == 'ValueError: This is a test ValueError'
+    assert 'param_message' in event['log']
+    assert event['log']['message'] == 'This is a test with an exception'
+
+
+def test_client_arg(test_client):
+    handler = LoggingHandler(test_client)
+    assert handler.client == test_client
+
+
+def test_client_kwarg(test_client):
+    handler = LoggingHandler(client=test_client)
+    assert handler.client == test_client
+
+
+def test_invalid_first_arg_type():
+    with pytest.raises(ValueError):
+        LoggingHandler(object)

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -4,17 +4,17 @@ import pytest
 
 from elasticapm.handlers.logging import LoggingHandler
 from elasticapm.utils.stacks import iter_stack_frames
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 @pytest.fixture()
-def logger(test_client):
-    test_client.config.include_paths = ['tests', 'elasticapm']
-    handler = LoggingHandler(test_client)
+def logger(elasticapm_client):
+    elasticapm_client.config.include_paths = ['tests', 'elasticapm']
+    handler = LoggingHandler(elasticapm_client)
     logger = logging.getLogger(__name__)
     logger.handlers = []
     logger.addHandler(handler)
-    logger.client = test_client
+    logger.client = elasticapm_client
     return logger
 
 
@@ -167,14 +167,14 @@ def test_logger_exception(logger):
     assert event['log']['message'] == 'This is a test with an exception'
 
 
-def test_client_arg(test_client):
-    handler = LoggingHandler(test_client)
-    assert handler.client == test_client
+def test_client_arg(elasticapm_client):
+    handler = LoggingHandler(elasticapm_client)
+    assert handler.client == elasticapm_client
 
 
-def test_client_kwarg(test_client):
-    handler = LoggingHandler(client=test_client)
-    assert handler.client == test_client
+def test_client_kwarg(elasticapm_client):
+    handler = LoggingHandler(client=elasticapm_client)
+    assert handler.client == elasticapm_client
 
 
 def test_invalid_first_arg_type():

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -2,24 +2,24 @@ import boto3
 import mock
 
 from elasticapm.traces import trace
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 @mock.patch("botocore.endpoint.Endpoint.make_request")
-def test_botocore_instrumentation(mock_make_request, test_client):
+def test_botocore_instrumentation(mock_make_request, elasticapm_client):
     mock_response = mock.Mock()
     mock_response.status_code = 200
     mock_make_request.return_value = (mock_response, {})
 
-    test_client.begin_transaction("transaction.test")
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_pipeline", "test"):
         session = boto3.Session(aws_access_key_id='foo',
                                 aws_secret_access_key='bar',
                                 region_name='us-west-2')
         ec2 = session.client('ec2')
         ec2.describe_instances()
-    test_client.end_transaction("MyView")
+    elasticapm_client.end_transaction("MyView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
     assert 'ec2:DescribeInstances' in map(lambda x: x['name'], traces)

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -1,33 +1,25 @@
 import boto3
 import mock
 
-import elasticapm
-import elasticapm.instrumentation.control
 from elasticapm.traces import trace
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-class InstrumentBotocoreTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        elasticapm.instrumentation.control.instrument()
+@mock.patch("botocore.endpoint.Endpoint.make_request")
+def test_botocore_instrumentation(mock_make_request, test_client):
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_make_request.return_value = (mock_response, {})
 
-    @mock.patch("botocore.endpoint.Endpoint.make_request")
-    def test_botocore_instrumentation(self, mock_make_request):
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_make_request.return_value = (mock_response, {})
+    test_client.begin_transaction("transaction.test")
+    with trace("test_pipeline", "test"):
+        session = boto3.Session(aws_access_key_id='foo',
+                                aws_secret_access_key='bar',
+                                region_name='us-west-2')
+        ec2 = session.client('ec2')
+        ec2.describe_instances()
+    test_client.end_transaction("MyView")
 
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            session = boto3.Session(aws_access_key_id='foo',
-                                    aws_secret_access_key='bar',
-                                    region_name='us-west-2')
-            ec2 = session.client('ec2')
-            ec2.describe_instances()
-        self.client.end_transaction("MyView")
-
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-        self.assertIn('ec2:DescribeInstances', map(lambda x: x['name'], traces))
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+    assert 'ec2:DescribeInstances' in map(lambda x: x['name'], traces)

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -4,14 +4,14 @@ pytest.importorskip("django")  # isort:skip
 from os.path import join
 
 import django
-from django.test import TestCase
+from django.test.utils import override_settings
 
 import mock
 import pytest
 
 from conftest import BASE_TEMPLATE_DIR
-from elasticapm.contrib.django.client import get_client
 from tests.utils.compat import middleware_setting
+from tests.contrib.django.fixtures import elasticapm_client
 
 try:
     # Django 1.10+
@@ -38,59 +38,56 @@ TEMPLATES = (
 )
 
 
-class TracesTest(TestCase):
-    def setUp(self):
-        self.elasticapm_client = get_client()
+@mock.patch("elasticapm.traces.TransactionsStore.should_collect")
+def test_template_rendering(should_collect, elasticapm_client, client):
+    should_collect.return_value = False
+    with override_settings(**middleware_setting(django.VERSION,
+                                            ['elasticapm.contrib.django.middleware.TracingMiddleware'])):
+        client.get(reverse('render-heavy-template'))
+        client.get(reverse('render-heavy-template'))
+        client.get(reverse('render-heavy-template'))
 
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_template_rendering(self, should_collect):
-        should_collect.return_value = False
-        with self.settings(**middleware_setting(django.VERSION,
-                                                ['elasticapm.contrib.django.middleware.TracingMiddleware'])):
-            self.client.get(reverse('render-heavy-template'))
-            self.client.get(reverse('render-heavy-template'))
-            self.client.get(reverse('render-heavy-template'))
+    transactions = elasticapm_client.instrumentation_store.get_all()
 
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
+    assert len(transactions) == 3
+    traces = transactions[0]['traces']
+    assert len(traces) == 2, [t['name'] for t in traces]
 
-        self.assertEqual(len(transactions), 3)
-        traces = transactions[0]['traces']
-        self.assertEqual(len(traces), 2, [t['name'] for t in traces])
+    kinds = ['code', 'template.django']
+    assert set([t['type'] for t in traces]) == set(kinds)
 
-        kinds = ['code', 'template.django']
-        self.assertEqual(set([t['type'] for t in traces]), set(kinds))
+    assert traces[0]['type'] == 'code'
+    assert traces[0]['name'] == 'something_expensive'
+    assert traces[0]['parent'] == 0
 
-        self.assertEqual(traces[0]['type'], 'code')
-        self.assertEqual(traces[0]['name'], 'something_expensive')
-        self.assertEqual(traces[0]['parent'], 0)
+    assert traces[1]['type'] == 'template.django'
+    assert traces[1]['name'] == 'list_users.html'
+    assert traces[1]['parent'] is None
 
-        self.assertEqual(traces[1]['type'], 'template.django')
-        self.assertEqual(traces[1]['name'], 'list_users.html')
-        self.assertIsNone(traces[1]['parent'])
 
-    @pytest.mark.skipif(django.VERSION < (1, 8),
-                        reason='Jinja2 support introduced with Django 1.8')
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_template_rendering_django18_jinja2(self, should_collect):
-        should_collect.return_value = False
-        with self.settings(
-                TEMPLATES=TEMPLATES,
-                **middleware_setting(django.VERSION,
-                                     ['elasticapm.contrib.django.middleware.TracingMiddleware'])
-            ):
-            self.client.get(reverse('render-jinja2-template'))
-            self.client.get(reverse('render-jinja2-template'))
-            self.client.get(reverse('render-jinja2-template'))
+@pytest.mark.skipif(django.VERSION < (1, 8),
+                    reason='Jinja2 support introduced with Django 1.8')
+@mock.patch("elasticapm.traces.TransactionsStore.should_collect")
+def test_template_rendering_django18_jinja2(should_collect, elasticapm_client, client):
+    should_collect.return_value = False
+    with override_settings(
+            TEMPLATES=TEMPLATES,
+            **middleware_setting(django.VERSION,
+                                 ['elasticapm.contrib.django.middleware.TracingMiddleware'])
+        ):
+        client.get(reverse('render-jinja2-template'))
+        client.get(reverse('render-jinja2-template'))
+        client.get(reverse('render-jinja2-template'))
 
-        transactions = self.elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
 
-        self.assertEqual(len(transactions), 3)
-        traces = transactions[0]['traces']
-        self.assertEqual(len(traces), 1, [t['name'] for t in traces])
+    assert len(transactions) == 3
+    traces = transactions[0]['traces']
+    assert len(traces) == 1, [t['name'] for t in traces]
 
-        kinds = ['template.jinja2']
-        self.assertEqual(set([t['type'] for t in traces]), set(kinds))
+    kinds = ['template.jinja2']
+    assert set([t['type'] for t in traces]) == set(kinds)
 
-        self.assertEqual(traces[0]['type'], 'template.jinja2')
-        self.assertEqual(traces[0]['name'], 'jinja2_template.html')
-        self.assertIsNone(traces[0]['parent'])
+    assert traces[0]['type'] == 'template.jinja2'
+    assert traces[0]['name'] == 'jinja2_template.html'
+    assert traces[0]['parent'] is None

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -10,8 +10,8 @@ import mock
 import pytest
 
 from conftest import BASE_TEMPLATE_DIR
-from tests.utils.compat import middleware_setting
 from tests.contrib.django.fixtures import elasticapm_client
+from tests.utils.compat import middleware_setting
 
 try:
     # Django 1.10+

--- a/tests/instrumentation/jinja2_tests/jinja2_tests.py
+++ b/tests/instrumentation/jinja2_tests/jinja2_tests.py
@@ -1,52 +1,51 @@
 import os
 
 import mock
+import pytest
 from jinja2 import Environment, FileSystemLoader
 from jinja2.environment import Template
 
-import elasticapm.instrumentation.control
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import elasticapm_client
 
 
-class InstrumentJinja2Test(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        filedir = os.path.dirname(__file__)
-        loader = FileSystemLoader(filedir)
-        self.env = Environment(loader=loader)
-        elasticapm.instrumentation.control.instrument()
+@pytest.fixture()
+def jinja_env():
+    filedir = os.path.dirname(__file__)
+    loader = FileSystemLoader(filedir)
+    return Environment(loader=loader)
 
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_from_file(self, should_collect):
-        should_collect.return_value = False
-        self.client.begin_transaction("transaction.test")
-        template = self.env.get_template('mytemplate.html')
-        template.render()
-        self.client.end_transaction("MyView")
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
+@mock.patch("elasticapm.traces.TransactionsStore.should_collect")
+def test_from_file(should_collect, jinja_env, elasticapm_client):
+    should_collect.return_value = False
+    elasticapm_client.begin_transaction("transaction.test")
+    template = jinja_env.get_template('mytemplate.html')
+    template.render()
+    elasticapm_client.end_transaction("MyView")
 
-        expected_signatures = {'mytemplate.html'}
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
 
-        assert {t['name'] for t in traces} == expected_signatures
+    expected_signatures = {'mytemplate.html'}
 
-        assert traces[0]['name'] == 'mytemplate.html'
-        assert traces[0]['type'] == 'template.jinja2'
+    assert {t['name'] for t in traces} == expected_signatures
 
-    def test_from_string(self):
-        self.client.begin_transaction("transaction.test")
-        template = Template("<html></html")
-        template.render()
-        self.client.end_transaction("test")
+    assert traces[0]['name'] == 'mytemplate.html'
+    assert traces[0]['type'] == 'template.jinja2'
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
 
-        expected_signatures = {'<template>'}
+def test_from_string(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
+    template = Template("<html></html")
+    template.render()
+    elasticapm_client.end_transaction("test")
 
-        assert {t['name'] for t in traces} == expected_signatures
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
 
-        assert traces[0]['name'] == '<template>'
-        assert traces[0]['type'] == 'template.jinja2'
+    expected_signatures = {'<template>'}
+
+    assert {t['name'] for t in traces} == expected_signatures
+
+    assert traces[0]['name'] == '<template>'
+    assert traces[0]['type'] == 'template.jinja2'

--- a/tests/instrumentation/jinja2_tests/jinja2_tests.py
+++ b/tests/instrumentation/jinja2_tests/jinja2_tests.py
@@ -30,10 +30,10 @@ class InstrumentJinja2Test(TestCase):
 
         expected_signatures = {'mytemplate.html'}
 
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
+        assert {t['name'] for t in traces} == expected_signatures
 
-        self.assertEqual(traces[0]['name'], 'mytemplate.html')
-        self.assertEqual(traces[0]['type'], 'template.jinja2')
+        assert traces[0]['name'] == 'mytemplate.html'
+        assert traces[0]['type'] == 'template.jinja2'
 
     def test_from_string(self):
         self.client.begin_transaction("transaction.test")
@@ -46,7 +46,7 @@ class InstrumentJinja2Test(TestCase):
 
         expected_signatures = {'<template>'}
 
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
+        assert {t['name'] for t in traces} == expected_signatures
 
-        self.assertEqual(traces[0]['name'], '<template>')
-        self.assertEqual(traces[0]['type'], 'template.jinja2')
+        assert traces[0]['name'] == '<template>'
+        assert traces[0]['type'] == 'template.jinja2'

--- a/tests/instrumentation/mysql_tests.py
+++ b/tests/instrumentation/mysql_tests.py
@@ -1,119 +1,133 @@
 # -*- coding: utf-8 -*-
 from elasticapm.instrumentation.packages.mysql import extract_signature
-from tests.utils.compat import TestCase
 
 
-class ExtractSignatureTest(TestCase):
-    def test_insert(self):
-        sql = """INSERT INTO `mytable` (id, name) VALUE ('2323', 'Ron')"""
-        actual = extract_signature(sql)
+def test_insert():
+    sql = """INSERT INTO `mytable` (id, name) VALUE ('2323', 'Ron')"""
+    actual = extract_signature(sql)
 
-        self.assertEqual("INSERT INTO mytable", actual)
+    assert "INSERT INTO mytable" == actual
 
-    def test_update(self):
-        sql = """UPDATE `mytable` set name='Ron' WHERE id = 2323"""
-        actual = extract_signature(sql)
 
-        self.assertEqual("UPDATE mytable", actual)
+def test_update():
+    sql = """UPDATE `mytable` set name='Ron' WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-    def test_delete(self):
-        sql = """DELETE FROM `mytable` WHERE id = 2323"""
-        actual = extract_signature(sql)
+    assert "UPDATE mytable" == actual
 
-        self.assertEqual("DELETE FROM mytable", actual)
 
-    def test_select_simple(self):
-        sql = """SELECT `id`, `name` FROM `mytable` WHERE id = 2323"""
-        actual = extract_signature(sql)
+def test_delete():
+    sql = """DELETE FROM `mytable` WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-        self.assertEqual("SELECT FROM mytable", actual)
+    assert "DELETE FROM mytable" == actual
 
-    def test_select_with_entity_quotes(self):
-        sql = """SELECT `id`, `name` FROM `mytable` WHERE id = 2323"""
-        actual = extract_signature(sql)
 
-        self.assertEqual("SELECT FROM mytable", actual)
+def test_select_simple():
+    sql = """SELECT `id`, `name` FROM `mytable` WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-    def test_select_with_difficult_values(self):
-        sql = """SELECT id, 'some \\'name' + " from Denmark" FROM `mytable` WHERE id = 2323"""
-        actual = extract_signature(sql)
+    assert "SELECT FROM mytable" == actual
 
-        self.assertEqual("SELECT FROM mytable", actual)
 
-    def test_select_with_difficult_table_name(self):
-        sql = "SELECT id FROM `myta\n-æøåble` WHERE id = 2323"""
-        actual = extract_signature(sql)
+def test_select_with_entity_quotes():
+    sql = """SELECT `id`, `name` FROM `mytable` WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-        self.assertEqual("SELECT FROM myta\n-æøåble", actual)
+    assert "SELECT FROM mytable" == actual
 
-    def test_select_subselect(self):
-        sql = """SELECT id, name FROM (
-                SELECT id, "not a FROM ''value" FROM mytable WHERE id = 2323
-        ) LIMIT 20"""
-        actual = extract_signature(sql)
 
-        self.assertEqual("SELECT FROM mytable", actual)
+def test_select_with_difficult_values():
+    sql = """SELECT id, 'some \\'name' + " from Denmark" FROM `mytable` WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-    def test_select_subselect_with_alias(self):
-        sql = """
-        SELECT count(*)
-        FROM (
-            SELECT count(id) AS some_alias, some_column
-            FROM mytable
-            GROUP BY some_colun
-            HAVING count(id) > 1
-        ) AS foo
-        """
-        actual = extract_signature(sql)
+    assert "SELECT FROM mytable" == actual
 
-        self.assertEqual("SELECT FROM mytable", actual)
 
-    def test_select_with_multiple_tables(self):
-        sql = """SELECT count(table2.id)
-            FROM table1, table2, table2
-            WHERE table2.id = table1.table2_id
-        """
-        actual = extract_signature(sql)
-        self.assertEqual("SELECT FROM table1", actual)
+def test_select_with_difficult_table_name():
+    sql = "SELECT id FROM `myta\n-æøåble` WHERE id = 2323"""
+    actual = extract_signature(sql)
 
-    def test_select_with_invalid_literal(self):
-        sql = "SELECT \"neverending literal FROM (SELECT * FROM ..."""
-        actual = extract_signature(sql)
+    assert "SELECT FROM myta\n-æøåble" == actual
 
-        self.assertEqual("SELECT FROM", actual)
 
-    def test_savepoint(self):
-        sql = """SAVEPOINT x_asd1234"""
-        actual = extract_signature(sql)
+def test_select_subselect():
+    sql = """SELECT id, name FROM (
+            SELECT id, "not a FROM ''value" FROM mytable WHERE id = 2323
+    ) LIMIT 20"""
+    actual = extract_signature(sql)
 
-        self.assertEqual("SAVEPOINT", actual)
+    assert "SELECT FROM mytable" == actual
 
-    def test_begin(self):
-        sql = """BEGIN"""
-        actual = extract_signature(sql)
 
-        self.assertEqual("BEGIN", actual)
+def test_select_subselect_with_alias():
+    sql = """
+    SELECT count(*)
+    FROM (
+        SELECT count(id) AS some_alias, some_column
+        FROM mytable
+        GROUP BY some_colun
+        HAVING count(id) > 1
+    ) AS foo
+    """
+    actual = extract_signature(sql)
 
-    def test_create_index_with_name(self):
-        sql = """CREATE INDEX myindex ON mytable"""
-        actual = extract_signature(sql)
+    assert "SELECT FROM mytable" == actual
 
-        self.assertEqual("CREATE INDEX", actual)
 
-    def test_create_index_without_name(self):
-        sql = """CREATE INDEX ON mytable"""
-        actual = extract_signature(sql)
+def test_select_with_multiple_tables():
+    sql = """SELECT count(table2.id)
+        FROM table1, table2, table2
+        WHERE table2.id = table1.table2_id
+    """
+    actual = extract_signature(sql)
+    assert "SELECT FROM table1" == actual
 
-        self.assertEqual("CREATE INDEX", actual)
 
-    def test_drop_table(self):
-        sql = """DROP TABLE mytable"""
-        actual = extract_signature(sql)
+def test_select_with_invalid_literal():
+    sql = "SELECT \"neverending literal FROM (SELECT * FROM ..."""
+    actual = extract_signature(sql)
 
-        self.assertEqual("DROP TABLE", actual)
+    assert "SELECT FROM" == actual
 
-    def test_multi_statement_sql(self):
-        sql = """CREATE TABLE mytable; SELECT * FROM mytable; DROP TABLE mytable"""
-        actual = extract_signature(sql)
 
-        self.assertEqual("CREATE TABLE", actual)
+def test_savepoint():
+    sql = """SAVEPOINT x_asd1234"""
+    actual = extract_signature(sql)
+
+    assert "SAVEPOINT" == actual
+
+
+def test_begin():
+    sql = """BEGIN"""
+    actual = extract_signature(sql)
+
+    assert "BEGIN" == actual
+
+
+def test_create_index_with_name():
+    sql = """CREATE INDEX myindex ON mytable"""
+    actual = extract_signature(sql)
+
+    assert "CREATE INDEX" == actual
+
+
+def test_create_index_without_name():
+    sql = """CREATE INDEX ON mytable"""
+    actual = extract_signature(sql)
+
+    assert "CREATE INDEX" == actual
+
+
+def test_drop_table():
+    sql = """DROP TABLE mytable"""
+    actual = extract_signature(sql)
+
+    assert "DROP TABLE" == actual
+
+
+def test_multi_statement_sql():
+    sql = """CREATE TABLE mytable; SELECT * FROM mytable; DROP TABLE mytable"""
+    actual = extract_signature(sql)
+
+    assert "CREATE TABLE" == actual

--- a/tests/instrumentation/pymongo_tests.py
+++ b/tests/instrumentation/pymongo_tests.py
@@ -4,7 +4,7 @@ import os
 import pymongo
 import pytest
 
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 @pytest.fixture()
@@ -21,8 +21,8 @@ def mongo_database():
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_bulk_write(test_client, mongo_database):
-    test_client.begin_transaction('transaction.test')
+def test_collection_bulk_write(elasticapm_client, mongo_database):
+    elasticapm_client.begin_transaction('transaction.test')
     requests = [pymongo.InsertOne({'x': 1}),
                 pymongo.DeleteOne({'x': 1}),
                 pymongo.ReplaceOne({'w': 1}, {'z': 1}, upsert=True)]
@@ -30,101 +30,101 @@ def test_collection_bulk_write(test_client, mongo_database):
     assert result.inserted_count == 1
     assert result.deleted_count == 1
     assert result.upserted_count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.bulk_write'
 
 
-def test_collection_count(test_client, mongo_database):
+def test_collection_count(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     mongo_database.blogposts.insert(blogpost)
-    test_client.instrumentation_store.get_all()
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.instrumentation_store.get_all()
+    elasticapm_client.begin_transaction('transaction.test')
     count = mongo_database.blogposts.count()
     assert count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.count'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_delete_one(test_client, mongo_database):
+def test_collection_delete_one(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     mongo_database.blogposts.insert_one(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.delete_one({'author': 'Tom'})
     assert r.deleted_count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.delete_one'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_delete_many(test_client, mongo_database):
+def test_collection_delete_many(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     mongo_database.blogposts.insert_one(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.delete_many({'author': 'Tom'})
     assert r.deleted_count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.delete_many'
 
 
-def test_collection_insert(test_client, mongo_database):
+def test_collection_insert(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.insert(blogpost)
     assert r is not None
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.insert'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_insert_one(test_client, mongo_database):
+def test_collection_insert_one(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.insert_one(blogpost)
     assert r.inserted_id is not None
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.insert_one'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_insert_many(test_client, mongo_database):
+def test_collection_insert_many(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.insert_many([blogpost])
     assert len(r.inserted_ids) == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
 
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.insert_many'
 
 
-def test_collection_find(test_client, mongo_database):
+def test_collection_find(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     blogposts = []
@@ -132,103 +132,103 @@ def test_collection_find(test_client, mongo_database):
         blogposts.append({'author': 'Tom', 'comments': i})
     mongo_database.blogposts.insert(blogposts)
     r = mongo_database.blogposts.insert(blogpost)
-    test_client.instrumentation_store.get_all()
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.instrumentation_store.get_all()
+    elasticapm_client.begin_transaction('transaction.test')
     r = list(mongo_database.blogposts.find({'comments': {'$gt': 995}}))
 
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.cursor.refresh'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_find_one(test_client, mongo_database):
+def test_collection_find_one(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     r = mongo_database.blogposts.insert_one(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.find_one({'author': 'Tom'})
     assert r['author'] == 'Tom'
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.find_one'
 
 
-def test_collection_remove(test_client, mongo_database):
+def test_collection_remove(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     r = mongo_database.blogposts.insert(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.remove({'author': 'Tom'})
     assert r['n'] == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.remove'
 
 
-def test_collection_update(test_client, mongo_database):
+def test_collection_update(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     r = mongo_database.blogposts.insert(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.update({'author': 'Tom'},
                                  {'$set': {'author': 'Jerry'}})
     assert r['n'] == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.update'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_update_one(test_client, mongo_database):
+def test_collection_update_one(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     r = mongo_database.blogposts.insert(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.update_one({'author': 'Tom'},
                                  {'$set': {'author': 'Jerry'}})
     assert r.modified_count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.update_one'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-def test_collection_update_many(test_client, mongo_database):
+def test_collection_update_many(elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     r = mongo_database.blogposts.insert(blogpost)
-    test_client.begin_transaction('transaction.test')
+    elasticapm_client.begin_transaction('transaction.test')
     r = mongo_database.blogposts.update_many({'author': 'Tom'},
                                  {'$set': {'author': 'Jerry'}})
     assert r.modified_count == 1
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.blogposts.update_many'
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (2, 7), reason='New in 2.7')
-def test_bulk_execute(test_client, mongo_database):
-    test_client.begin_transaction('transaction.test')
+def test_bulk_execute(elasticapm_client, mongo_database):
+    elasticapm_client.begin_transaction('transaction.test')
     bulk = mongo_database.test_bulk.initialize_ordered_bulk_op()
     bulk.insert({'x': 'y'})
     bulk.insert({'z': 'x'})
     bulk.find({'x': 'y'}).replace_one({'x': 'z'})
     bulk.execute()
-    test_client.end_transaction('transaction.test')
-    transactions = test_client.instrumentation_store.get_all()
+    elasticapm_client.end_transaction('transaction.test')
+    transactions = elasticapm_client.instrumentation_store.get_all()
     trace = _get_pymongo_trace(transactions[0]['traces'])
     assert trace['type'] == 'db.mongodb.query'
     assert trace['name'] == 'elasticapm_test.test_bulk.bulk.execute'

--- a/tests/instrumentation/pymongo_tests.py
+++ b/tests/instrumentation/pymongo_tests.py
@@ -4,239 +4,234 @@ import os
 import pymongo
 import pytest
 
-import elasticapm
-import elasticapm.instrumentation.control
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-@pytest.mark.integrationtest
-class InstrumentPyMongoTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        elasticapm.instrumentation.control.instrument()
-        connection_params = {'host': os.environ.get('MONGODB_HOST', 'localhost'),
-                             'port': int(os.environ.get('MONGODB_PORT', 27017))}
-        if pymongo.version_tuple < (3, 0):
-            connection_params['safe'] = True
-        self.mongo = pymongo.MongoClient(**connection_params)
-        self.db = self.mongo.elasticapm_test
+@pytest.fixture()
+def mongo_database():
+    connection_params = {'host': os.environ.get('MONGODB_HOST', 'localhost'),
+                         'port': int(os.environ.get('MONGODB_PORT', 27017))}
+    if pymongo.version_tuple < (3, 0):
+        connection_params['safe'] = True
+    mongo = pymongo.MongoClient(**connection_params)
+    db = mongo.elasticapm_test
+    yield db
+    mongo.drop_database('elasticapm_test')
+    mongo.close()
 
-    def tearDown(self):
-        self.mongo.drop_database('elasticapm_test')
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_bulk_write(self):
-        self.client.begin_transaction('transaction.test')
-        requests = [pymongo.InsertOne({'x': 1}),
-                    pymongo.DeleteOne({'x': 1}),
-                    pymongo.ReplaceOne({'w': 1}, {'z': 1}, upsert=True)]
-        result = self.db.blogposts.bulk_write(requests)
-        self.assertEqual(result.inserted_count, 1)
-        self.assertEqual(result.deleted_count, 1)
-        self.assertEqual(result.upserted_count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.bulk_write')
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_bulk_write(test_client, mongo_database):
+    test_client.begin_transaction('transaction.test')
+    requests = [pymongo.InsertOne({'x': 1}),
+                pymongo.DeleteOne({'x': 1}),
+                pymongo.ReplaceOne({'w': 1}, {'z': 1}, upsert=True)]
+    result = mongo_database.blogposts.bulk_write(requests)
+    assert result.inserted_count == 1
+    assert result.deleted_count == 1
+    assert result.upserted_count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.bulk_write'
 
-    def test_collection_count(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.db.blogposts.insert(blogpost)
-        self.client.instrumentation_store.get_all()
-        self.client.begin_transaction('transaction.test')
-        count = self.db.blogposts.count()
-        self.assertEqual(count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'], 'elasticapm_test.blogposts.count')
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_delete_one(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.db.blogposts.insert_one(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.delete_one({'author': 'Tom'})
-        self.assertEqual(r.deleted_count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.delete_one')
+def test_collection_count(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    mongo_database.blogposts.insert(blogpost)
+    test_client.instrumentation_store.get_all()
+    test_client.begin_transaction('transaction.test')
+    count = mongo_database.blogposts.count()
+    assert count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.count'
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_delete_many(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.db.blogposts.insert_one(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.delete_many({'author': 'Tom'})
-        self.assertEqual(r.deleted_count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.delete_many')
 
-    def test_collection_insert(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.insert(blogpost)
-        self.assertIsNotNone(r)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.insert')
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_delete_one(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    mongo_database.blogposts.insert_one(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.delete_one({'author': 'Tom'})
+    assert r.deleted_count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.delete_one'
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_insert_one(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.insert_one(blogpost)
-        self.assertIsNotNone(r.inserted_id)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.insert_one')
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_insert_many(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.insert_many([blogpost])
-        self.assertEqual(len(r.inserted_ids), 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_delete_many(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    mongo_database.blogposts.insert_one(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.delete_many({'author': 'Tom'})
+    assert r.deleted_count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.delete_many'
 
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.insert_many')
 
-    def test_collection_find(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        blogposts = []
-        for i in range(1000):
-            blogposts.append({'author': 'Tom', 'comments': i})
-        self.db.blogposts.insert(blogposts)
-        r = self.db.blogposts.insert(blogpost)
-        self.client.instrumentation_store.get_all()
-        self.client.begin_transaction('transaction.test')
-        r = list(self.db.blogposts.find({'comments': {'$gt': 995}}))
+def test_collection_insert(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.insert(blogpost)
+    assert r is not None
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.insert'
 
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.cursor.refresh')
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_find_one(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        r = self.db.blogposts.insert_one(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.find_one({'author': 'Tom'})
-        self.assertEqual(r['author'], 'Tom')
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.find_one')
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_insert_one(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.insert_one(blogpost)
+    assert r.inserted_id is not None
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.insert_one'
 
-    def test_collection_remove(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        r = self.db.blogposts.insert(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.remove({'author': 'Tom'})
-        self.assertEqual(r['n'], 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.remove')
 
-    def test_collection_update(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        r = self.db.blogposts.insert(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.update({'author': 'Tom'},
-                                     {'$set': {'author': 'Jerry'}})
-        self.assertEqual(r['n'], 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.update')
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_insert_many(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.insert_many([blogpost])
+    assert len(r.inserted_ids) == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_update_one(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        r = self.db.blogposts.insert(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.update_one({'author': 'Tom'},
-                                     {'$set': {'author': 'Jerry'}})
-        self.assertEqual(r.modified_count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.update_one')
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.insert_many'
 
-    @pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
-    def test_collection_update_many(self):
-        blogpost = {'author': 'Tom', 'text': 'Foo',
-                    'date': datetime.datetime.utcnow()}
-        r = self.db.blogposts.insert(blogpost)
-        self.client.begin_transaction('transaction.test')
-        r = self.db.blogposts.update_many({'author': 'Tom'},
-                                     {'$set': {'author': 'Jerry'}})
-        self.assertEqual(r.modified_count, 1)
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.blogposts.update_many')
 
-    @pytest.mark.skipif(pymongo.version_tuple < (2, 7), reason='New in 2.7')
-    def test_bulk_execute(self):
-        self.client.begin_transaction('transaction.test')
-        bulk = self.db.test_bulk.initialize_ordered_bulk_op()
-        bulk.insert({'x': 'y'})
-        bulk.insert({'z': 'x'})
-        bulk.find({'x': 'y'}).replace_one({'x': 'z'})
-        bulk.execute()
-        self.client.end_transaction('transaction.test')
-        transactions = self.client.instrumentation_store.get_all()
-        trace = _get_pymongo_trace(transactions[0]['traces'])
-        self.assertEqual(trace['type'], 'db.mongodb.query')
-        self.assertEqual(trace['name'],
-                         'elasticapm_test.test_bulk.bulk.execute')
+def test_collection_find(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    blogposts = []
+    for i in range(1000):
+        blogposts.append({'author': 'Tom', 'comments': i})
+    mongo_database.blogposts.insert(blogposts)
+    r = mongo_database.blogposts.insert(blogpost)
+    test_client.instrumentation_store.get_all()
+    test_client.begin_transaction('transaction.test')
+    r = list(mongo_database.blogposts.find({'comments': {'$gt': 995}}))
+
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.cursor.refresh'
+
+
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_find_one(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    r = mongo_database.blogposts.insert_one(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.find_one({'author': 'Tom'})
+    assert r['author'] == 'Tom'
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.find_one'
+
+
+def test_collection_remove(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    r = mongo_database.blogposts.insert(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.remove({'author': 'Tom'})
+    assert r['n'] == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.remove'
+
+
+def test_collection_update(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    r = mongo_database.blogposts.insert(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.update({'author': 'Tom'},
+                                 {'$set': {'author': 'Jerry'}})
+    assert r['n'] == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.update'
+
+
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_update_one(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    r = mongo_database.blogposts.insert(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.update_one({'author': 'Tom'},
+                                 {'$set': {'author': 'Jerry'}})
+    assert r.modified_count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.update_one'
+
+
+@pytest.mark.skipif(pymongo.version_tuple < (3, 0), reason='New in 3.0')
+def test_collection_update_many(test_client, mongo_database):
+    blogpost = {'author': 'Tom', 'text': 'Foo',
+                'date': datetime.datetime.utcnow()}
+    r = mongo_database.blogposts.insert(blogpost)
+    test_client.begin_transaction('transaction.test')
+    r = mongo_database.blogposts.update_many({'author': 'Tom'},
+                                 {'$set': {'author': 'Jerry'}})
+    assert r.modified_count == 1
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.blogposts.update_many'
+
+
+@pytest.mark.skipif(pymongo.version_tuple < (2, 7), reason='New in 2.7')
+def test_bulk_execute(test_client, mongo_database):
+    test_client.begin_transaction('transaction.test')
+    bulk = mongo_database.test_bulk.initialize_ordered_bulk_op()
+    bulk.insert({'x': 'y'})
+    bulk.insert({'z': 'x'})
+    bulk.find({'x': 'y'}).replace_one({'x': 'z'})
+    bulk.execute()
+    test_client.end_transaction('transaction.test')
+    transactions = test_client.instrumentation_store.get_all()
+    trace = _get_pymongo_trace(transactions[0]['traces'])
+    assert trace['type'] == 'db.mongodb.query'
+    assert trace['name'] == 'elasticapm_test.test_bulk.bulk.execute'
 
 
 def _get_pymongo_trace(traces):

--- a/tests/instrumentation/python_memcached_tests.py
+++ b/tests/instrumentation/python_memcached_tests.py
@@ -1,54 +1,43 @@
 import os
 
 import memcache
-import mock
 
-import elasticapm
-import elasticapm.instrumentation.control
 from elasticapm.traces import trace
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-class InstrumentMemcachedTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        elasticapm.instrumentation.control.instrument()
+def test_memcached(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_memcached", "test"):
+        host = os.environ.get('MEMCACHED_HOST', 'localhost')
+        conn = memcache.Client([host + ':11211'], debug=0)
+        conn.set("mykey", "a")
+        assert "a" == conn.get("mykey")
+        assert {"mykey": "a"} == conn.get_multi(["mykey", "myotherkey"])
+    test_client.end_transaction("BillingView")
 
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_memcached(self, should_collect):
-        should_collect.return_value = False
-        self.client.begin_transaction("transaction.test")
-        with trace("test_memcached", "test"):
-            host = os.environ.get('MEMCACHED_HOST', 'localhost')
-            conn = memcache.Client([host + ':11211'], debug=0)
-            conn.set("mykey", "a")
-            assert "a" == conn.get("mykey")
-            assert {"mykey": "a"} == conn.get_multi(["mykey", "myotherkey"])
-        self.client.end_transaction("BillingView")
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
+    expected_signatures = {'test_memcached',
+                           'Client.set', 'Client.get',
+                           'Client.get_multi'}
 
-        expected_signatures = {'test_memcached',
-                               'Client.set', 'Client.get',
-                               'Client.get_multi'}
+    assert {t['name'] for t in traces} == expected_signatures
 
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
+    assert traces[0]['name'] == 'Client.set'
+    assert traces[0]['type'] == 'cache.memcached'
+    assert traces[0]['parent'] == 0
 
-        self.assertEqual(traces[0]['name'], 'Client.set')
-        self.assertEqual(traces[0]['type'], 'cache.memcached')
-        self.assertEqual(traces[0]['parent'], 0)
+    assert traces[1]['name'] == 'Client.get'
+    assert traces[1]['type'] == 'cache.memcached'
+    assert traces[1]['parent'] == 0
 
-        self.assertEqual(traces[1]['name'], 'Client.get')
-        self.assertEqual(traces[1]['type'], 'cache.memcached')
-        self.assertEqual(traces[1]['parent'], 0)
+    assert traces[2]['name'] == 'Client.get_multi'
+    assert traces[2]['type'] == 'cache.memcached'
+    assert traces[2]['parent'] == 0
 
-        self.assertEqual(traces[2]['name'], 'Client.get_multi')
-        self.assertEqual(traces[2]['type'], 'cache.memcached')
-        self.assertEqual(traces[2]['parent'], 0)
+    assert traces[3]['name'] == 'test_memcached'
+    assert traces[3]['type'] == 'test'
 
-        self.assertEqual(traces[3]['name'], 'test_memcached')
-        self.assertEqual(traces[3]['type'], 'test')
-
-        self.assertEqual(len(traces), 4)
+    assert len(traces) == 4

--- a/tests/instrumentation/python_memcached_tests.py
+++ b/tests/instrumentation/python_memcached_tests.py
@@ -3,20 +3,20 @@ import os
 import memcache
 
 from elasticapm.traces import trace
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
-def test_memcached(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_memcached(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_memcached", "test"):
         host = os.environ.get('MEMCACHED_HOST', 'localhost')
         conn = memcache.Client([host + ':11211'], debug=0)
         conn.set("mykey", "a")
         assert "a" == conn.get("mykey")
         assert {"mykey": "a"} == conn.get_multi(["mykey", "myotherkey"])
-    test_client.end_transaction("BillingView")
+    elasticapm_client.end_transaction("BillingView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
 
     expected_signatures = {'test_memcached',

--- a/tests/instrumentation/redis_tests.py
+++ b/tests/instrumentation/redis_tests.py
@@ -6,103 +6,96 @@ import pytest
 import redis
 from redis.client import StrictRedis
 
-import elasticapm
-import elasticapm.instrumentation.control
 from elasticapm.traces import trace
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 
-@pytest.mark.integrationtest
-class InstrumentRedisTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        elasticapm.instrumentation.control.instrument()
+@pytest.fixture()
+def redis_conn():
+    conn = redis.StrictRedis(
+        host=os.environ.get('REDIS_HOST', 'localhost'),
+        port=os.environ.get('REDIS_PORT', 6379),
 
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_pipeline(self, should_collect):
-        should_collect.return_value = False
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            conn = redis.StrictRedis(host=os.environ.get('REDIS_HOST', 'localhost'))
-            pipeline = conn.pipeline()
-            pipeline.rpush("mykey", "a", "b")
-            pipeline.expire("mykey", 1000)
-            pipeline.execute()
-        self.client.end_transaction("MyView")
-
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-
-        expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
-
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
-
-        self.assertEqual(traces[0]['name'], 'StrictPipeline.execute')
-        self.assertEqual(traces[0]['type'], 'cache.redis')
-
-        self.assertEqual(traces[1]['name'], 'test_pipeline')
-        self.assertEqual(traces[1]['type'], 'test')
-
-        self.assertEqual(len(traces), 2)
-
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_rq_patches_redis(self, should_collect):
-        should_collect.return_value = False
-
-        # Let's go ahead and change how something important works
-        conn = redis.StrictRedis(host=os.environ.get('REDIS_HOST', 'localhost'))
-        conn._pipeline = partial(StrictRedis.pipeline, conn)
-
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            # conn = redis.StrictRedis()
-            pipeline = conn._pipeline()
-            pipeline.rpush("mykey", "a", "b")
-            pipeline.expire("mykey", 1000)
-            pipeline.execute()
-        self.client.end_transaction("MyView")
-
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-
-        expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
-
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
-
-        self.assertEqual(traces[0]['name'], 'StrictPipeline.execute')
-        self.assertEqual(traces[0]['type'], 'cache.redis')
-
-        self.assertEqual(traces[1]['name'], 'test_pipeline')
-        self.assertEqual(traces[1]['type'], 'test')
-
-        self.assertEqual(len(traces), 2)
-
-    @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-    def test_redis_client(self, should_collect):
-        should_collect.return_value = False
-        self.client.begin_transaction("transaction.test")
-        with trace("test_redis_client", "test"):
-            conn = redis.StrictRedis(host=os.environ.get('REDIS_HOST', 'localhost'))
-            conn.rpush("mykey", "a", "b")
-            conn.expire("mykey", 1000)
-        self.client.end_transaction("MyView")
-
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-
-        expected_signatures = {'test_redis_client', 'RPUSH', 'EXPIRE'}
-
-        self.assertEqual({t['name'] for t in traces}, expected_signatures)
-
-        self.assertEqual(traces[0]['name'], 'RPUSH')
-        self.assertEqual(traces[0]['type'], 'cache.redis')
-
-        self.assertEqual(traces[1]['name'], 'EXPIRE')
-        self.assertEqual(traces[1]['type'], 'cache.redis')
-
-        self.assertEqual(traces[2]['name'], 'test_redis_client')
-        self.assertEqual(traces[2]['type'], 'test')
+    )
+    yield conn
+    del conn
 
 
-        self.assertEqual(len(traces), 3)
+def test_pipeline(test_client, redis_conn):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_pipeline", "test"):
+        pipeline = redis_conn.pipeline()
+        pipeline.rpush("mykey", "a", "b")
+        pipeline.expire("mykey", 1000)
+        pipeline.execute()
+    test_client.end_transaction("MyView")
+
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+
+    expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
+
+    assert {t['name'] for t in traces} == expected_signatures
+
+    assert traces[0]['name'] == 'StrictPipeline.execute'
+    assert traces[0]['type'] == 'cache.redis'
+
+    assert traces[1]['name'] == 'test_pipeline'
+    assert traces[1]['type'] == 'test'
+
+    assert len(traces) == 2
+
+
+def test_rq_patches_redis(test_client, redis_conn):
+    # Let's go ahead and change how something important works
+    redis_conn._pipeline = partial(StrictRedis.pipeline, redis_conn)
+
+    test_client.begin_transaction("transaction.test")
+    with trace("test_pipeline", "test"):
+        # conn = redis.StrictRedis()
+        pipeline = redis_conn._pipeline()
+        pipeline.rpush("mykey", "a", "b")
+        pipeline.expire("mykey", 1000)
+        pipeline.execute()
+    test_client.end_transaction("MyView")
+
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+
+    expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
+
+    assert {t['name'] for t in traces} == expected_signatures
+
+    assert traces[0]['name'] == 'StrictPipeline.execute'
+    assert traces[0]['type'] == 'cache.redis'
+
+    assert traces[1]['name'] == 'test_pipeline'
+    assert traces[1]['type'] == 'test'
+
+    assert len(traces) == 2
+
+
+def test_redis_client(test_client, redis_conn):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_redis_client", "test"):
+        redis_conn.rpush("mykey", "a", "b")
+        redis_conn.expire("mykey", 1000)
+    test_client.end_transaction("MyView")
+
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+
+    expected_signatures = {'test_redis_client', 'RPUSH', 'EXPIRE'}
+
+    assert {t['name'] for t in traces} == expected_signatures
+
+    assert traces[0]['name'] == 'RPUSH'
+    assert traces[0]['type'] == 'cache.redis'
+
+    assert traces[1]['name'] == 'EXPIRE'
+    assert traces[1]['type'] == 'cache.redis'
+
+    assert traces[2]['name'] == 'test_redis_client'
+    assert traces[2]['type'] == 'test'
+
+    assert len(traces) == 3

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -1,79 +1,80 @@
+import pytest
 import requests
 from requests.exceptions import InvalidURL, MissingSchema
 from urllib3_mock import Responses
 
-import elasticapm
-import elasticapm.instrumentation.control
 from elasticapm.traces import trace
-from tests.helpers import get_tempstoreclient
-from tests.utils.compat import TestCase
+from tests.fixtures import test_client
 
 try:
     from requests.packages import urllib3  # noqa
     responses = Responses('requests.packages.urllib3')
 except ImportError:
     responses = Responses('urllib3')
+responses.add('GET', '/', status=200, adding_headers={'Location': 'http://example.com/foo'})
 
 
-class InstrumentRequestsTest(TestCase):
-    def setUp(self):
-        self.client = get_tempstoreclient()
-        elasticapm.instrumentation.control.instrument()
-        responses.add('GET', '/', status=200, adding_headers={'Location': 'http://example.com/foo'})
+def test_requests_instrumentation(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        # NOTE: The `allow_redirects` argument has to be set to `False`,
+        # because mocking is done a level deeper, and the mocked response
+        # from the `HTTPAdapter` is about to be used to make further
+        # requests to resolve redirects, which doesn't make sense for this
+        # test case.
+        requests.get('http://example.com', allow_redirects=False)
+    test_client.end_transaction("MyView")
 
-    def test_requests_instrumentation(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            # NOTE: The `allow_redirects` argument has to be set to `False`,
-            # because mocking is done a level deeper, and the mocked response
-            # from the `HTTPAdapter` is about to be used to make further
-            # requests to resolve redirects, which doesn't make sense for this
-            # test case.
-            requests.get('http://example.com', allow_redirects=False)
-        self.client.end_transaction("MyView")
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+    assert 'GET example.com' == traces[0]['name']
+    assert 'http://example.com/' == traces[0]['context']['url']
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-        self.assertEqual('GET example.com', traces[0]['name'])
-        self.assertEqual('http://example.com/', traces[0]['context']['url'])
 
-    def test_requests_instrumentation_via_session(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            s = requests.Session()
-            s.get('http://example.com', allow_redirects=False)
-        self.client.end_transaction("MyView")
+def test_requests_instrumentation_via_session(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        s = requests.Session()
+        s.get('http://example.com', allow_redirects=False)
+    test_client.end_transaction("MyView")
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-        self.assertEqual('GET example.com', traces[0]['name'])
-        self.assertEqual('http://example.com/', traces[0]['context']['url'])
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+    assert 'GET example.com' == traces[0]['name']
+    assert 'http://example.com/' == traces[0]['context']['url']
 
-    def test_requests_instrumentation_via_prepared_request(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            r = requests.Request('get', 'http://example.com')
-            pr = r.prepare()
-            s = requests.Session()
-            s.send(pr, allow_redirects=False)
-        self.client.end_transaction("MyView")
 
-        transactions = self.client.instrumentation_store.get_all()
-        traces = transactions[0]['traces']
-        self.assertEqual('GET example.com', traces[0]['name'])
-        self.assertEqual('http://example.com/', traces[0]['context']['url'])
+def test_requests_instrumentation_via_prepared_request(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        r = requests.Request('get', 'http://example.com')
+        pr = r.prepare()
+        s = requests.Session()
+        s.send(pr, allow_redirects=False)
+    test_client.end_transaction("MyView")
 
-    def test_requests_instrumentation_malformed_none(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            self.assertRaises(MissingSchema, requests.get, None)
+    transactions = test_client.instrumentation_store.get_all()
+    traces = transactions[0]['traces']
+    assert 'GET example.com' == traces[0]['name']
+    assert 'http://example.com/' == traces[0]['context']['url']
 
-    def test_requests_instrumentation_malformed_schema(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            self.assertRaises(MissingSchema, requests.get, '')
 
-    def test_requests_instrumentation_malformed_path(self):
-        self.client.begin_transaction("transaction.test")
-        with trace("test_pipeline", "test"):
-            self.assertRaises(InvalidURL, requests.get, 'http://')
+def test_requests_instrumentation_malformed_none(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        with pytest.raises(MissingSchema):
+            requests.get(None)
+
+
+def test_requests_instrumentation_malformed_schema(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        with pytest.raises(MissingSchema):
+            requests.get('')
+
+
+def test_requests_instrumentation_malformed_path(test_client):
+    test_client.begin_transaction("transaction.test")
+    with trace("test_request", "test"):
+        with pytest.raises(InvalidURL):
+            requests.get('http://')

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -4,7 +4,7 @@ from requests.exceptions import InvalidURL, MissingSchema
 from urllib3_mock import Responses
 
 from elasticapm.traces import trace
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 try:
     from requests.packages import urllib3  # noqa
@@ -14,8 +14,8 @@ except ImportError:
 responses.add('GET', '/', status=200, adding_headers={'Location': 'http://example.com/foo'})
 
 
-def test_requests_instrumentation(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         # NOTE: The `allow_redirects` argument has to be set to `False`,
         # because mocking is done a level deeper, and the mocked response
@@ -23,58 +23,58 @@ def test_requests_instrumentation(test_client):
         # requests to resolve redirects, which doesn't make sense for this
         # test case.
         requests.get('http://example.com', allow_redirects=False)
-    test_client.end_transaction("MyView")
+    elasticapm_client.end_transaction("MyView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
     assert 'GET example.com' == traces[0]['name']
     assert 'http://example.com/' == traces[0]['context']['url']
 
 
-def test_requests_instrumentation_via_session(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation_via_session(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         s = requests.Session()
         s.get('http://example.com', allow_redirects=False)
-    test_client.end_transaction("MyView")
+    elasticapm_client.end_transaction("MyView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
     assert 'GET example.com' == traces[0]['name']
     assert 'http://example.com/' == traces[0]['context']['url']
 
 
-def test_requests_instrumentation_via_prepared_request(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation_via_prepared_request(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         r = requests.Request('get', 'http://example.com')
         pr = r.prepare()
         s = requests.Session()
         s.send(pr, allow_redirects=False)
-    test_client.end_transaction("MyView")
+    elasticapm_client.end_transaction("MyView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
     assert 'GET example.com' == traces[0]['name']
     assert 'http://example.com/' == traces[0]['context']['url']
 
 
-def test_requests_instrumentation_malformed_none(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation_malformed_none(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         with pytest.raises(MissingSchema):
             requests.get(None)
 
 
-def test_requests_instrumentation_malformed_schema(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation_malformed_schema(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         with pytest.raises(MissingSchema):
             requests.get('')
 
 
-def test_requests_instrumentation_malformed_path(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_requests_instrumentation_malformed_path(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
     with trace("test_request", "test"):
         with pytest.raises(InvalidURL):
             requests.get('http://')

--- a/tests/instrumentation/sqlite_tests.py
+++ b/tests/instrumentation/sqlite_tests.py
@@ -1,10 +1,10 @@
 import sqlite3
 
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
-def test_connect(test_client):
-    test_client.begin_transaction("transaction.test")
+def test_connect(elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
 
     conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
@@ -13,9 +13,9 @@ def test_connect(test_client):
     cursor.execute("""INSERT INTO testdb VALUES (1, "Ron")""")
     cursor.execute("""DROP TABLE testdb""")
 
-    test_client.end_transaction("MyView")
+    elasticapm_client.end_transaction("MyView")
 
-    transactions = test_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.instrumentation_store.get_all()
     traces = transactions[0]['traces']
 
     expected_signatures = {'sqlite3.connect :memory:',

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -92,7 +92,7 @@ class RequestStoreTest(TestCase):
             with trace("bleh", "custom"):
                 time.sleep(0.01)
 
-        self.assertEqual(self.mock_get_frames.call_count, 10)
+        assert self.mock_get_frames.call_count == 10
 
     def test_leaf_tracing(self):
         self.requests_store.begin_transaction("transaction.test")
@@ -112,10 +112,10 @@ class RequestStoreTest(TestCase):
         transactions = self.requests_store.get_all()
         traces = transactions[0]['traces']
 
-        self.assertEqual(len(traces), 2)
+        assert len(traces) == 2
 
         signatures = {'root', 'child1-leaf'}
-        self.assertEqual({t['name'] for t in traces}, signatures)
+        assert {t['name'] for t in traces} == signatures
 
 
 def test_get_transaction():

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -1,121 +1,123 @@
 import logging
 import time
 
+import pytest
 from mock import Mock
 
 import elasticapm
 from elasticapm.traces import TransactionsStore, get_transaction, trace
-from tests.utils.compat import TestCase
 
 
-class RequestStoreTest(TestCase):
-    def setUp(self):
-        self.mock_get_frames = Mock()
+@pytest.fixture()
+def transaction_store():
+    mock_get_frames = Mock()
 
-        frames = [{'function': 'something_expensive',
-                   'abs_path': '/var/parent-elasticapm/elasticapm/tests/contrib/django/testapp/views.py',
-                   'lineno': 52, 'module': 'tests.contrib.django.testapp.views',
-                   'filename': 'tests/contrib/django/testapp/views.py'},
-                  {'function': '_resolve_lookup',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
-                   'lineno': 789, 'module': 'django.template.base',
-                   'filename': 'django/template/base.py'},
-                  {'function': 'resolve',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
-                   'lineno': 735, 'module': 'django.template.base',
-                   'filename': 'django/template/base.py'},
-                  {'function': 'resolve',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
-                   'lineno': 585, 'module': 'django.template.base',
-                   'filename': 'django/template/base.py'}, {'lineno': 4,
-                                                            'filename': u'/var/parent-elasticapm/elasticapm/tests/contrib/django/testapp/templates/list_fish.html'},
-                  {'function': 'render',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/defaulttags.py',
-                   'lineno': 4, 'module': 'django.template.defaulttags',
-                   'filename': 'django/template/defaulttags.py'},
-                  {'function': 'render_node',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/debug.py',
-                   'lineno': 78, 'module': 'django.template.debug',
-                   'filename': 'django/template/debug.py'},
-                  {'function': 'render',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
-                   'lineno': 840, 'module': 'django.template.base',
-                   'filename': 'django/template/base.py'},
-                  {'function': 'instrumented_test_render',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/utils.py',
-                   'lineno': 85, 'module': 'django.test.utils',
-                   'filename': 'django/test/utils.py'}, {'function': 'render',
-                                                         'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
-                                                         'lineno': 140,
-                                                         'module': 'django.template.base',
-                                                         'filename': 'django/template/base.py'},
-                  {'function': 'rendered_content',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/response.py',
-                   'lineno': 82, 'module': 'django.template.response',
-                   'filename': 'django/template/response.py'},
-                  {'function': 'render',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/response.py',
-                   'lineno': 105, 'module': 'django.template.response',
-                   'filename': 'django/template/response.py'},
-                  {'function': 'get_response',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/core/handlers/base.py',
-                   'lineno': 137, 'module': 'django.core.handlers.base',
-                   'filename': 'django/core/handlers/base.py'},
-                  {'function': '__call__',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
-                   'lineno': 109, 'module': 'django.test.client',
-                   'filename': 'django/test/client.py'}, {'function': 'request',
-                                                          'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
-                                                          'lineno': 426,
-                                                          'module': 'django.test.client',
-                                                          'filename': 'django/test/client.py'},
-                  {'function': 'get',
-                   'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
-                   'lineno': 280, 'module': 'django.test.client',
-                   'filename': 'django/test/client.py'}, {'function': 'get',
-                                                          'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
-                                                          'lineno': 473,
-                                                          'module': 'django.test.client',
-                                                          'filename': 'django/test/client.py'},
-                  {'function': 'test_template_name_as_view',
-                   'abs_path': '/var/parent-elasticapm/elasticapm/tests/contrib/django/django_tests.py',
-                   'lineno': 710, 'module': 'tests.contrib.django.django_tests',
-                   'filename': 'tests/contrib/django/django_tests.py'}]
+    frames = [{'function': 'something_expensive',
+               'abs_path': '/var/parent-elasticapm/elasticapm/tests/contrib/django/testapp/views.py',
+               'lineno': 52, 'module': 'tests.contrib.django.testapp.views',
+               'filename': 'tests/contrib/django/testapp/views.py'},
+              {'function': '_resolve_lookup',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
+               'lineno': 789, 'module': 'django.template.base',
+               'filename': 'django/template/base.py'},
+              {'function': 'resolve',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
+               'lineno': 735, 'module': 'django.template.base',
+               'filename': 'django/template/base.py'},
+              {'function': 'resolve',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
+               'lineno': 585, 'module': 'django.template.base',
+               'filename': 'django/template/base.py'}, {'lineno': 4,
+                                                        'filename': u'/var/parent-elasticapm/elasticapm/tests/contrib/django/testapp/templates/list_fish.html'},
+              {'function': 'render',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/defaulttags.py',
+               'lineno': 4, 'module': 'django.template.defaulttags',
+               'filename': 'django/template/defaulttags.py'},
+              {'function': 'render_node',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/debug.py',
+               'lineno': 78, 'module': 'django.template.debug',
+               'filename': 'django/template/debug.py'},
+              {'function': 'render',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
+               'lineno': 840, 'module': 'django.template.base',
+               'filename': 'django/template/base.py'},
+              {'function': 'instrumented_test_render',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/utils.py',
+               'lineno': 85, 'module': 'django.test.utils',
+               'filename': 'django/test/utils.py'}, {'function': 'render',
+                                                     'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/base.py',
+                                                     'lineno': 140,
+                                                     'module': 'django.template.base',
+                                                     'filename': 'django/template/base.py'},
+              {'function': 'rendered_content',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/response.py',
+               'lineno': 82, 'module': 'django.template.response',
+               'filename': 'django/template/response.py'},
+              {'function': 'render',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/template/response.py',
+               'lineno': 105, 'module': 'django.template.response',
+               'filename': 'django/template/response.py'},
+              {'function': 'get_response',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/core/handlers/base.py',
+               'lineno': 137, 'module': 'django.core.handlers.base',
+               'filename': 'django/core/handlers/base.py'},
+              {'function': '__call__',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
+               'lineno': 109, 'module': 'django.test.client',
+               'filename': 'django/test/client.py'}, {'function': 'request',
+                                                      'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
+                                                      'lineno': 426,
+                                                      'module': 'django.test.client',
+                                                      'filename': 'django/test/client.py'},
+              {'function': 'get',
+               'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
+               'lineno': 280, 'module': 'django.test.client',
+               'filename': 'django/test/client.py'}, {'function': 'get',
+                                                      'abs_path': '/home/ron/.virtualenvs/elasticapm/local/lib/python2.7/site-packages/django/test/client.py',
+                                                      'lineno': 473,
+                                                      'module': 'django.test.client',
+                                                      'filename': 'django/test/client.py'},
+              {'function': 'test_template_name_as_view',
+               'abs_path': '/var/parent-elasticapm/elasticapm/tests/contrib/django/django_tests.py',
+               'lineno': 710, 'module': 'tests.contrib.django.django_tests',
+               'filename': 'tests/contrib/django/django_tests.py'}]
 
-        self.mock_get_frames.return_value = frames
-        self.requests_store = TransactionsStore(self.mock_get_frames, 99999)
+    mock_get_frames.return_value = frames
+    return TransactionsStore(mock_get_frames, 99999)
 
-    def test_lru_get_frames_cache(self):
-        self.requests_store.begin_transaction("transaction.test")
 
-        for i in range(10):
-            with trace("bleh", "custom"):
+def test_lru_get_frames_cache(transaction_store):
+    transaction_store.begin_transaction("transaction.test")
+
+    for i in range(10):
+        with trace("bleh", "custom"):
+            time.sleep(0.01)
+
+    assert transaction_store._get_frames.call_count == 10
+
+
+def test_leaf_tracing(transaction_store):
+    transaction_store.begin_transaction("transaction.test")
+
+    with trace("root", "custom"):
+        with trace("child1-leaf", "custom", leaf=True):
+
+            # These two traces should not show up
+            with trace("ignored-child1", "custom", leaf=True):
                 time.sleep(0.01)
 
-        assert self.mock_get_frames.call_count == 10
+            with trace("ignored-child2", "custom", leaf=False):
+                time.sleep(0.01)
 
-    def test_leaf_tracing(self):
-        self.requests_store.begin_transaction("transaction.test")
+    transaction_store.end_transaction(None, "transaction")
 
-        with trace("root", "custom"):
-            with trace("child1-leaf", "custom", leaf=True):
+    transactions = transaction_store.get_all()
+    traces = transactions[0]['traces']
 
-                # These two traces should not show up
-                with trace("ignored-child1", "custom", leaf=True):
-                    time.sleep(0.01)
+    assert len(traces) == 2
 
-                with trace("ignored-child2", "custom", leaf=False):
-                    time.sleep(0.01)
-
-        self.requests_store.end_transaction(None, "transaction")
-
-        transactions = self.requests_store.get_all()
-        traces = transactions[0]['traces']
-
-        assert len(traces) == 2
-
-        signatures = {'root', 'child1-leaf'}
-        assert {t['name'] for t in traces} == signatures
+    signatures = {'root', 'child1-leaf'}
+    assert {t['name'] for t in traces} == signatures
 
 
 def test_get_transaction():

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -1,49 +1,43 @@
 from __future__ import absolute_import
 
+import pytest
 import webob
 
 from elasticapm.middleware import ElasticAPM
-from tests.utils.compat import TestCase
-
-from ..helpers import get_tempstoreclient
+from tests.fixtures import test_client
 
 
 def example_app(environ, start_response):
     raise ValueError('hello world')
 
 
-class MiddlewareTest(TestCase):
-    def setUp(self):
-        self.app = example_app
+def test_error_handler(test_client):
+    middleware = ElasticAPM(example_app, client=test_client)
 
-    def test_error_handler(self):
-        client = get_tempstoreclient()
-        middleware = ElasticAPM(self.app, client=client)
+    request = webob.Request.blank('/an-error?foo=bar')
+    response = middleware(request.environ, lambda *args: None)
 
-        request = webob.Request.blank('/an-error?foo=bar')
-        response = middleware(request.environ, lambda *args: None)
+    with pytest.raises(ValueError):
+        list(response)
 
-        with self.assertRaises(ValueError):
-            list(response)
+    assert len(test_client.events) == 1
+    event = test_client.events.pop(0)['errors'][0]
 
-        self.assertEquals(len(client.events), 1)
-        event = client.events.pop(0)['errors'][0]
+    assert 'exception' in event
+    exc = event['exception']
+    assert exc['type'] == 'ValueError'
+    assert exc['message'] == 'ValueError: hello world'
 
-        self.assertTrue('exception' in event)
-        exc = event['exception']
-        self.assertEquals(exc['type'], 'ValueError')
-        self.assertEquals(exc['message'], 'ValueError: hello world')
-
-        self.assertTrue('request' in event['context'])
-        request = event['context']['request']
-        self.assertEquals(request['url']['raw'], 'http://localhost/an-error?foo=bar')
-        self.assertEquals(request['url']['search'], 'foo=bar')
-        self.assertEquals(request['method'], 'GET')
-        headers = request['headers']
-        self.assertTrue('host' in headers, headers.keys())
-        self.assertEquals(headers['host'], 'localhost:80')
-        env = request['env']
-        self.assertTrue('SERVER_NAME' in env, env.keys())
-        self.assertEquals(env['SERVER_NAME'], 'localhost')
-        self.assertTrue('SERVER_PORT' in env, env.keys())
-        self.assertEquals(env['SERVER_PORT'], '80')
+    assert 'request' in event['context']
+    request = event['context']['request']
+    assert request['url']['raw'] == 'http://localhost/an-error?foo=bar'
+    assert request['url']['search'] == 'foo=bar'
+    assert request['method'] == 'GET'
+    headers = request['headers']
+    assert 'host' in headers, headers.keys()
+    assert headers['host'] == 'localhost:80'
+    env = request['env']
+    assert 'SERVER_NAME' in env, env.keys()
+    assert env['SERVER_NAME'] == 'localhost'
+    assert 'SERVER_PORT' in env, env.keys()
+    assert env['SERVER_PORT'] == '80'

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -4,15 +4,15 @@ import pytest
 import webob
 
 from elasticapm.middleware import ElasticAPM
-from tests.fixtures import test_client
+from tests.fixtures import elasticapm_client
 
 
 def example_app(environ, start_response):
     raise ValueError('hello world')
 
 
-def test_error_handler(test_client):
-    middleware = ElasticAPM(example_app, client=test_client)
+def test_error_handler(elasticapm_client):
+    middleware = ElasticAPM(example_app, client=elasticapm_client)
 
     request = webob.Request.blank('/an-error?foo=bar')
     response = middleware(request.environ, lambda *args: None)
@@ -20,8 +20,8 @@ def test_error_handler(test_client):
     with pytest.raises(ValueError):
         list(response)
 
-    assert len(test_client.events) == 1
-    event = test_client.events.pop(0)['errors'][0]
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
 
     assert 'exception' in event
     exc = event['exception']

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -1,183 +1,178 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import pytest
+
 from elasticapm import Client, processors
 from elasticapm.utils import compat
-from tests.utils.compat import TestCase
 
 
-class SanitizePasswordsProcessorTest(TestCase):
-    def setUp(self):
-        self.http_test_data = {
-            'context': {
-                'request': {
-                    'body': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
-                    'env': {
-                        'foo': 'bar',
-                        'password': 'hello',
-                        'the_secret': 'hello',
-                        'a_password_here': 'hello',
-                    },
-                    'headers': {
-                        'foo': 'bar',
-                        'password': 'hello',
-                        'the_secret': 'hello',
-                        'a_password_here': 'hello',
-                    },
-                    'cookies': {
-                        'foo': 'bar',
-                        'password': 'topsecret',
-                        'the_secret': 'topsecret',
-                        'sessionid': '123',
-                        'a_password_here': '123456',
-                    },
-                    'url': {
-                        'raw': 'http://example.com/bla?foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
-                        'search': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765'
-                    }
+@pytest.fixture()
+def http_test_data():
+    return {
+        'context': {
+            'request': {
+                'body': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
+                'env': {
+                    'foo': 'bar',
+                    'password': 'hello',
+                    'the_secret': 'hello',
+                    'a_password_here': 'hello',
                 },
-                'response': {
-                    'status_code': '200',
-                    'headers': {
-                        'foo': 'bar',
-                        'password': 'hello',
-                        'the_secret': 'hello',
-                        'a_password_here': 'hello',
-                    }
+                'headers': {
+                    'foo': 'bar',
+                    'password': 'hello',
+                    'the_secret': 'hello',
+                    'a_password_here': 'hello',
+                },
+                'cookies': {
+                    'foo': 'bar',
+                    'password': 'topsecret',
+                    'the_secret': 'topsecret',
+                    'sessionid': '123',
+                    'a_password_here': '123456',
+                },
+                'url': {
+                    'raw': 'http://example.com/bla?foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
+                    'search': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765'
+                }
+            },
+            'response': {
+                'status_code': '200',
+                'headers': {
+                    'foo': 'bar',
+                    'password': 'hello',
+                    'the_secret': 'hello',
+                    'a_password_here': 'hello',
                 }
             }
         }
-
-    def test_stacktrace(self):
-        data = {
-            'exception': {
-                'stacktrace': [
-                    {
-                        'vars': {
-                            'foo': 'bar',
-                            'password': 'hello',
-                            'the_secret': 'hello',
-                            'a_password_here': 'hello',
-                        },
-                    }
-                ]
-            }
-        }
-
-        result = processors.sanitize_stacktrace_locals(None, data)
-
-        self.assertTrue('stacktrace' in result['exception'])
-        stack = result['exception']['stacktrace']
-        self.assertEquals(len(stack), 1)
-        frame = stack[0]
-        self.assertTrue('vars' in frame)
-        vars = frame['vars']
-        self.assertTrue('foo' in vars)
-        self.assertEquals(vars['foo'], 'bar')
-        self.assertTrue('password' in vars)
-        self.assertEquals(vars['password'], processors.MASK)
-        self.assertTrue('the_secret' in vars)
-        self.assertEquals(vars['the_secret'], processors.MASK)
-        self.assertTrue('a_password_here' in vars)
-        self.assertEquals(vars['a_password_here'], processors.MASK)
-
-    def test_remove_http_request_body(self):
-        assert 'body' in self.http_test_data['context']['request']
-
-        result = processors.remove_http_request_body(None, self.http_test_data)
-
-        assert 'body' not in result['context']['request']
-
-    def test_sanitize_http_request_cookies(self):
-        self.http_test_data['context']['request']['headers']['cookie'] =\
-            'foo=bar; password=12345; the_secret=12345; csrftoken=abc'
-
-        result = processors.sanitize_http_request_cookies(None, self.http_test_data)
-
-        assert result['context']['request']['cookies'] == {
-            'foo': 'bar',
-            'password': processors.MASK,
-            'the_secret': processors.MASK,
-            'sessionid': processors.MASK,
-            'a_password_here': processors.MASK,
-        }
-
-        assert (result['context']['request']['headers']['cookie'] ==
-                'foo=bar; password={0}; the_secret={0}; csrftoken={0}'.format(processors.MASK))
-
-    def test_sanitize_http_headers(self):
-        result = processors.sanitize_http_headers(None, self.http_test_data)
-        expected = {
-            'foo': 'bar',
-            'password': processors.MASK,
-            'the_secret': processors.MASK,
-            'a_password_here': processors.MASK,
-        }
-        assert result['context']['request']['headers'] == expected
-        assert result['context']['response']['headers'] == expected
-
-    def test_sanitize_http_wgi_env(self):
-        result = processors.sanitize_http_wsgi_env(None, self.http_test_data)
-
-        assert result['context']['request']['env'] == {
-            'foo': 'bar',
-            'password': processors.MASK,
-            'the_secret': processors.MASK,
-            'a_password_here': processors.MASK,
-        }
-
-    def test_sanitize_http_query_string(self):
-        result = processors.sanitize_http_request_querystring(None, self.http_test_data)
-
-        expected = 'foo=bar&password={0}&the_secret={0}&cc={0}'.format(
-            processors.MASK
-        )
-        assert result['context']['request']['url']['search'] == expected
-        assert result['context']['request']['url']['raw'].endswith(expected)
-
-    def test_post_as_string(self):
-        result = processors.sanitize_http_request_body(None, self.http_test_data)
-        expected = 'foo=bar&password={0}&the_secret={0}&cc={0}'.format(
-            processors.MASK
-        )
-        assert result['context']['request']['body'] == expected
-
-    def test_querystring_as_string_with_partials(self):
-        self.http_test_data['context']['request']['url']['search'] = 'foo=bar&password&secret=123456'
-        result = processors.sanitize_http_request_querystring(None, self.http_test_data)
-
-        assert (result['context']['request']['url']['search'] ==
-                'foo=bar&password&secret={0}'.format(processors.MASK))
-
-    def test_sanitize_credit_card(self):
-        result = processors._sanitize('foo', '4242424242424242')
-        self.assertEquals(result, processors.MASK)
-
-    def test_sanitize_credit_card_with_spaces(self):
-        result = processors._sanitize('foo', '4242 4242 4242 4242')
-        self.assertEquals(result, processors.MASK)
-
-    def test_non_utf8_encoding(self):
-        broken = compat.b('broken=') + u"aéöüa".encode('latin-1')
-        self.http_test_data['context']['request']['url']['search'] = broken
-        result = processors.sanitize_http_request_querystring(None, self.http_test_data)
-        assert result['context']['request']['url']['search'] == u'broken=a\ufffd\ufffd\ufffda'
+    }
 
 
-def test_remove_http_request_body():
+def test_stacktrace():
     data = {
-        'context': {
-            'request': {
-                'body': 'foo'
-            },
+        'exception': {
+            'stacktrace': [
+                {
+                    'vars': {
+                        'foo': 'bar',
+                        'password': 'hello',
+                        'the_secret': 'hello',
+                        'a_password_here': 'hello',
+                    },
+                }
+            ]
         }
     }
 
-    result = processors.remove_http_request_body(None, data)
+    result = processors.sanitize_stacktrace_locals(None, data)
 
-    assert 'request' in result['context']
-    request = result['context']['request']
-    assert 'body' not in request
+    assert 'stacktrace' in result['exception']
+    stack = result['exception']['stacktrace']
+    assert len(stack) == 1
+    frame = stack[0]
+    assert 'vars' in frame
+    vars = frame['vars']
+    assert 'foo' in vars
+    assert vars['foo'] == 'bar'
+    assert 'password' in vars
+    assert vars['password'] == processors.MASK
+    assert 'the_secret' in vars
+    assert vars['the_secret'] == processors.MASK
+    assert 'a_password_here' in vars
+    assert vars['a_password_here'] == processors.MASK
+
+
+def test_remove_http_request_body(http_test_data):
+    assert 'body' in http_test_data['context']['request']
+
+    result = processors.remove_http_request_body(None, http_test_data)
+
+    assert 'body' not in result['context']['request']
+
+
+def test_sanitize_http_request_cookies(http_test_data):
+    http_test_data['context']['request']['headers']['cookie'] =\
+        'foo=bar; password=12345; the_secret=12345; csrftoken=abc'
+
+    result = processors.sanitize_http_request_cookies(None, http_test_data)
+
+    assert result['context']['request']['cookies'] == {
+        'foo': 'bar',
+        'password': processors.MASK,
+        'the_secret': processors.MASK,
+        'sessionid': processors.MASK,
+        'a_password_here': processors.MASK,
+    }
+
+    assert (result['context']['request']['headers']['cookie'] ==
+            'foo=bar; password={0}; the_secret={0}; csrftoken={0}'.format(processors.MASK))
+
+
+def test_sanitize_http_headers(http_test_data):
+    result = processors.sanitize_http_headers(None, http_test_data)
+    expected = {
+        'foo': 'bar',
+        'password': processors.MASK,
+        'the_secret': processors.MASK,
+        'a_password_here': processors.MASK,
+    }
+    assert result['context']['request']['headers'] == expected
+    assert result['context']['response']['headers'] == expected
+
+
+def test_sanitize_http_wgi_env(http_test_data):
+    result = processors.sanitize_http_wsgi_env(None, http_test_data)
+
+    assert result['context']['request']['env'] == {
+        'foo': 'bar',
+        'password': processors.MASK,
+        'the_secret': processors.MASK,
+        'a_password_here': processors.MASK,
+    }
+
+
+def test_sanitize_http_query_string(http_test_data):
+    result = processors.sanitize_http_request_querystring(None, http_test_data)
+
+    expected = 'foo=bar&password={0}&the_secret={0}&cc={0}'.format(
+        processors.MASK
+    )
+    assert result['context']['request']['url']['search'] == expected
+    assert result['context']['request']['url']['raw'].endswith(expected)
+
+
+def test_post_as_string(http_test_data):
+    result = processors.sanitize_http_request_body(None, http_test_data)
+    expected = 'foo=bar&password={0}&the_secret={0}&cc={0}'.format(
+        processors.MASK
+    )
+    assert result['context']['request']['body'] == expected
+
+
+def test_querystring_as_string_with_partials(http_test_data):
+    http_test_data['context']['request']['url']['search'] = 'foo=bar&password&secret=123456'
+    result = processors.sanitize_http_request_querystring(None, http_test_data)
+
+    assert (result['context']['request']['url']['search'] ==
+            'foo=bar&password&secret={0}'.format(processors.MASK))
+
+
+def test_sanitize_credit_card():
+    result = processors._sanitize('foo', '4242424242424242')
+    assert result == processors.MASK
+
+def test_sanitize_credit_card_with_spaces():
+    result = processors._sanitize('foo', '4242 4242 4242 4242')
+    assert result == processors.MASK
+
+
+def test_non_utf8_encoding(http_test_data):
+    broken = compat.b('broken=') + u"aéöüa".encode('latin-1')
+    http_test_data['context']['request']['url']['search'] = broken
+    result = processors.sanitize_http_request_querystring(None, http_test_data)
+    assert result['context']['request']['url']['search'] == u'broken=a\ufffd\ufffd\ufffda'
 
 
 def test_remove_stacktrace_locals():

--- a/tests/requirements/requirements-python-2.txt
+++ b/tests/requirements/requirements-python-2.txt
@@ -1,2 +1,1 @@
-unittest2
 python-memcached

--- a/tests/transports/test_http.py
+++ b/tests/transports/test_http.py
@@ -6,50 +6,51 @@ import pytest
 from elasticapm.transport.base import TransportException
 from elasticapm.transport.http import HTTPTransport
 from elasticapm.utils import compat
-from tests.utils.compat import TestCase
 
 
-class TestHttpFailures(TestCase):
-    @mock.patch('elasticapm.transport.http.urlopen')
-    def test_send(self, mock_urlopen):
-        transport = HTTPTransport(compat.urlparse.urlparse('http://localhost:9999'))
-        mock_response = mock.Mock(
-            info=lambda: {'Location': 'http://example.com/foo'}
-        )
-        mock_urlopen.return_value = mock_response
-        url = transport.send('x', {})
-        assert url == 'http://example.com/foo'
-        assert mock_response.close.call_count == 1
+@mock.patch('elasticapm.transport.http.urlopen')
+def test_send(mock_urlopen):
+    transport = HTTPTransport(compat.urlparse.urlparse('http://localhost:9999'))
+    mock_response = mock.Mock(
+        info=lambda: {'Location': 'http://example.com/foo'}
+    )
+    mock_urlopen.return_value = mock_response
+    url = transport.send('x', {})
+    assert url == 'http://example.com/foo'
+    assert mock_response.close.call_count == 1
 
-    @mock.patch('elasticapm.transport.http.urlopen')
-    def test_timeout(self, mock_urlopen):
-        transport = HTTPTransport(compat.urlparse.urlparse('http://localhost:9999'))
-        mock_urlopen.side_effect = socket.timeout()
-        with pytest.raises(TransportException) as exc_info:
-            transport.send('x', {})
-        assert 'timeout' in str(exc_info.value)
 
-    @mock.patch('elasticapm.transport.http.urlopen')
-    def test_http_error(self, mock_urlopen):
-        url, status, message, body = (
-            'http://localhost:9999', 418, "I'm a teapot", 'Nothing'
-        )
-        transport = HTTPTransport(compat.urlparse.urlparse(url))
-        mock_urlopen.side_effect = compat.HTTPError(
-            url, status, message, hdrs={}, fp=compat.StringIO(body)
-        )
-        with pytest.raises(TransportException) as exc_info:
-            transport.send('x', {})
-        for val in (url, status, message, body):
-            assert str(val) in str(exc_info.value)
+@mock.patch('elasticapm.transport.http.urlopen')
+def test_timeout(mock_urlopen):
+    transport = HTTPTransport(compat.urlparse.urlparse('http://localhost:9999'))
+    mock_urlopen.side_effect = socket.timeout()
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    assert 'timeout' in str(exc_info.value)
 
-    @mock.patch('elasticapm.transport.http.urlopen')
-    def test_generic_error(self, mock_urlopen):
-        url, status, message, body = (
-            'http://localhost:9999', 418, "I'm a teapot", 'Nothing'
-        )
-        transport = HTTPTransport(compat.urlparse.urlparse(url))
-        mock_urlopen.side_effect = Exception('Oopsie')
-        with pytest.raises(TransportException) as exc_info:
-            transport.send('x', {})
-        assert 'Oopsie' in str(exc_info.value)
+
+@mock.patch('elasticapm.transport.http.urlopen')
+def test_http_error(mock_urlopen):
+    url, status, message, body = (
+        'http://localhost:9999', 418, "I'm a teapot", 'Nothing'
+    )
+    transport = HTTPTransport(compat.urlparse.urlparse(url))
+    mock_urlopen.side_effect = compat.HTTPError(
+        url, status, message, hdrs={}, fp=compat.StringIO(body)
+    )
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    for val in (url, status, message, body):
+        assert str(val) in str(exc_info.value)
+
+
+@mock.patch('elasticapm.transport.http.urlopen')
+def test_generic_error(mock_urlopen):
+    url, status, message, body = (
+        'http://localhost:9999', 418, "I'm a teapot", 'Nothing'
+    )
+    transport = HTTPTransport(compat.urlparse.urlparse(url))
+    mock_urlopen.side_effect = Exception('Oopsie')
+    with pytest.raises(TransportException) as exc_info:
+        transport.send('x', {})
+    assert 'Oopsie' in str(exc_info.value)

--- a/tests/utils/compat.py
+++ b/tests/utils/compat.py
@@ -1,12 +1,3 @@
-
-try:
-    from unittest2 import TestCase
-    from unittest2 import skipIf
-except ImportError:
-    from unittest import TestCase
-    from unittest import skipIf
-
-
 def middleware_setting(django_version, middleware_list):
     if django_version < (1, 10):
         return {'MIDDLEWARE_CLASSES': middleware_list}

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -132,7 +132,7 @@ def test_transform_recursive():
 
 def test_transform_custom_repr():
     class Foo(object):
-        def __elasticapm__():
+        def __elasticapm__(self):
             return 'example'
 
     x = Foo()
@@ -143,7 +143,7 @@ def test_transform_custom_repr():
 
 def test_transform_broken_repr():
     class Foo(object):
-        def __repr__():
+        def __repr__(self):
             raise ValueError
 
     x = Foo()
@@ -152,7 +152,7 @@ def test_transform_broken_repr():
     if compat.PY2:
         expected = u"<BadRepr: <class 'tests.utils.encoding.tests.Foo'>>"
     else:
-        expected = "<BadRepr: <class 'tests.utils.encoding.tests.TransformTest.test_broken_repr.<locals>.Foo'>>"
+        expected = "<BadRepr: <class 'tests.utils.encoding.tests.test_transform_broken_repr.<locals>.Foo'>>"
     assert result == expected
 
 

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -5,179 +5,192 @@ import uuid
 
 from elasticapm.utils import compat
 from elasticapm.utils.encoding import shorten, transform
-from tests.utils.compat import TestCase
 
 
-class TransformTest(TestCase):
-    def test_incorrect_unicode(self):
-        x = 'רונית מגן'
+def test_transform_incorrect_unicode():
+    x = 'רונית מגן'
 
-        result = transform(x)
-        self.assertEquals(type(result), str)
-        self.assertEquals(result, 'רונית מגן')
-
-    def test_correct_unicode(self):
-        x = 'רונית מגן'
-        if compat.PY2:
-            x = x.decode('utf-8')
-
-        result = transform(x)
-        self.assertEquals(type(result), compat.text_type)
-        self.assertEquals(result, x)
-
-    def test_bad_string(self):
-        x = compat.b('The following character causes problems: \xd4')
-
-        result = transform(x)
-        self.assertEquals(type(result), compat.binary_type)
-        self.assertEquals(result, compat.b('(Error decoding value)'))
-
-    def test_float(self):
-        result = transform(13.0)
-        self.assertEquals(type(result), float)
-        self.assertEquals(result, 13.0)
-
-    def test_bool(self):
-        result = transform(True)
-        self.assertEquals(type(result), bool)
-        self.assertEquals(result, True)
-
-    def test_int_subclass(self):
-        class X(int):
-            pass
-
-        result = transform(X())
-        self.assertEquals(type(result), int)
-        self.assertEquals(result, 0)
-
-    # def test_bad_string(self):
-    #     x = 'The following character causes problems: \xd4'
-
-    #     result = transform(x)
-    #     self.assertEquals(result, '(Error decoding value)')
-
-    # def test_model_instance(self):
-    #     instance = DuplicateKeyModel(foo='foo')
-
-    #     result = transform(instance)
-    #     self.assertEquals(result, '<DuplicateKeyModel: foo>')
-
-    # def test_handles_gettext_lazy(self):
-    #     from django.utils.functional import lazy
-    #     def fake_gettext(to_translate):
-    #         return u'Igpay Atinlay'
-
-    #     fake_gettext_lazy = lazy(fake_gettext, str)
-
-    #     self.assertEquals(
-    #         pickle.loads(pickle.dumps(
-    #                 transform(fake_gettext_lazy("something")))),
-    #         u'Igpay Atinlay')
-
-    def test_dict_keys(self):
-        x = {'foo': 'bar'}
-
-        result = transform(x)
-        self.assertEquals(type(result), dict)
-        keys = list(result.keys())
-        self.assertEquals(len(keys), 1)
-        self.assertTrue(type(keys[0]), str)
-        self.assertEquals(keys[0], 'foo')
-
-    def test_dict_keys_utf8_as_str(self):
-        x = {'רונית מגן': 'bar'}
-
-        result = transform(x)
-        self.assertEquals(type(result), dict)
-        keys = list(result.keys())
-        self.assertEquals(len(keys), 1)
-        self.assertTrue(type(keys[0]), compat.binary_type)
-        if compat.PY3:
-            self.assertEquals(keys[0], 'רונית מגן')
-        else:
-            self.assertEquals(keys[0], u'רונית מגן')
-
-    def test_dict_keys_utf8_as_unicode(self):
-        x = {
-            compat.text_type('\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df'): 'bar'
-        }
-
-        result = transform(x)
-        keys = list(result.keys())
-        self.assertEquals(len(keys), 1)
-        self.assertTrue(type(keys[0]), str)
-        self.assertEquals(keys[0], '\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df')
-
-    def test_uuid(self):
-        x = uuid.uuid4()
-        result = transform(x)
-        self.assertEquals(result, repr(x))
-        self.assertTrue(type(result), str)
-
-    def test_recursive(self):
-        x = []
-        x.append(x)
-
-        result = transform(x)
-        self.assertEquals(result, ['<...>'])
-
-    def test_custom_repr(self):
-        class Foo(object):
-            def __elasticapm__(self):
-                return 'example'
-
-        x = Foo()
-
-        result = transform(x)
-        self.assertEquals(result, 'example')
-
-    def test_broken_repr(self):
-        class Foo(object):
-            def __repr__(self):
-                raise ValueError
-
-        x = Foo()
-
-        result = transform(x)
-        if compat.PY2:
-            expected = u"<BadRepr: <class 'tests.utils.encoding.tests.Foo'>>"
-        else:
-            expected = "<BadRepr: <class 'tests.utils.encoding.tests.TransformTest.test_broken_repr.<locals>.Foo'>>"
-        self.assertEquals(result, expected)
+    result = transform(x)
+    assert type(result) == str
+    assert result == 'רונית מגן'
 
 
-class ShortenTest(TestCase):
-    def test_shorten_string(self):
-        result = shorten('hello world!', string_length=5)
-        self.assertEquals(len(result), 5)
-        self.assertEquals(result, 'he...')
+def test_transform_correct_unicode():
+    x = 'רונית מגן'
+    if compat.PY2:
+        x = x.decode('utf-8')
 
-    def test_shorten_lists(self):
-        result = shorten(list(range(500)), list_length=50)
-        self.assertEquals(len(result), 52)
-        self.assertEquals(result[-2], '...')
-        self.assertEquals(result[-1], '(450 more elements)')
+    result = transform(x)
+    assert type(result) == compat.text_type
+    assert result == x
 
-    def test_shorten_sets(self):
-        result = shorten(set(range(500)), list_length=50)
-        self.assertEquals(len(result), 52)
-        self.assertEquals(result[-2], '...')
-        self.assertEquals(result[-1], '(450 more elements)')
 
-    def test_shorten_frozenset(self):
-        result = shorten(frozenset(range(500)), list_length=50)
-        self.assertEquals(len(result), 52)
-        self.assertEquals(result[-2], '...')
-        self.assertEquals(result[-1], '(450 more elements)')
+def test_transform_bad_string():
+    x = compat.b('The following character causes problems: \xd4')
 
-    def test_shorten_tuple(self):
-        result = shorten(tuple(range(500)), list_length=50)
-        self.assertEquals(len(result), 52)
-        self.assertEquals(result[-2], '...')
-        self.assertEquals(result[-1], '(450 more elements)')
+    result = transform(x)
+    assert type(result) == compat.binary_type
+    assert result == compat.b('(Error decoding value)')
 
-    # def test_shorten_generator(self):
+
+def test_transform_float():
+    result = transform(13.0)
+    assert type(result) == float
+    assert result == 13.0
+
+
+def test_transform_bool():
+    result = transform(True)
+    assert type(result) == bool
+    assert result == True
+
+
+def test_transform_int_subclass():
+    class X(int):
+        pass
+
+    result = transform(X())
+    assert type(result) == int
+    assert result == 0
+
+# def test_transform_bad_string():
+#     x = 'The following character causes problems: \xd4'
+
+#     result = transform(x)
+#     assert result == '(Error decoding value)'
+
+# def test_transform_model_instance():
+#     instance = DuplicateKeyModel(foo='foo')
+
+#     result = transform(instance)
+#     assert result == '<DuplicateKeyModel: foo>'
+
+# def test_transform_handles_gettext_lazy():
+#     from django.utils.functional import lazy
+#     def fake_gettext(to_translate):
+#         return u'Igpay Atinlay'
+
+#     fake_gettext_lazy = lazy(fake_gettext, str)
+
+#     self.assertEquals(
+#         pickle.loads(pickle.dumps(
+#                 transform(fake_gettext_lazy("something")))),
+#         u'Igpay Atinlay')
+
+
+def test_transform_dict_keys():
+    x = {'foo': 'bar'}
+
+    result = transform(x)
+    assert type(result) == dict
+    keys = list(result.keys())
+    assert len(keys) == 1
+    assert type(keys[0]), str
+    assert keys[0] == 'foo'
+
+
+def test_transform_dict_keys_utf8_as_str():
+    x = {'רונית מגן': 'bar'}
+
+    result = transform(x)
+    assert type(result) == dict
+    keys = list(result.keys())
+    assert len(keys) == 1
+    assert type(keys[0]), compat.binary_type
+    if compat.PY3:
+        assert keys[0] == 'רונית מגן'
+    else:
+        assert keys[0] == u'רונית מגן'
+
+
+def test_transform_dict_keys_utf8_as_unicode():
+    x = {
+        compat.text_type('\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df'): 'bar'
+    }
+
+    result = transform(x)
+    keys = list(result.keys())
+    assert len(keys) == 1
+    assert type(keys[0]), str
+    assert keys[0] == '\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df'
+
+
+def test_transform_uuid():
+    x = uuid.uuid4()
+    result = transform(x)
+    assert result == repr(x)
+    assert type(result), str
+
+
+def test_transform_recursive():
+    x = []
+    x.append(x)
+
+    result = transform(x)
+    assert result == ['<...>']
+
+
+def test_transform_custom_repr():
+    class Foo(object):
+        def __elasticapm__():
+            return 'example'
+
+    x = Foo()
+
+    result = transform(x)
+    assert result == 'example'
+
+
+def test_transform_broken_repr():
+    class Foo(object):
+        def __repr__():
+            raise ValueError
+
+    x = Foo()
+
+    result = transform(x)
+    if compat.PY2:
+        expected = u"<BadRepr: <class 'tests.utils.encoding.tests.Foo'>>"
+    else:
+        expected = "<BadRepr: <class 'tests.utils.encoding.tests.TransformTest.test_broken_repr.<locals>.Foo'>>"
+    assert result == expected
+
+
+def test_shorten_string():
+    result = shorten('hello world!', string_length=5)
+    assert len(result) == 5
+    assert result == 'he...'
+
+
+def test_shorten_lists():
+    result = shorten(list(range(500)), list_length=50)
+    assert len(result) == 52
+    assert result[-2] == '...'
+    assert result[-1] == '(450 more elements)'
+
+
+def test_shorten_sets():
+    result = shorten(set(range(500)), list_length=50)
+    assert len(result) == 52
+    assert result[-2] == '...'
+    assert result[-1] == '(450 more elements)'
+
+
+def test_shorten_frozenset():
+    result = shorten(frozenset(range(500)), list_length=50)
+    assert len(result) == 52
+    assert result[-2] == '...'
+    assert result[-1] == '(450 more elements)'
+
+
+def test_shorten_tuple():
+    result = shorten(tuple(range(500)), list_length=50)
+    assert len(result) == 52
+    assert result[-2] == '...'
+    assert result[-1] == '(450 more elements)'
+
+    # def test_shorten_generator():
     #     result = shorten(xrange(500))
-    #     self.assertEquals(len(result), 52)
-    #     self.assertEquals(result[-2], '...')
-    #     self.assertEquals(result[-1], '(450 more elements)')
+    #     assert len(result) == 52
+    #     assert result[-2] == '...'
+    #     assert result[-1] == '(450 more elements)'

--- a/tests/utils/json/tests.py
+++ b/tests/utils/json/tests.py
@@ -6,29 +6,31 @@ import uuid
 
 from elasticapm.utils import json_encoder as json
 from elasticapm.utils import compat
-from tests.utils.compat import TestCase
 
 
-class JSONTest(TestCase):
-    def test_uuid(self):
-        res = uuid.uuid4()
-        self.assertEquals(json.dumps(res), '"%s"' % res.hex)
+def test_uuid():
+    res = uuid.uuid4()
+    assert json.dumps(res) == '"%s"' % res.hex
 
-    def test_datetime(self):
-        res = datetime.datetime(day=1, month=1, year=2011, hour=1, minute=1, second=1)
-        self.assertEquals(json.dumps(res), '"2011-01-01T01:01:01.000000Z"')
 
-    def test_set(self):
-        res = set(['foo', 'bar'])
-        self.assertIn(json.dumps(res), ('["foo", "bar"]', '["bar", "foo"]'))
+def test_datetime():
+    res = datetime.datetime(day=1, month=1, year=2011, hour=1, minute=1, second=1)
+    assert json.dumps(res) == '"2011-01-01T01:01:01.000000Z"'
 
-    def test_frozenset(self):
-        res = frozenset(['foo', 'bar'])
-        self.assertIn(json.dumps(res), ('["foo", "bar"]', '["bar", "foo"]'))
 
-    def test_bytes(self):
-        if compat.PY2:
-            res = bytes('foobar')
-        else:
-            res = bytes('foobar', encoding='ascii')
-        self.assertEqual(json.dumps(res), '"foobar"')
+def test_set():
+    res = set(['foo', 'bar'])
+    assert json.dumps(res) in ('["foo", "bar"]', '["bar", "foo"]')
+
+
+def test_frozenset():
+    res = frozenset(['foo', 'bar'])
+    assert json.dumps(res) in ('["foo", "bar"]', '["bar", "foo"]')
+
+
+def test_bytes():
+    if compat.PY2:
+        res = bytes('foobar')
+    else:
+        res = bytes('foobar', encoding='ascii')
+    assert json.dumps(res) == '"foobar"'

--- a/tests/utils/lru_tests.py
+++ b/tests/utils/lru_tests.py
@@ -1,17 +1,15 @@
 from __future__ import absolute_import
 
 from elasticapm.utils.lru import LRUCache
-from tests.utils.compat import TestCase
 
 
-class LRUTest(TestCase):
-    def test_insert_overflow(self):
+def test_insert_overflow():
 
-        lru = LRUCache(4)
+    lru = LRUCache(4)
 
-        for x in range(6):
-            lru.set(x)
+    for x in range(6):
+        lru.set(x)
 
-        self.assertNotIn(1, lru)
-        for x in range(2, 6):
-            self.assertIn(x, lru)
+    assert 1 not in lru
+    for x in range(2, 6):
+        assert x in lru

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -5,7 +5,6 @@ from mock import Mock
 
 from elasticapm.utils import compat
 from elasticapm.utils.stacks import get_culprit, get_stack_info
-from tests.utils.compat import TestCase
 
 
 class Context(object):
@@ -17,41 +16,41 @@ class Context(object):
     iterkeys = lambda s, *a: compat.iterkeys(s.dict, *a)
 
 
-class StackTest(TestCase):
-    def test_get_culprit_bad_module(self):
-        culprit = get_culprit([{
-            'module': None,
-            'function': 'foo',
-        }])
-        self.assertEquals(culprit, '<unknown>.foo')
+def test_get_culprit_bad_module():
+    culprit = get_culprit([{
+        'module': None,
+        'function': 'foo',
+    }])
+    assert culprit == '<unknown>.foo'
 
-        culprit = get_culprit([{
-            'module': 'foo',
-            'function': None,
-        }])
-        self.assertEquals(culprit, 'foo.<unknown>')
+    culprit = get_culprit([{
+        'module': 'foo',
+        'function': None,
+    }])
+    assert culprit == 'foo.<unknown>'
 
-        culprit = get_culprit([{
-        }])
-        self.assertEquals(culprit, '<unknown>.<unknown>')
+    culprit = get_culprit([{
+    }])
+    assert culprit == '<unknown>.<unknown>'
 
-    def test_bad_locals_in_frame(self):
-        frame = Mock()
-        frame.f_locals = Context({
-            'foo': 'bar',
-            'biz': 'baz',
-        })
-        frame.f_lineno = 1
-        frame.f_globals = {}
-        frame.f_code.co_filename = __file__.replace('.pyc', '.py')
-        frame.f_code.co_name = __name__
-        frames = [(frame, 1)]
-        results = get_stack_info(frames)
-        self.assertEquals(len(results), 1)
-        result = results[0]
-        self.assertTrue('vars' in result)
-        vars = {
-            "foo": "bar",
-            "biz": "baz",
-        }
-        self.assertEquals(result['vars'], vars)
+
+def test_bad_locals_in_frame():
+    frame = Mock()
+    frame.f_locals = Context({
+        'foo': 'bar',
+        'biz': 'baz',
+    })
+    frame.f_lineno = 1
+    frame.f_globals = {}
+    frame.f_code.co_filename = __file__.replace('.pyc', '.py')
+    frame.f_code.co_name = __name__
+    frames = [(frame, 1)]
+    results = get_stack_info(frames)
+    assert len(results) == 1
+    result = results[0]
+    assert 'vars' in result
+    vars = {
+        "foo": "bar",
+        "biz": "baz",
+    }
+    assert result['vars'] == vars

--- a/tests/utils/wsgi/tests.py
+++ b/tests/utils/wsgi/tests.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from elasticapm.utils.wsgi import get_environ, get_headers, get_host
-from tests.utils.compat import TestCase
 
 
 def test_get_headers_tuple_as_key():

--- a/tests/utils/wsgi/tests.py
+++ b/tests/utils/wsgi/tests.py
@@ -4,85 +4,92 @@ from elasticapm.utils.wsgi import get_environ, get_headers, get_host
 from tests.utils.compat import TestCase
 
 
-class GetHeadersTest(TestCase):
-    def test_tuple_as_key(self):
-        result = dict(get_headers({
-            ('a', 'tuple'): 'foo',
-        }))
-        self.assertEquals(result, {})
-
-    def test_coerces_http_name(self):
-        result = dict(get_headers({
-            'HTTP_ACCEPT': 'text/plain',
-        }))
-        self.assertIn('accept', result)
-        self.assertEquals(result['accept'], 'text/plain')
-
-    def test_coerces_content_type(self):
-        result = dict(get_headers({
-            'CONTENT_TYPE': 'text/plain',
-        }))
-        self.assertIn('content-type', result)
-        self.assertEquals(result['content-type'], 'text/plain')
-
-    def test_coerces_content_length(self):
-        result = dict(get_headers({
-            'CONTENT_LENGTH': '134',
-        }))
-        self.assertIn('content-length', result)
-        self.assertEquals(result['content-length'], '134')
+def test_get_headers_tuple_as_key():
+    result = dict(get_headers({
+        ('a', 'tuple'): 'foo',
+    }))
+    assert result == {}
 
 
-class GetEnvironTest(TestCase):
-    def test_has_remote_addr(self):
-        result = dict(get_environ({'REMOTE_ADDR': '127.0.0.1'}))
-        self.assertIn('REMOTE_ADDR', result)
-        self.assertEquals(result['REMOTE_ADDR'], '127.0.0.1')
-
-    def test_has_server_name(self):
-        result = dict(get_environ({'SERVER_NAME': '127.0.0.1'}))
-        self.assertIn('SERVER_NAME', result)
-        self.assertEquals(result['SERVER_NAME'], '127.0.0.1')
-
-    def test_has_server_port(self):
-        result = dict(get_environ({'SERVER_PORT': 80}))
-        self.assertIn('SERVER_PORT', result)
-        self.assertEquals(result['SERVER_PORT'], 80)
-
-    def test_hides_wsgi_input(self):
-        result = list(get_environ({'wsgi.input': 'foo'}))
-        self.assertNotIn('wsgi.input', result)
+def test_get_headers_coerces_http_name():
+    result = dict(get_headers({
+        'HTTP_ACCEPT': 'text/plain',
+    }))
+    assert 'accept' in result
+    assert result['accept'] == 'text/plain'
 
 
-class GetHostTest(TestCase):
-    def test_http_x_forwarded_host(self):
-        result = get_host({'HTTP_X_FORWARDED_HOST': 'example.com'})
-        self.assertEquals(result, 'example.com')
+def test_get_headers_coerces_content_type():
+    result = dict(get_headers({
+        'CONTENT_TYPE': 'text/plain',
+    }))
+    assert 'content-type' in result
+    assert result['content-type'] == 'text/plain'
 
-    def test_http_host(self):
-        result = get_host({'HTTP_HOST': 'example.com'})
-        self.assertEquals(result, 'example.com')
 
-    def test_http_strips_port(self):
-        result = get_host({
-            'wsgi.url_scheme': 'http',
-            'SERVER_NAME': 'example.com',
-            'SERVER_PORT': '80',
-        })
-        self.assertEquals(result, 'example.com')
+def test_get_headers_coerces_content_length():
+    result = dict(get_headers({
+        'CONTENT_LENGTH': '134',
+    }))
+    assert 'content-length' in result
+    assert result['content-length'] == '134'
 
-    def test_https_strips_port(self):
-        result = get_host({
-            'wsgi.url_scheme': 'https',
-            'SERVER_NAME': 'example.com',
-            'SERVER_PORT': '443',
-        })
-        self.assertEquals(result, 'example.com')
 
-    def test_http_nonstandard_port(self):
-        result = get_host({
-            'wsgi.url_scheme': 'http',
-            'SERVER_NAME': 'example.com',
-            'SERVER_PORT': '81',
-        })
-        self.assertEquals(result, 'example.com:81')
+def test_get_environ_has_remote_addr():
+    result = dict(get_environ({'REMOTE_ADDR': '127.0.0.1'}))
+    assert 'REMOTE_ADDR' in result
+    assert result['REMOTE_ADDR'] == '127.0.0.1'
+
+
+def test_get_environ_has_server_name():
+    result = dict(get_environ({'SERVER_NAME': '127.0.0.1'}))
+    assert 'SERVER_NAME' in result
+    assert result['SERVER_NAME'] == '127.0.0.1'
+
+
+def test_get_environ_has_server_port():
+    result = dict(get_environ({'SERVER_PORT': 80}))
+    assert 'SERVER_PORT' in result
+    assert result['SERVER_PORT'] == 80
+
+
+def test_get_environ_hides_wsgi_input():
+    result = list(get_environ({'wsgi.input': 'foo'}))
+    assert 'wsgi.input' not in result
+
+
+def test_get_host_http_x_forwarded_host():
+    result = get_host({'HTTP_X_FORWARDED_HOST': 'example.com'})
+    assert result == 'example.com'
+
+
+def test_get_host_http_host():
+    result = get_host({'HTTP_HOST': 'example.com'})
+    assert result == 'example.com'
+
+
+def test_get_host_http_strips_port():
+    result = get_host({
+        'wsgi.url_scheme': 'http',
+        'SERVER_NAME': 'example.com',
+        'SERVER_PORT': '80',
+    })
+    assert result == 'example.com'
+
+
+def test_get_host_https_strips_port():
+    result = get_host({
+        'wsgi.url_scheme': 'https',
+        'SERVER_NAME': 'example.com',
+        'SERVER_PORT': '443',
+    })
+    assert result == 'example.com'
+
+
+def test_get_host_http_nonstandard_port():
+    result = get_host({
+        'wsgi.url_scheme': 'http',
+        'SERVER_NAME': 'example.com',
+        'SERVER_PORT': '81',
+    })
+    assert result == 'example.com:81'


### PR DESCRIPTION
Most of this PR is a more-or-less 1:1 transformation of nosetests `TestCase` methods to py.test functions, replacing `setUp` / `tearDown` methods with py.test fixtures.

It also includes some refactoring in how we get the "current" client instance in Django code. For the most part, we used to rely on the global `get_client()` function. This has been replaced with getting the client from the ["app configuration"](https://docs.djangoproject.com/en/1.11/ref/applications/) instance. The main reason for this is so we can set the current client to the one created in the fixture, but it also makes it clearer which client instance is used in the actual code.