### PR TITLE
retry fetching the gosu PGP key up to 5 times

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,7 +4,9 @@ FROM ${PYTHON_IMAGE}
 RUN apt-get update && apt-get -y --no-install-recommends install ca-certificates curl python-virtualenv &&\
     rm -rf /var/lib/apt/lists/*
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+# connection to ha.pool.sks-keyservers.net fails sometimes, so let's retry a couple times
+RUN for i in $(seq 1 5); do gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && s=0 && break || s=$? && sleep 5; done; (exit $s)
+
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \

--- a/tests/DockerfileDocs
+++ b/tests/DockerfileDocs
@@ -4,7 +4,9 @@ RUN apt-get update && \
     apt-get install -y xsltproc ca-certificates libxml2-utils build-essential git curl python2.7 && \
 		rm -rf /var/lib/apt/lists/*
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+# connection to ha.pool.sks-keyservers.net fails sometimes, so let's retry a couple times
+RUN for i in $(seq 1 5); do gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && s=0 && break || s=$? && sleep 5; done; (exit $s)
+
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture)" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture).asc" \
     && gpg --verify /usr/local/bin/gosu.asc \


### PR DESCRIPTION
This should reduce build failures on Jenkins due to intermittent
connectivity issues with ha.pool.sks-keyservers.net