### PR TITLE
normalize HTTP status code in transaction.result

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,9 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev2\...master[Check 
  * ensured that transaction data is also passed through processors ({pull}84[#84])
  * added `uninstrument` function to reverse instrumentation,
    and exposed both `instrument` and `uninstrument` as public API in the `elasticapm` namespace  ({pull}90[#90])
+ * added normalization of HTTP status codes into classes for the `transaction.result` field. A HTTP status of `200`
+   will be turned into `HTTP 2xx`. The unchanged status code is still available in `context.response.status_code`.
+   ({pull}85[#85])
 
 [[release-v1.0.0.dev2]]
 [float]

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -190,7 +190,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
                     self.client.set_transaction_extra_data(
                         user_data, 'user')
 
-                self.client.end_transaction(transaction_name, status_code)
+                self.client.end_transaction(transaction_name, 'HTTP {}xx'.format(status_code // 100))
         except Exception:
             self.client.error_logger.error(
                 'Exception during timing of request',

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -136,7 +136,11 @@ class ElasticAPM(object):
         response_data = get_data_from_response(response)
         self.client.set_transaction_extra_data(request_data, 'request')
         self.client.set_transaction_extra_data(response_data, 'response')
-        self.client.end_transaction(rule, response.status_code)
+        if response.status_code:
+            result = 'HTTP {}xx'.format(response.status_code // 100)
+        else:
+            result = response.status
+        self.client.end_transaction(rule, result)
 
     def capture_exception(self, *args, **kwargs):
         assert self.client, 'capture_exception called before application configured'

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -628,6 +628,7 @@ def test_transaction_request_response_data(django_elasticapm_client, client):
     transactions = django_elasticapm_client.instrumentation_store.get_all()
     assert len(transactions) == 1
     transaction = transactions[0]
+    assert transaction['result'] == 'HTTP 2xx'
     assert 'request' in transaction['context']
     request = transaction['context']['request']
     assert request['method'] == 'GET'
@@ -660,7 +661,7 @@ def test_transaction_metrics(django_elasticapm_client, client):
         assert len(transactions) == 1
         transaction = transactions[0]
         assert transaction['duration'] > 0
-        assert transaction['result'] == '200'
+        assert transaction['result'] == 'HTTP 2xx'
         assert transaction['name'] == 'GET tests.contrib.django.testapp.views.no_error'
 
 
@@ -688,6 +689,7 @@ def test_request_metrics_301_append_slash(django_elasticapm_client, client):
         # django 1.9+
         'GET django.middleware.common.CommonMiddleware.process_response',
     )
+    assert transactions[0]['result'] == 'HTTP 3xx'
 
 
 def test_request_metrics_301_prepend_www(django_elasticapm_client, client):
@@ -709,6 +711,7 @@ def test_request_metrics_301_prepend_www(django_elasticapm_client, client):
         client.get(reverse('elasticapm-no-error'))
     transactions = django_elasticapm_client.instrumentation_store.get_all()
     assert transactions[0]['name'] == 'GET django.middleware.common.CommonMiddleware.process_request'
+    assert transactions[0]['result'] == 'HTTP 3xx'
 
 
 @pytest.mark.django_db
@@ -733,6 +736,7 @@ def test_request_metrics_contrib_redirect(django_elasticapm_client, client):
 
     transactions = django_elasticapm_client.instrumentation_store.get_all()
     assert transactions[0]['name'] == 'GET django.contrib.redirects.middleware.RedirectFallbackMiddleware.process_response'
+    assert transactions[0]['result'] == 'HTTP 3xx'
 
 
 def test_request_metrics_name_override(django_elasticapm_client, client):
@@ -904,6 +908,7 @@ def test_stacktraces_have_templates(client, django_elasticapm_client):
     transactions = django_elasticapm_client.instrumentation_store.get_all()
     assert len(transactions) == 1
     transaction = transactions[0]
+    assert transaction['result'] == 'HTTP 2xx'
     traces = transaction['traces']
     assert len(traces) == 2, [t['name'] for t in traces]
 
@@ -936,6 +941,7 @@ def test_stacktrace_filtered_for_elasticapm(client, django_elasticapm_client):
     assert resp.status_code == 200
 
     transactions = django_elasticapm_client.instrumentation_store.get_all()
+    assert transactions[0]['result'] == 'HTTP 2xx'
     traces = transactions[0]['traces']
 
     expected_signatures = ['transaction', 'list_users.html',
@@ -967,6 +973,7 @@ def test_perf_template_render(benchmark, client, django_elasticapm_client):
     assert len(transactions) == len(responses)
     for transaction in transactions:
         assert len(transaction['traces']) == 2
+        assert transaction['result'] == 'HTTP 2xx'
 
 
 @pytest.mark.parametrize('django_elasticapm_client', [{'_wait_to_first_send': 100}], indirect=True)

--- a/tests/contrib/flask/fixtures.py
+++ b/tests/contrib/flask/fixtures.py
@@ -20,6 +20,10 @@ def flask_app():
         response.headers.add('bar', 'bazzinga')
         return response
 
+    @app.route('/non-standard-status/', methods=['GET', 'POST'])
+    def non_standard_status():
+        return "foo", 'fail'
+
     return app
 
 


### PR DESCRIPTION
This normalizes the status code into status classes 2xx, 3xx, 4xx and 5xx.
The unmodified status code is still available in context.response.status_code