### PR TITLE
avoid all the IO from inspect.stack(), collect stack ourselves

### DIFF
--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -142,13 +142,12 @@ def iter_stack_frames(frames=None):
     local variable.
     """
     if not frames:
-        frames = inspect.stack(0)[1:]
-
-    for frame, lineno in ((f[0], f[2]) for f in frames):
+        frame = inspect.currentframe().f_back
+        frames = _walk_stack(frame)
+    for frame in frames:
         f_locals = getattr(frame, 'f_locals', {})
-        if _getitem_from_frame(f_locals, '__traceback_hide__'):
-            continue
-        yield frame, lineno
+        if not _getitem_from_frame(f_locals, '__traceback_hide__'):
+            yield frame, frame.f_lineno,
 
 
 def get_frame_info(frame, lineno, extended=True):
@@ -231,3 +230,9 @@ def get_stack_info(frames, extended=True):
         if result:
             results.append(result)
     return results
+
+
+def _walk_stack(frame):
+    while frame:
+        yield frame
+        frame = frame.f_back

--- a/tests/utils/stacks/__init__.py
+++ b/tests/utils/stacks/__init__.py
@@ -1,0 +1,6 @@
+import inspect
+
+
+def get_me_a_test_frame():
+    a_local_var = 42
+    return inspect.currentframe()

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 
 from mock import Mock
 
-from elasticapm.utils import compat
+from elasticapm.utils import compat, stacks
 from elasticapm.utils.stacks import get_culprit, get_stack_info
+from tests.utils.stacks import get_me_a_test_frame
 
 
 class Context(object):
@@ -49,8 +50,37 @@ def test_bad_locals_in_frame():
     assert len(results) == 1
     result = results[0]
     assert 'vars' in result
-    vars = {
+    variables = {
         "foo": "bar",
         "biz": "baz",
     }
-    assert result['vars'] == vars
+    assert result['vars'] == variables
+
+
+def test_traceback_hide(elasticapm_client):
+    def get_me_a_filtered_frame(hide=True):
+        __traceback_hide__ = True
+        if not hide:
+            del __traceback_hide__
+
+        return list(stacks.iter_stack_frames())
+
+    # hide frame from `get_me_a_filtered_frame
+    frames = list(stacks.get_stack_info(get_me_a_filtered_frame(hide=True)))
+    assert frames[0]['function'] == 'test_traceback_hide'
+
+    # don't hide it:
+    frames = list(stacks.get_stack_info(get_me_a_filtered_frame(hide=False)))
+    assert frames[0]['function'] == 'get_me_a_filtered_frame'
+
+
+def test_get_frame_info():
+    frame = get_me_a_test_frame()
+    frame_info = stacks.get_frame_info(frame, frame.f_lineno, extended=True)
+
+    assert frame_info['function'] == 'get_me_a_test_frame'
+    assert frame_info['filename'] == 'tests/utils/stacks/__init__.py'
+    assert frame_info['module'] == 'tests.utils.stacks'
+    assert frame_info['lineno'] == 6
+    assert frame_info['context_line'] == '    return inspect.currentframe()'
+    assert frame_info['vars'] == {'a_local_var': 42}


### PR DESCRIPTION
inspect.stack() causes a lot of IO by checking for each frame if
the file exists. This is unnecessary.