### PR TITLE
stack collection optimizations [WIP]

### DIFF
--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -11,6 +11,7 @@ Large portions are
 
 from __future__ import absolute_import
 
+import itertools
 import logging
 
 import django
@@ -209,19 +210,15 @@ class DjangoClient(Client):
 
         return result
 
-    def get_stack_info_for_trace(self, frames, extended=True):
+    def get_stack_info_for_trace(self, frames):
         """If the stacktrace originates within the elasticapm module, it will skip
         frames until some other module comes up."""
-        frames = list(iterate_with_template_sources(frames, extended))
-        i = 0
-        while len(frames) > i:
-            if 'module' in frames[i] and not (
-                    frames[i]['module'].startswith('elasticapm.') or
-                    frames[i]['module'] == 'contextlib'
-            ):
-                return frames[i:]
-            i += 1
-        return frames
+        def discard_test(frame):
+            return 'module' in frame and (
+                frame['module'].startswith('elasticapm.') or
+                frame['module'] == 'contextlib'
+            )
+        return itertools.dropwhile(discard_test, iterate_with_template_sources(frames))
 
     def send(self, url, **kwargs):
         """

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -218,7 +218,7 @@ class DjangoClient(Client):
                 frame['module'].startswith('elasticapm.') or
                 frame['module'] == 'contextlib'
             )
-        return itertools.dropwhile(discard_test, iterate_with_template_sources(frames))
+        return itertools.dropwhile(discard_test, iterate_with_template_sources(self, frames))
 
     def send(self, url, **kwargs):
         """

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -77,9 +77,9 @@ def get_data_from_template_debug(template_debug):
     }
 
 
-def iterate_with_template_sources(frames, extended=True):
+def iterate_with_template_sources(frames):
     template = None
-    for frame, lineno in frames:
+    for frame, lineno, in_app, extended in frames:
         f_code = getattr(frame, 'f_code', None)
         if f_code:
             function = frame.f_code.co_name
@@ -104,4 +104,4 @@ def iterate_with_template_sources(frames, extended=True):
                         yield template
                         template = None
 
-        yield get_frame_info(frame, lineno, extended)
+        yield get_frame_info(frame, lineno, in_app, extended)

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -77,9 +77,11 @@ def get_data_from_template_debug(template_debug):
     }
 
 
-def iterate_with_template_sources(frames):
+def iterate_with_template_sources(client, frames):
     template = None
-    for frame, lineno, in_app, extended in frames:
+    include_paths = client.include_paths_re
+    exclude_paths = client.exclude_paths_re
+    for frame, lineno, extended in frames:
         f_code = getattr(frame, 'f_code', None)
         if f_code:
             function = frame.f_code.co_name
@@ -104,4 +106,7 @@ def iterate_with_template_sources(frames):
                         yield template
                         template = None
 
-        yield get_frame_info(frame, lineno, in_app, extended)
+        yield get_frame_info(frame, lineno,
+                             extended=extended,
+                             include_paths_regex=include_paths,
+                             exclude_paths_regex=exclude_paths)

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -75,10 +75,8 @@ class Exception(BaseEvent):
 
             frames = varmap(
                 lambda k, v: shorten(v),
-                list(get_stack_info((iter_traceback_frames(
+                list(get_stack_info(client, (iter_traceback_frames(
                     exc_traceback,
-                    client.config.include_paths,
-                    client.config.exclude_paths,
                     extended=True
                 ))))
             )

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -75,7 +75,12 @@ class Exception(BaseEvent):
 
             frames = varmap(
                 lambda k, v: shorten(v),
-                get_stack_info((iter_traceback_frames(exc_traceback)))
+                list(get_stack_info((iter_traceback_frames(
+                    exc_traceback,
+                    client.config.include_paths,
+                    client.config.exclude_paths,
+                    extended=True
+                ))))
             )
 
             culprit = get_culprit(frames, client.config.include_paths, client.config.exclude_paths)

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -82,9 +82,9 @@ class LoggingHandler(logging.Handler):
             last_mod = ''
             for item in stack:
                 if isinstance(item, (list, tuple)):
-                    frame, lineno = item
+                    frame, lineno, in_app, extended = item
                 else:
-                    frame, lineno = item, item.f_lineno
+                    frame, lineno, in_app, extended = item, item.f_lineno, False, True
 
                 if not started:
                     f_globals = getattr(frame, 'f_globals', {})
@@ -96,7 +96,7 @@ class LoggingHandler(logging.Handler):
                     else:
                         last_mod = module_name
                         continue
-                frames.append((frame, lineno))
+                frames.append((frame, lineno, in_app, extended))
             stack = frames
 
         extra = getattr(record, 'data', {})

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -82,9 +82,9 @@ class LoggingHandler(logging.Handler):
             last_mod = ''
             for item in stack:
                 if isinstance(item, (list, tuple)):
-                    frame, lineno, in_app, extended = item
+                    frame, lineno, extended = item
                 else:
-                    frame, lineno, in_app, extended = item, item.f_lineno, False, True
+                    frame, lineno, extended = item, item.f_lineno, True
 
                 if not started:
                     f_globals = getattr(frame, 'f_globals', {})
@@ -96,7 +96,7 @@ class LoggingHandler(logging.Handler):
                     else:
                         last_mod = module_name
                         continue
-                frames.append((frame, lineno, in_app, extended))
+                frames.append((frame, lineno, extended))
             stack = frames
 
         extra = getattr(record, 'data', {})

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -1,5 +1,6 @@
 import datetime
 import functools
+import itertools
 import logging
 import re
 import threading
@@ -88,7 +89,7 @@ class Transaction(object):
         if self.trace_stack:
             trace.parent = self.trace_stack[-1].idx
 
-        trace.frames = self.get_frames()[skip_frames:]
+        trace.frames = itertools.islice(self.get_frames(), skip_frames, None)
         self.traces.append(trace)
 
         return trace
@@ -145,7 +146,7 @@ class Trace(object):
             'start': self.start_time * 1000,  # milliseconds
             'duration': self.duration * 1000,  # milliseconds
             'parent': self.parent,
-            'stacktrace': self.frames,
+            'stacktrace': list(self.frames),
             'context': self.context
         }
 

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -147,7 +147,7 @@ def iter_stack_frames(frames=None, extended=True):
     local variable.
     """
     if not frames:
-        frame = inspect.currentframe()
+        frame = inspect.currentframe().f_back
         while frame:
             f_locals = getattr(frame, 'f_locals', {})
             if not _getitem_from_frame(f_locals, '__traceback_hide__'):
@@ -155,7 +155,9 @@ def iter_stack_frames(frames=None, extended=True):
             frame = frame.f_back
     else:
         for frame in frames:
-            yield frame, frame.f_lineno, extended
+            f_locals = getattr(frame, 'f_locals', {})
+            if not _getitem_from_frame(f_locals, '__traceback_hide__'):
+                yield frame, frame.f_lineno, extended
 
 
 def get_frame_info(frame, lineno, extended=False, include_paths_regex=None, exclude_paths_regex=None):

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -163,11 +163,10 @@ def get_frame_info(frame, lineno, extended=True):
     loader = f_globals.get('__loader__')
     module_name = f_globals.get('__name__')
 
-    f_code = getattr(frame, 'f_code', None)
-    if f_code:
+    try:
         abs_path = frame.f_code.co_filename
         function = frame.f_code.co_name
-    else:
+    except AttributeError:
         abs_path = None
         function = None
 

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -142,14 +142,13 @@ def iter_stack_frames(frames=None):
     local variable.
     """
     if not frames:
-        frames = inspect.stack(0)[1:]
-
-    for frame, lineno in ((f[0], f[2]) for f in frames):
-        f_locals = getattr(frame, 'f_locals', {})
-        if _getitem_from_frame(f_locals, '__traceback_hide__'):
-            continue
-        yield frame, lineno
-
+        frame = inspect.currentframe()
+        while frame:
+            yield frame, frame.f_lineno
+            frame = frame.f_back
+    else:
+        for frame, in_app in frames:
+            yield frame, frame.f_lineno
 
 def get_frame_info(frame, lineno, extended=True):
     # Support hidden frames

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -160,7 +160,6 @@ def get_frame_info(frame, lineno, extended=True):
         return None
 
     f_globals = getattr(frame, 'f_globals', {})
-    loader = f_globals.get('__loader__')
     module_name = f_globals.get('__name__')
 
     try:
@@ -196,12 +195,13 @@ def get_frame_info(frame, lineno, extended=True):
     }
 
     if extended:
+        loader = f_globals.get('__loader__')
         if lineno is not None and abs_path:
             pre_context, context_line, post_context = get_lines_from_file(
                 abs_path, lineno, 3, loader, module_name)
         else:
             pre_context, context_line, post_context = [], None, []
-
+        f_locals = getattr(frame, 'f_locals', {})
         if f_locals is not None and not isinstance(f_locals, dict):
             # XXX: Genshi (and maybe others) have broken implementations of
             # f_locals that are not actually dictionaries

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -149,7 +149,9 @@ def iter_stack_frames(frames=None, extended=True):
     if not frames:
         frame = inspect.currentframe()
         while frame:
-            yield frame, frame.f_lineno, extended
+            f_locals = getattr(frame, 'f_locals', {})
+            if not _getitem_from_frame(f_locals, '__traceback_hide__'):
+                yield frame, frame.f_lineno, extended
             frame = frame.f_back
     else:
         for frame in frames:

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -309,6 +309,7 @@ def test_exception_event(elasticapm_client):
     assert frame['filename'] == 'tests/client/client_tests.py'
     assert frame['module'] == __name__
     assert frame['function'] == 'test_exception_event'
+    assert frame['in_app'] == False
     assert 'timestamp' in event
     assert 'log' not in event
 

--- a/tests/utils/stacks/__init__.py
+++ b/tests/utils/stacks/__init__.py
@@ -1,0 +1,6 @@
+import inspect
+
+
+def get_me_a_test_frame():
+    a_local_var = 42
+    return inspect.currentframe()

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import inspect
+
 from mock import Mock
+import pytest
 
 from elasticapm.utils import compat
-from elasticapm.utils.stacks import get_culprit, get_stack_info
+from elasticapm.utils import stacks
+
+from tests.utils.stacks import get_me_a_test_frame
 
 
 class Context(object):
@@ -17,24 +22,25 @@ class Context(object):
 
 
 def test_get_culprit_bad_module():
-    culprit = get_culprit([{
+    culprit = stacks.get_culprit([{
         'module': None,
         'function': 'foo',
     }])
     assert culprit == '<unknown>.foo'
 
-    culprit = get_culprit([{
+    culprit = stacks.get_culprit([{
         'module': 'foo',
         'function': None,
     }])
     assert culprit == 'foo.<unknown>'
 
-    culprit = get_culprit([{
+    culprit = stacks.get_culprit([{
     }])
     assert culprit == '<unknown>.<unknown>'
 
 
-def test_bad_locals_in_frame():
+
+def test_bad_locals_in_frame(elasticapm_client):
     frame = Mock()
     frame.f_locals = Context({
         'foo': 'bar',
@@ -44,8 +50,8 @@ def test_bad_locals_in_frame():
     frame.f_globals = {}
     frame.f_code.co_filename = __file__.replace('.pyc', '.py')
     frame.f_code.co_name = __name__
-    frames = [(frame, 1, False, True)]
-    results = list(get_stack_info(frames))
+    frames = [(frame, 1, True)]
+    results = list(stacks.get_stack_info(elasticapm_client, frames))
     assert len(results) == 1
     result = results[0]
     assert 'vars' in result
@@ -54,3 +60,34 @@ def test_bad_locals_in_frame():
         "biz": "baz",
     }
     assert result['vars'] == vars
+
+
+@pytest.mark.parametrize('elasticapm_client', [{
+    'include_paths': ('a.b.c', 'c.d'),
+    'exclude_paths': ('c',)
+}], indirect=True)
+def test_in_app(elasticapm_client):
+    include = elasticapm_client.include_paths_re
+    exclude = elasticapm_client.exclude_paths_re
+    frame1 = Mock(f_globals={'__name__': 'a.b.c'})
+    frame2 = Mock(f_globals={'__name__': 'a.b.c.d'})
+    frame3 = Mock(f_globals={'__name__': 'c.d'})
+
+    info1 = stacks.get_frame_info(frame1, 1, False, include_paths_regex=include, exclude_paths_regex=exclude)
+    info2 = stacks.get_frame_info(frame2, 1, False, include_paths_regex=include, exclude_paths_regex=exclude)
+    info3 = stacks.get_frame_info(frame3, 1, False, include_paths_regex=include, exclude_paths_regex=exclude)
+    assert info1['in_app']
+    assert info2['in_app']
+    assert not info3['in_app']
+
+
+def test_get_frame_info():
+    frame = get_me_a_test_frame()
+    frame_info = stacks.get_frame_info(frame, frame.f_lineno, extended=True)
+
+    assert frame_info['function'] == 'get_me_a_test_frame'
+    assert frame_info['filename'] == 'tests/utils/stacks/__init__.py'
+    assert frame_info['module'] == 'tests.utils.stacks'
+    assert frame_info['lineno'] == 6
+    assert frame_info['context_line'] == '    return inspect.currentframe()'
+    assert frame_info['vars'] == {'a_local_var': 42}

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -44,8 +44,8 @@ def test_bad_locals_in_frame():
     frame.f_globals = {}
     frame.f_code.co_filename = __file__.replace('.pyc', '.py')
     frame.f_code.co_name = __name__
-    frames = [(frame, 1)]
-    results = get_stack_info(frames)
+    frames = [(frame, 1, False, True)]
+    results = list(get_stack_info(frames))
     assert len(results) == 1
     result = results[0]
     assert 'vars' in result


### PR DESCRIPTION
This PR tries to mitigate what turned out to be a major bottleneck: collecting stack frames for every single trace of a transaction. 

The most significant win came from not using `inspect.stack(0)`, and instead use `inspect.currentframe()` and then walk up the stack. This is due to the fact that deep inside the call stack of `inspect.stack()`, an `os.exists()` is called for every frame's filename. This causes a lot of IO, which can be avoided.

Other gains mostly come from using iterators instead of lists wherever possible, and avoid work unless it is absolutely necessary.

In a (very) synthetic benchmark, these changes reduces the overhead by about factor 7 (from ~28ms per transaction to ~4ms). The benchmarked transaction has 16 traces, each of which has about ~80 frames (due to using py.test / pytest-benchmark, which bloats the call stack quite a bit).