### PR TITLE
use `timeit.default_timer` as timer function

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/apm-agent-python/compare/v1.0.0\...master[Check the H
  * added `transaction_max_spans` setting to limit the amount of spans that are recorded per transaction ({pull}127[#127])
  * added configuration options to limit captured local variables to a certain length ({pull}130[#130])
  * added options for configuring the amount of context lines that are captured with each frame ({pull}136[#136])
+ * switched to `time.perf_counter` as timing function on Python 3 ({pull}138[#138])
  * BREAKING: Several settings and APIs have been renamed ({pull}111[#111], {pull}119[#119]):
  ** The decorator for custom instrumentation, `elasticapm.trace`, is now `elasticapm.capture_span`
  ** The setting `traces_send_frequency` has been renamed to `transaction_send_frequency`.

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -4,7 +4,7 @@ import logging
 import random
 import re
 import threading
-import time
+import timeit
 import uuid
 
 from elasticapm.conf import constants
@@ -18,7 +18,8 @@ thread_local = threading.local()
 thread_local.transaction = None
 
 
-_time_func = time.time
+_time_func = timeit.default_timer
+
 
 TAG_RE = re.compile('^[^.*\"]+$')
 


### PR DESCRIPTION
on Python 3, this is `timer.perf_counter`, which is preferable
to `time.time` due to it being monotonic.

on Python 2, it's either `time.clock` (Windows) or `time.time`
(everywhere else).