### PR TITLE
renamed `server` configuration variable to `server_url`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,7 +14,7 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0.dev3\...master[Check 
 
  * added `max-event-queue-length` setting. ({pull}67[#67])
  * changed name that the agent reports itself with to the APM server from `elasticapm-python` to `python`. This aligns the Python agent with other languages. ({pull}104[#104])
-
+ * BREAKING: renamed `server` configuration variable to `server_url` to better align with other language agents ({pull}105[#105]) 
 [[release-v1.0.0.dev3]]
 [float]
 === v1.0.0.dev3

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@
 import sys
 from os.path import abspath, dirname, join
 
-from tests.fixtures import elasticapm_client
+from tests.fixtures import elasticapm_client, sending_elasticapm_client
 from tests.utils.compat import middleware_setting
 
 try:

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -58,13 +58,13 @@ In less regexy terms:
 Your app name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.
 
 [float]
-[[config-server]]
-==== `server`
+[[config-server-url]]
+==== `server_url`
 
 [options="header"]
 |============
-| Environment           | Django/Flask   | Default
-| `ELASTIC_APM_SERVER`  | `SERVER`       | `'http://localhost:8200'`
+| Environment              | Django/Flask   | Default
+| `ELASTIC_APM_SERVER_URL` | `SERVER_URL`   | `'http://localhost:8200'`
 |============
 
 The URL for your APM Server.

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -135,7 +135,7 @@ class Config(_ConfigBase):
     app_name = _ConfigValue('APP_NAME', validators=[lambda val: re.match('^[a-zA-Z0-9 _-]+$', val)], required=True)
     secret_token = _ConfigValue('SECRET_TOKEN')
     debug = _BoolConfigValue('DEBUG', default=False)
-    server = _ConfigValue('SERVER', default='http://localhost:8200', required=True)
+    server_url = _ConfigValue('SERVER_URL', default='http://localhost:8200', required=True)
     include_paths = _ListConfigValue('INCLUDE_PATHS')
     exclude_paths = _ListConfigValue('EXCLUDE_PATHS', default=['elasticapm'])
     filter_exception_types = _ListConfigValue('FILTER_EXCEPTION_TYPES')

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -223,15 +223,15 @@ class DjangoClient(Client):
             i += 1
         return frames
 
-    def send(self, **kwargs):
+    def send(self, url, **kwargs):
         """
         Serializes and signs ``data`` and passes the payload off to ``send_remote``
 
         If ``server`` was passed into the constructor, this will serialize the data and pipe it to
         the server using ``send_remote()``.
         """
-        if self.config.server:
-            return super(DjangoClient, self).send(**kwargs)
+        if self.config.server_url:
+            return super(DjangoClient, self).send(url, **kwargs)
         else:
             self.error_logger.error('No server configured, and elasticapm not installed. Cannot send message')
             return None

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -151,7 +151,7 @@ class Command(BaseCommand):
             "SERVER:\t\t%s\n\n" % (
                 client.config.app_name,
                 client.config.secret_token,
-                client.config.server,
+                client.config.server_url,
             )
         )
 

--- a/tests/asyncio/test_asyncio_client.py
+++ b/tests/asyncio/test_asyncio_client.py
@@ -42,13 +42,13 @@ async def test_client_success():
     from elasticapm.contrib.asyncio import Client
 
     client = Client(
-        server='http://localhost',
+        server_url='http://localhost',
         app_name='app_name',
         secret_token='secret',
         transport_class='.'.join(
             (__name__, MockTransport.__name__)),
     )
-    client.send(foo='bar')
+    client.send(client.config.server_url, foo='bar')
     tasks = asyncio.Task.all_tasks()
     task = next(t for t in tasks if t is not asyncio.Task.current_task())
     await task
@@ -63,13 +63,13 @@ async def test_client_failure():
     from elasticapm.transport.base import TransportException
 
     client = Client(
-        server='http://error',
+        server_url='http://error',
         app_name='app_name',
         secret_token='secret',
         transport_class='.'.join(
             (__name__, MockTransport.__name__)),
     )
-    client.send(foo='bar')
+    client.send(client.config.server_url, foo='bar')
     tasks = asyncio.Task.all_tasks()
     task = next(t for t in tasks if t is not asyncio.Task.current_task())
     with pytest.raises(TransportException):
@@ -83,7 +83,7 @@ async def test_client_failure_stdlib_exception(mocker):
     from elasticapm.transport.base import TransportException
 
     client = Client(
-        server='http://elastic.co',
+        server_url='http://elastic.co',
         app_name='app_name',
         secret_token='secret',
         async_mode=False,
@@ -93,7 +93,7 @@ async def test_client_failure_stdlib_exception(mocker):
     mock_client.post = mocker.Mock(side_effect=RuntimeError('oops'))
     transport = client._get_transport(urlparse('http://elastic.co'))
     transport.client = mock_client
-    client.send(foo='bar')
+    client.send(client.config.server_url, foo='bar')
     tasks = asyncio.Task.all_tasks()
     task = next(t for t in tasks if t is not asyncio.Task.current_task())
     with pytest.raises(TransportException):

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -30,7 +30,7 @@ def test_config_dict():
     config = Config({
         'APP_NAME': 'foo',
         'SECRET_TOKEN': 'bar',
-        'SERVER': 'http://example.com:1234',
+        'SERVER_URL': 'http://example.com:1234',
         'APP_VERSION': 1,
         'HOSTNAME': 'localhost',
         'TRACES_SEND_FREQ': '5'
@@ -38,7 +38,7 @@ def test_config_dict():
 
     assert config.app_name == 'foo'
     assert config.secret_token == 'bar'
-    assert config.server == 'http://example.com:1234'
+    assert config.server_url == 'http://example.com:1234'
     assert config.app_version == '1'
     assert config.hostname == 'localhost'
     assert config.traces_send_frequency == 5
@@ -48,7 +48,7 @@ def test_config_environment():
     with mock.patch.dict('os.environ', {
         'ELASTIC_APM_APP_NAME': 'foo',
         'ELASTIC_APM_SECRET_TOKEN': 'bar',
-        'ELASTIC_APM_SERVER': 'http://example.com:1234',
+        'ELASTIC_APM_SERVER_URL': 'http://example.com:1234',
         'ELASTIC_APM_APP_VERSION': '1',
         'ELASTIC_APM_HOSTNAME': 'localhost',
         'ELASTIC_APM_TRACES_SEND_FREQ': '5',
@@ -58,7 +58,7 @@ def test_config_environment():
 
         assert config.app_name == 'foo'
         assert config.secret_token == 'bar'
-        assert config.server == 'http://example.com:1234'
+        assert config.server_url == 'http://example.com:1234'
         assert config.app_version == '1'
         assert config.hostname == 'localhost'
         assert config.traces_send_frequency == 5
@@ -69,7 +69,7 @@ def test_config_defaults_dict():
     config = Config(default_dict={
         'app_name': 'foo',
         'secret_token': 'bar',
-        'server': 'http://example.com:1234',
+        'server_url': 'http://example.com:1234',
         'app_version': '1',
         'hostname': 'localhost',
         'traces_send_frequency': '5',
@@ -77,7 +77,7 @@ def test_config_defaults_dict():
 
     assert config.app_name == 'foo'
     assert config.secret_token == 'bar'
-    assert config.server == 'http://example.com:1234'
+    assert config.server_url == 'http://example.com:1234'
     assert config.app_version == '1'
     assert config.hostname == 'localhost'
     assert config.traces_send_frequency == 5

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -768,72 +768,67 @@ def test_get_app_info(django_elasticapm_client):
     assert django_elasticapm_client.config.framework_name == 'django'
 
 
-@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
 @pytest.mark.parametrize('django_sending_elasticapm_client', [{'filter_exception_types': [
         'KeyError', 'tests.contrib.django.fake1.FakeException'
     ]}], indirect=True)
-def test_filter_no_match(send_encoded, django_sending_elasticapm_client):
+def test_filter_no_match(django_sending_elasticapm_client):
     try:
         raise ValueError('foo')
-    except:
+    except ValueError:
         django_sending_elasticapm_client.capture('Exception')
 
-    assert send_encoded.call_count == 1
+    assert len(django_sending_elasticapm_client.httpserver.requests) == 1
 
 
-@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
 @pytest.mark.parametrize('django_sending_elasticapm_client', [{'filter_exception_types': [
         'KeyError', 'tests.contrib.django.fake1.FakeException'
     ]}], indirect=True)
-def test_filter_matches_type(send_encoded, django_sending_elasticapm_client):
+def test_filter_matches_type(django_sending_elasticapm_client):
     try:
         raise KeyError('foo')
-    except:
+    except KeyError:
         django_sending_elasticapm_client.capture('Exception')
 
-    assert send_encoded.call_count == 0
+    assert len(django_sending_elasticapm_client.httpserver.requests) == 0
 
 
-@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
 @pytest.mark.parametrize('django_sending_elasticapm_client', [{'filter_exception_types': [
         'KeyError', 'tests.contrib.django.fake1.FakeException'
     ]}], indirect=True)
-def test_filter_matches_type_but_not_module(send_encoded, django_sending_elasticapm_client):
+def test_filter_matches_type_but_not_module(django_sending_elasticapm_client):
+    from tests.contrib.django.fake2 import FakeException
     try:
-        from tests.contrib.django.fake2 import FakeException
         raise FakeException('foo')
-    except:
+    except FakeException:
         django_sending_elasticapm_client.capture('Exception')
 
-    assert send_encoded.call_count == 1
+    assert len(django_sending_elasticapm_client.httpserver.requests) == 1
 
 
-@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
 @pytest.mark.parametrize('django_sending_elasticapm_client', [{'filter_exception_types': [
         'KeyError', 'tests.contrib.django.fake1.FakeException'
     ]}], indirect=True)
-def test_filter_matches_type_and_module(send_encoded, django_sending_elasticapm_client):
+def test_filter_matches_type_and_module(django_sending_elasticapm_client):
+    from tests.contrib.django.fake1 import FakeException
     try:
-        from tests.contrib.django.fake1 import FakeException
         raise FakeException('foo')
-    except:
+    except FakeException:
         django_sending_elasticapm_client.capture('Exception')
 
-    assert send_encoded.call_count == 0
+    assert len(django_sending_elasticapm_client.httpserver.requests) == 0
 
 
-@mock.patch('elasticapm.contrib.django.DjangoClient.send_encoded')
 @pytest.mark.parametrize('django_sending_elasticapm_client', [{'filter_exception_types': [
         'KeyError', 'tests.contrib.django.fake1.FakeException'
     ]}], indirect=True)
-def test_filter_matches_module_only(send_encoded, django_sending_elasticapm_client):
+def test_filter_matches_module_only(django_sending_elasticapm_client):
+    from tests.contrib.django.fake1 import OtherFakeException
     try:
-        from tests.contrib.django.fake1 import OtherFakeException
         raise OtherFakeException('foo')
     except OtherFakeException:
         django_sending_elasticapm_client.capture('Exception')
 
-    assert send_encoded.call_count == 1
+        assert len(django_sending_elasticapm_client.httpserver.requests) == 1
 
 
 def test_django_logging_request_kwarg(django_elasticapm_client):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,9 +6,23 @@ from elasticapm.base import Client
 @pytest.fixture()
 def elasticapm_client(request):
     client_config = getattr(request, 'param', {})
-    app_name = client_config.pop('app_name', 'myapp')
-    secret_token = client_config.pop('secret_token', 'test_key')
-    client = TempStoreClient(app_name=app_name, secret_token=secret_token, **client_config)
+    client_config.setdefault('app_name', 'myapp')
+    client_config.setdefault('secret_token', 'test_key')
+    client = TempStoreClient(**client_config)
+    yield client
+    client.close()
+
+
+@pytest.fixture()
+def sending_elasticapm_client(request, httpserver):
+    httpserver.serve_content(code=202, content='', headers={'Location': 'http://example.com/foo'})
+    client_config = getattr(request, 'param', {})
+    client_config.setdefault('server_url', httpserver.url)
+    client_config.setdefault('app_name', 'myapp')
+    client_config.setdefault('secret_token', 'test_key')
+    client_config.setdefault('transport_class', 'elasticapm.transport.http_urllib3.Urllib3Transport')
+    client = Client(**client_config)
+    client.httpserver = httpserver
     yield client
     client.close()
 
@@ -18,5 +32,5 @@ class TempStoreClient(Client):
         self.events = []
         super(TempStoreClient, self).__init__(**defaults)
 
-    def send(self, **kwargs):
+    def send(self, url, **kwargs):
         self.events.append(kwargs)

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -182,9 +182,9 @@ def test_invalid_first_arg_type():
 
 
 def test_logger_setup():
-    handler = LoggingHandler(server='foo', app_name='bar', secret_token='baz')
+    handler = LoggingHandler(server_url='foo', app_name='bar', secret_token='baz')
     client = handler.client
-    assert client.config.server == 'foo'
+    assert client.config.server_url == 'foo'
     assert client.config.app_name == 'bar'
     assert client.config.secret_token == 'baz'
     assert handler.level == logging.NOTSET

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -5,7 +5,7 @@ pytest-django==3.1.2
 coverage==4.4.1
 pytest-cov==2.5.1
 pytest-mock
-pytest-localserver==0.3.7
+pytest-localserver==0.4.1
 pytest-benchmark==3.1.1
 
 docutils==0.14


### PR DESCRIPTION
This aligns the Python agent to agents in other languages

This PR also simplifies the logic for sending data, and
uses a test server instead of mocks for many tests