### PR TITLE
added schema-validating HTTP server to test fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,8 @@
 import sys
 from os.path import abspath, dirname, join
 
-from tests.fixtures import elasticapm_client, sending_elasticapm_client
+from tests.fixtures import (elasticapm_client, sending_elasticapm_client,
+                            validating_httpserver)
 from tests.utils.compat import middleware_setting
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ multi_line_output=0
 known_standard_library=importlib,types,asyncio
 known_django=django
 known_first_party=elasticapm,tests
-known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope,urllib3,redis,jinja2,requests,certifi,mock
+known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope,urllib3,redis,jinja2,requests,certifi,mock,jsonschema,werkzeug,pytest_localserver
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -34,10 +34,10 @@ def django_elasticapm_client(request):
 
 
 @pytest.fixture()
-def django_sending_elasticapm_client(request, httpserver):
-    httpserver.serve_content(code=202, content='', headers={'Location': 'http://example.com/foo'})
+def django_sending_elasticapm_client(request, validating_httpserver):
+    validating_httpserver.serve_content(code=202, content='', headers={'Location': 'http://example.com/foo'})
     client_config = getattr(request, 'param', {})
-    client_config.setdefault('server_url', httpserver.url)
+    client_config.setdefault('server_url', validating_httpserver.url)
     client_config.setdefault('app_name', 'app')
     client_config.setdefault('secret_token', 'secret')
     client_config.setdefault('transport_class', 'elasticapm.transport.http.Transport')
@@ -47,7 +47,7 @@ def django_sending_elasticapm_client(request, httpserver):
     register_handlers(client)
     instrument(client)
     app.client = client
-    client.httpserver = httpserver
+    client.httpserver = validating_httpserver
     yield client
 
     app.client = old_client

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -7,6 +7,7 @@ pytest-cov==2.5.1
 pytest-mock
 pytest-localserver==0.4.1
 pytest-benchmark==3.1.1
+jsonschema==2.6.0
 
 docutils==0.14
 pathlib==1.0.1


### PR DESCRIPTION
This server decodes and validates the errors and transactions
sent to the test server

Most tests don't hit this server yet, but I'll gradually change them.