### PR TITLE
ensure TracingMiddleware and LoggingHandler get the client from the app registry

### DIFF
--- a/elasticapm/contrib/django/apps.py
+++ b/elasticapm/contrib/django/apps.py
@@ -10,13 +10,17 @@ class ElasticAPMConfig(AppConfig):
     label = 'elasticapm.contrib.django'
     verbose_name = 'ElasticAPM'
 
+    def __init__(self, *args, **kwargs):
+        super(ElasticAPMConfig, self).__init__(*args, **kwargs)
+        self.client = None
+
     def ready(self):
-        client = get_client()
-        register_handlers(client)
-        if not client.config.disable_instrumentation:
-            instrument(client)
+        self.client = get_client()
+        register_handlers(self.client)
+        if not self.client.config.disable_instrumentation:
+            instrument(self.client)
         else:
-            client.logger.debug("Skipping instrumentation. DISABLE_INSTRUMENTATION is set.")
+            self.client.logger.debug("Skipping instrumentation. DISABLE_INSTRUMENTATION is set.")
 
 
 def register_handlers(client):

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 import logging
 import threading
 
+from django.apps import apps
 from django.conf import settings as django_settings
 
 from elasticapm.contrib.django.client import client, get_client
@@ -107,7 +108,11 @@ class TracingMiddleware(MiddlewareMixin):
 
     def __init__(self, *args, **kwargs):
         super(TracingMiddleware, self).__init__(*args, **kwargs)
-        self.client = get_client()
+        try:
+            app = apps.get_app_config('elasticapm.contrib.django')
+            self.client = app.client
+        except LookupError:
+            self.client = get_client()
 
         if not self._elasticapm_instrumented:
             with self._instrumenting_lock:

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -1,0 +1,32 @@
+from django.apps import apps
+
+import pytest
+
+from elasticapm.contrib.django.apps import instrument, register_handlers
+from elasticapm.contrib.django.client import DjangoClient
+
+
+class TempStoreClient(DjangoClient):
+    def __init__(self, *args, **kwargs):
+        self.events = []
+        super(TempStoreClient, self).__init__(*args, **kwargs)
+
+    def send(self, **kwargs):
+        self.events.append(kwargs)
+
+
+@pytest.fixture()
+def elasticapm_client():
+    app = apps.get_app_config('elasticapm.contrib.django')
+    old_client = app.client
+    client = TempStoreClient()
+    register_handlers(client)
+    instrument(client)
+    app.client = client
+    yield client
+
+    app.client = old_client
+
+    if old_client:
+        register_handlers(old_client)
+        instrument(old_client)

--- a/tests/contrib/django/testapp/urls.py
+++ b/tests/contrib/django/testapp/urls.py
@@ -19,6 +19,7 @@ urlpatterns = (
     url(r'^render-user-template$', views.render_user_view, name='render-user-template'),
     url(r'^no-error$', views.no_error, name='elasticapm-no-error'),
     url(r'^no-error-slash/$', views.no_error, name='elasticapm-no-error-slash'),
+    url(r'^logging$', views.logging_view, name='elasticapm-logging'),
     url(r'^ignored-exception/$', views.ignored_exception, name='elasticapm-ignored-exception'),
     url(r'^fake-login$', views.fake_login, name='elasticapm-fake-login'),
     url(r'^trigger-500$', views.raise_exc, name='elasticapm-raise-exc'),

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -56,6 +56,12 @@ def logging_request_exc(request):
     return HttpResponse('')
 
 
+def logging_view(request):
+    logger = logging.getLogger('logmiddleware')
+    logger.info("Just loggin'")
+    return HttpResponse('')
+
+
 def render_template_view(request):
     def something_expensive():
         with trace("something_expensive", "code"):


### PR DESCRIPTION
While this is mostly helpful for testing, it also reduces our reliance on the `client` / `get_client()` globals (albeit by replacing it with a dependency on the global Django app registry).