### PR TITLE
rename url.raw to url.full

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,8 +24,8 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0\...master[Check the H
      The name of the analogous environment variable changed from `ELASTIC_APM_APP_NAME`
      to `ELASTIC_APM_SERVICE_NAME`.
  ** `app_name` arguments to API calls in the whole code base changed to `service_name`.
+ ** `context.request.url.raw` has been renamed to `context.request.url.full` ({pull}121[#121])
 
->>>>>>> renamed traces to spans, app to service
 [[release-1.0.0]]
 [float]
 === v1.0.0

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -141,7 +141,7 @@ class DjangoClient(Client):
             except DisallowedHost:
                 # We can't figure out the real URL, so we have to set it to
                 # DisallowedHost
-                result['url'] = {'raw': 'DisallowedHost'}
+                result['url'] = {'full': 'DisallowedHost'}
                 url = None
         if url:
             result['url'] = get_url_dict(url)

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -157,9 +157,9 @@ def sanitize_http_request_querystring(client, event):
         return event
     if '=' in query_string:
         sanitized_query_string = _sanitize_string(query_string, '&', '=')
-        raw = event['context']['request']['url']['raw']
+        full_url = event['context']['request']['url']['full']
         event['context']['request']['url']['search'] = sanitized_query_string
-        event['context']['request']['url']['raw'] = raw.replace(
+        event['context']['request']['url']['full'] = full_url.replace(
             query_string,
             sanitized_query_string
         )

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -82,7 +82,7 @@ def get_url_dict(url):
     else:
         hostname, port = (netloc, None)
     url_dict = {
-        'raw': url,
+        'full': url,
         'protocol': scheme + ':',
         'hostname': hostname,
         'pathname': path,

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -415,7 +415,7 @@ def test_404_middleware(django_elasticapm_client, client):
 
         assert 'request' in event['context']
         request = event['context']['request']
-        assert request['url']['raw'] == u'http://testserver/non-existant-page'
+        assert request['url']['full'] == u'http://testserver/non-existant-page'
         assert request['method'] == 'GET'
         assert request['body'] == None
 
@@ -534,7 +534,7 @@ def test_disallowed_hosts_error_django_19(django_elasticapm_client):
         # this should not raise a DisallowedHost exception
         django_elasticapm_client.capture('Message', message='foo', request=request)
     event = django_elasticapm_client.events.pop(0)['errors'][0]
-    assert event['context']['request']['url']['raw'] == 'http://testserver/'
+    assert event['context']['request']['url']['full'] == 'http://testserver/'
 
 
 @pytest.mark.skipif(django.VERSION >= (1, 9),
@@ -553,7 +553,7 @@ def test_disallowed_hosts_error_django_18(django_elasticapm_client):
         # this should not raise a DisallowedHost exception
         django_elasticapm_client.capture('Message', message='foo', request=request)
     event = django_elasticapm_client.events.pop(0)['errors'][0]
-    assert event['context']['request']['url'] == {'raw': 'DisallowedHost'}
+    assert event['context']['request']['url'] == {'full': 'DisallowedHost'}
 
 
 def test_request_capture(django_elasticapm_client):

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -31,7 +31,7 @@ def test_get(flask_apm_client):
 
     assert 'request' in event['context']
     request = event['context']['request']
-    assert request['url']['raw'] == 'http://localhost/an-error/?foo=bar'
+    assert request['url']['full'] == 'http://localhost/an-error/?foo=bar'
     assert request['url']['search'] == '?foo=bar'
     assert request['method'] == 'GET'
     assert request['body'] == None
@@ -79,7 +79,7 @@ def test_post(flask_apm_client):
 
     assert 'request' in event['context']
     request = event['context']['request']
-    assert request['url']['raw'] == 'http://localhost/an-error/?biz=baz'
+    assert request['url']['full'] == 'http://localhost/an-error/?biz=baz'
     assert request['url']['search'] == '?biz=baz'
     assert request['method'] == 'POST'
     assert request['body'] == 'foo=bar'
@@ -112,7 +112,7 @@ def test_instrumentation(flask_apm_client):
     assert transaction['type'] == 'request'
     assert transaction['result'] == 'HTTP 2xx'
     assert 'request' in transaction['context']
-    assert transaction['context']['request']['url']['raw'] == 'http://localhost/users/'
+    assert transaction['context']['request']['url']['full'] == 'http://localhost/users/'
     assert transaction['context']['request']['method'] == 'POST'
     assert transaction['context']['response']['status_code'] == 200
     assert transaction['context']['response']['headers'] == {

--- a/tests/middleware/tests.py
+++ b/tests/middleware/tests.py
@@ -29,7 +29,7 @@ def test_error_handler(elasticapm_client):
 
     assert 'request' in event['context']
     request = event['context']['request']
-    assert request['url']['raw'] == 'http://localhost/an-error?foo=bar'
+    assert request['url']['full'] == 'http://localhost/an-error?foo=bar'
     assert request['url']['search'] == '?foo=bar'
     assert request['method'] == 'GET'
     headers = request['headers']

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -34,7 +34,7 @@ def http_test_data():
                     'a_password_here': '123456',
                 },
                 'url': {
-                    'raw': 'http://example.com/bla?foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
+                    'full': 'http://example.com/bla?foo=bar&password=123456&the_secret=abc&cc=1234567890098765',
                     'search': 'foo=bar&password=123456&the_secret=abc&cc=1234567890098765'
                 }
             },
@@ -141,7 +141,7 @@ def test_sanitize_http_query_string(http_test_data):
         processors.MASK
     )
     assert result['context']['request']['url']['search'] == expected
-    assert result['context']['request']['url']['raw'].endswith(expected)
+    assert result['context']['request']['url']['full'].endswith(expected)
 
 
 def test_post_as_string(http_test_data):

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -17,28 +17,28 @@ def test_get_url_dict():
             'protocol': 'http:',
             'hostname': 'example.com',
             'pathname': '',
-            'raw': 'http://example.com',
+            'full': 'http://example.com',
         },
         'http://example.com:443': {
             'protocol': 'http:',
             'hostname': 'example.com',
             'port': '443',
             'pathname': '',
-            'raw': 'http://example.com:443',
+            'full': 'http://example.com:443',
         },
         'http://example.com:443/a/b/c': {
             'protocol': 'http:',
             'hostname': 'example.com',
             'port': '443',
             'pathname': '/a/b/c',
-            'raw': 'http://example.com:443/a/b/c',
+            'full': 'http://example.com:443/a/b/c',
         },
         'https://example.com:443/': {
             'protocol': 'https:',
             'hostname': 'example.com',
             'port': '443',
             'pathname': '/',
-            'raw': 'https://example.com:443/',
+            'full': 'https://example.com:443/',
         },
         'https://example.com:443/a/b/c?de': {
             'protocol': 'https:',
@@ -46,7 +46,7 @@ def test_get_url_dict():
             'port': '443',
             'pathname': '/a/b/c',
             'search': '?de',
-            'raw': 'https://example.com:443/a/b/c?de',
+            'full': 'https://example.com:443/a/b/c?de',
         }
     }
     for url, expected in data.items():


### PR DESCRIPTION
`url.raw` is only used by the Node agent (so far), and was a misnomer for all other agents. 