### PR TITLE
moved the `handled` attribute to the correct place

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -470,7 +470,8 @@ class Client(object):
 
         # Make sure all data is coerced
         event_data = transform(event_data)
-        event_data['handled'] = handled
+        if 'exception' in event_data:
+            event_data['exception']['handled'] = bool(handled)
 
         event_data.update({
             'timestamp': date.strftime(constants.TIMESTAMP_FORMAT),

--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -19,7 +19,7 @@ def test_failing_celery_task(django_elasticapm_client):
     error = django_elasticapm_client.events[0]['errors'][0]
     assert error['culprit'] == 'tests.contrib.django.testapp.tasks.failing_task'
     assert error['exception']['message'] == 'ValueError: foo'
-    assert error['handled'] is False
+    assert error['exception']['handled'] is False
 
     transaction = django_elasticapm_client.events[1]['transactions'][0]
     assert transaction['name'] == 'tests.contrib.django.testapp.tasks.failing_task'

--- a/tests/contrib/celery/flask_tests.py
+++ b/tests/contrib/celery/flask_tests.py
@@ -19,7 +19,7 @@ def test_task_failure(flask_celery):
     error = apm_client.events[0]['errors'][0]
     assert error['culprit'] == 'tests.contrib.celery.flask_tests.failing_task'
     assert error['exception']['message'] == 'ValueError: foo'
-    assert error['handled'] is False
+    assert error['exception']['handled'] is False
 
     transaction = apm_client.events[1]['transactions'][0]
     assert transaction['name'] == 'tests.contrib.celery.flask_tests.failing_task'

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -99,8 +99,8 @@ def test_signal_integration(django_elasticapm_client):
     exc = event['exception']
     assert exc['type'] == 'ValueError'
     assert exc['message'] == u"ValueError: invalid literal for int() with base 10: 'hello'"
+    assert exc['handled'] is False
     assert event['culprit'] == 'tests.contrib.django.django_tests.test_signal_integration'
-    assert event['handled'] is False
 
 
 def test_view_exception(django_elasticapm_client, client):
@@ -113,8 +113,8 @@ def test_view_exception(django_elasticapm_client, client):
     exc = event['exception']
     assert exc['type'] == 'Exception'
     assert exc['message'] == 'Exception: view exception'
+    assert exc['handled'] is False
     assert event['culprit'] == 'tests.contrib.django.testapp.views.raise_exc'
-    assert event['handled'] is False
 
 
 def test_view_exception_debug(django_elasticapm_client, client):
@@ -287,8 +287,8 @@ def test_request_middleware_exception(django_elasticapm_client, client):
         exc = event['exception']
         assert exc['type'] == 'ImportError'
         assert exc['message'] == 'ImportError: request'
+        assert exc['handled'] is False
         assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_request'
-        assert event['handled'] is False
 
 
 def test_response_middlware_exception(django_elasticapm_client, client):
@@ -306,8 +306,8 @@ def test_response_middlware_exception(django_elasticapm_client, client):
         exc = event['exception']
         assert exc['type'] == 'ImportError'
         assert exc['message'] == 'ImportError: response'
+        assert exc['handled'] is False
         assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_response'
-        assert event['handled'] is False
 
 
 def test_broken_500_handler_with_middleware(django_elasticapm_client, client):
@@ -333,8 +333,8 @@ def test_broken_500_handler_with_middleware(django_elasticapm_client, client):
         exc = event['exception']
         assert exc['type'] == 'ValueError'
         assert exc['message'] == 'ValueError: handler500'
+        assert exc['handled'] is False
         assert event['culprit'] == 'tests.contrib.django.testapp.urls.handler500'
-        assert event['handled'] is False
 
 
 def test_view_middleware_exception(django_elasticapm_client, client):
@@ -350,8 +350,8 @@ def test_view_middleware_exception(django_elasticapm_client, client):
         exc = event['exception']
         assert exc['type'] == 'ImportError'
         assert exc['message'] == 'ImportError: view'
+        assert exc['handled'] is False
         assert event['culprit'] == 'tests.contrib.django.testapp.middleware.process_view'
-        assert event['handled'] is False
 
 
 def test_exclude_modules_view(django_elasticapm_client, client):

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -18,8 +18,8 @@ def test_error_handler(flask_apm_client):
     exc = event['exception']
     assert exc['type'] == 'ValueError'
     assert exc['message'] == 'ValueError: hello world'
+    assert exc['handled'] is False
     assert event['culprit'] == 'tests.contrib.flask.fixtures.an_error'
-    assert event['handled'] is False
 
 
 def test_get(flask_apm_client):

--- a/tests/contrib/twisted/tests.py
+++ b/tests/contrib/twisted/tests.py
@@ -16,4 +16,4 @@ def test_twisted_log_observer(elasticapm_client):
 
     cli_event = elasticapm_client.events.pop(0)['errors'][0]
     assert cli_event['exception']['type'] == 'ZeroDivisionError'
-    assert cli_event['handled'] is False
+    assert cli_event['exception']['handled'] is False

--- a/tests/contrib/zerorpc/zeropc_tests.py
+++ b/tests/contrib/zerorpc/zeropc_tests.py
@@ -48,4 +48,4 @@ def test_zerorpc_middleware_with_reqrep(elasticapm_client):
     frames = exc['stacktrace']
     assert frames[0]['function'] == 'choice'
     assert frames[0]['module'] == 'random'
-    assert elasticapm_client.events[0]['errors'][0]['handled'] is False
+    assert elasticapm_client.events[0]['errors'][0]['exception']['handled'] is False


### PR DESCRIPTION
the attribute was mistakenly set on the `error` object instead of the `error.exception` object