### PR TITLE
added `uninstrument` function to reverse instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,6 +15,8 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev2\...master[Check 
  * added a background thread to process the transactions queue every 60 seconds (configurable) ({pull}68[#68])
  * adapted trace context for SQL traces to new API ({pull}77[#77])
  * ensured that transaction data is also passed through processors ({pull}84[#84])
+ * added `uninstrument` function to reverse instrumentation,
+   and exposed both `instrument` and `uninstrument` as public API in the `elasticapm` namespace  ({pull}90[#90])
 
 [[release-v1.0.0.dev2]]
 [float]

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -19,4 +19,6 @@ except Exception as e:
 
 from elasticapm.base import *  # noqa E403
 from elasticapm.conf import *  # noqa E403
+from elasticapm.instrumentation.control import (instrument,  # noqa E403
+                                                uninstrument)
 from elasticapm.traces import *  # noqa E403

--- a/elasticapm/instrumentation/control.py
+++ b/elasticapm/instrumentation/control.py
@@ -1,6 +1,23 @@
+import threading
+
 from elasticapm.instrumentation import register
+
+_lock = threading.Lock()
 
 
 def instrument():
-    for obj in register.get_instrumentation_objects():
-        obj.instrument()
+    """
+    Instruments all registered methods/functions with a wrapper
+    """
+    with _lock:
+        for obj in register.get_instrumentation_objects():
+            obj.instrument()
+
+
+def uninstrument():
+    """
+    If present, removes instrumentation and replaces it with the original method/function
+    """
+    with _lock:
+        for obj in register.get_instrumentation_objects():
+            obj.uninstrument()

--- a/tests/instrumentation/base_tests.py
+++ b/tests/instrumentation/base_tests.py
@@ -1,19 +1,37 @@
 # -*- coding: utf-8 -*-
+import types
 
-from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+import pytest
+
+from elasticapm.instrumentation.packages.base import (AbstractInstrumentedModule,
+                                                      OriginalNamesBoundFunctionWrapper)
+from elasticapm.utils import compat
+
+
+class Dummy(object):
+    def dummy(self):
+        pass
 
 
 class _TestInstrumentNonExistingFunctionOnModule(AbstractInstrumentedModule):
     name = "test_non_existing_function_instrumentation"
     instrument_list = [
-        ("os.path", "non_existing_function")
+        ("os.path", "non_existing_function"),
     ]
 
 
 class _TestInstrumentNonExistingMethod(AbstractInstrumentedModule):
     name = "test_non_existing_method_instrumentation"
     instrument_list = [
-        ("dict", "non_existing_method")
+        ("dict", "non_existing_method"),
+    ]
+
+
+class _TestDummyInstrumentation(AbstractInstrumentedModule):
+    name = "test_dummy_instrument"
+
+    instrument_list = [
+        ("tests.instrumentation.base_tests", "Dummy.dummy"),
     ]
 
 
@@ -23,3 +41,33 @@ def test_instrument_nonexisting_method_on_module():
 
 def test_instrument_nonexisting_method():
     _TestInstrumentNonExistingMethod().instrument()
+
+
+@pytest.mark.skipif(compat.PY3, reason="different object model")
+def test_uninstrument_py2():
+    assert isinstance(Dummy.dummy, types.MethodType)
+    assert not isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)
+
+    instrumentation = _TestDummyInstrumentation()
+    instrumentation.instrument()
+    assert isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)
+
+    instrumentation.uninstrument()
+    assert isinstance(Dummy.dummy, types.MethodType)
+    assert not isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)
+
+
+@pytest.mark.skipif(compat.PY2, reason="different object model")
+def test_uninstrument_py3():
+    original = Dummy.dummy
+    assert not isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)
+
+    instrumentation = _TestDummyInstrumentation()
+    instrumentation.instrument()
+
+    assert Dummy.dummy is not original
+    assert isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)
+
+    instrumentation.uninstrument()
+    assert Dummy.dummy is original
+    assert not isinstance(Dummy.dummy, OriginalNamesBoundFunctionWrapper)


### PR DESCRIPTION
This allows instrumentation to be reversible, e.g. to disable instrumentation on the fly during tests, or even in production.