### PR TITLE
changed Celery integration to store the task state in `transaction.result`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,7 +14,9 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev3\...master[Check 
 
  * added `max-event-queue-length` setting. ({pull}67[#67])
  * changed name that the agent reports itself with to the APM server from `elasticapm-python` to `python`. This aligns the Python agent with other languages. ({pull}104[#104])
+ * changed Celery integration to store the task state (e.g. `SUCCESS` or `FAILURE`) in `transaction.result` ({pull}100[#100])
  * BREAKING: renamed `server` configuration variable to `server_url` to better align with other language agents ({pull}105[#105]) 
+
 [[release-v1.0.0.dev3]]
 [float]
 === v1.0.0.dev3

--- a/elasticapm/contrib/celery/__init__.py
+++ b/elasticapm/contrib/celery/__init__.py
@@ -45,7 +45,7 @@ def register_instrumentation(client):
 
     def end_transaction(task_id, task, *args, **kwargs):
         name = get_name_from_func(task)
-        client.end_transaction(name, 200)
+        client.end_transaction(name, kwargs.get('state', 'None'))
 
     dispatch_uid = 'elasticapm-tracing-%s'
 

--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -11,12 +11,19 @@ from tests.contrib.django.testapp.tasks import failing_task, successful_task
 
 def test_failing_celery_task(django_elasticapm_client):
     register_exception_tracking(django_elasticapm_client)
-    t = failing_task.delay()
+    with mock.patch('elasticapm.traces.TransactionsStore.should_collect') as should_collect_mock:
+        should_collect_mock.return_value = True
+        t = failing_task.delay()
     assert t.state == 'FAILURE'
-    assert len(django_elasticapm_client.events) == 1
+    assert len(django_elasticapm_client.events) == 2
     error = django_elasticapm_client.events[0]['errors'][0]
     assert error['culprit'] == 'tests.contrib.django.testapp.tasks.failing_task'
     assert error['exception']['message'] == 'ValueError: foo'
+
+    transaction = django_elasticapm_client.events[1]['transactions'][0]
+    assert transaction['name'] == 'tests.contrib.django.testapp.tasks.failing_task'
+    assert transaction['type'] == 'celery'
+    assert transaction['result'] == 'FAILURE'
 
 
 def test_successful_celery_task_instrumentation(django_elasticapm_client):
@@ -29,3 +36,4 @@ def test_successful_celery_task_instrumentation(django_elasticapm_client):
     transaction = django_elasticapm_client.events[0]['transactions'][0]
     assert transaction['name'] == 'tests.contrib.django.testapp.tasks.successful_task'
     assert transaction['type'] == 'celery'
+    assert transaction['result'] == 'SUCCESS'


### PR DESCRIPTION
This allows us to show the different RPM numbers for `SUCCESS`, `FAILURE` and `RETRY`, similar to the HTTP status classes for requests.