### PR TITLE
truncate strings that are stored as keywords in ES (#159)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@
 https://github.com/elastic/apm-agent-python/compare/v2.0.0\...master[Check the HEAD diff]
 
  * fixed compatibility issue with aiohttp 3.0 ({pull}157[#157])
+ * Added truncation for fields that have a `maxLength` in the JSON Schema ({pull}159[#159])
 
 [[release-2.0.0]]
 [float]

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -21,7 +21,7 @@ from django.http import HttpRequest
 
 from elasticapm.base import Client
 from elasticapm.contrib.django.utils import iterate_with_template_sources
-from elasticapm.utils import compat, get_url_dict
+from elasticapm.utils import compat, encoding, get_url_dict
 from elasticapm.utils.module_import import import_string
 from elasticapm.utils.wsgi import get_environ, get_headers
 
@@ -80,11 +80,11 @@ class DjangoClient(Client):
                 else:
                     user_info['is_authenticated'] = bool(user.is_authenticated)
             if hasattr(user, 'id'):
-                user_info['id'] = user.id
+                user_info['id'] = encoding.keyword_field(user.id)
             if hasattr(user, 'get_username'):
-                user_info['username'] = user.get_username()
+                user_info['username'] = encoding.keyword_field(user.get_username())
             elif hasattr(user, 'username'):
-                user_info['username'] = user.username
+                user_info['username'] = encoding.keyword_field(user.username)
 
             if hasattr(user, 'email'):
                 user_info['email'] = user.email

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -14,7 +14,7 @@ import sys
 import uuid
 
 from elasticapm.utils import varmap
-from elasticapm.utils.encoding import shorten, to_unicode
+from elasticapm.utils.encoding import keyword_field, shorten, to_unicode
 from elasticapm.utils.stacks import (get_culprit, get_stack_info,
                                      iter_traceback_frames)
 
@@ -112,8 +112,8 @@ class Exception(BaseEvent):
             'culprit': culprit,
             'exception': {
                 'message': message,
-                'type': str(exc_type),
-                'module': str(exc_module),
+                'type': keyword_field(str(exc_type)),
+                'module': keyword_field(str(exc_module)),
                 'stacktrace': frames,
             }
         }
@@ -146,10 +146,10 @@ class Message(BaseEvent):
         message_data = {
             'id': str(uuid.uuid4()),
             'log': {
-                'level': level or 'error',
-                'logger_name': logger_name or '__root__',
+                'level': keyword_field(level or 'error'),
+                'logger_name': keyword_field(logger_name or '__root__'),
                 'message': message,
-                'param_message': param_message['message'],
+                'param_message': keyword_field(param_message['message']),
             }
         }
         if isinstance(data.get('stacktrace'), dict):

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -10,13 +10,7 @@ Large portions are
 """
 import os
 
-from elasticapm.utils import compat
-
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
-
+from elasticapm.utils import compat, encoding
 
 default_ports = {
     "https": 433,
@@ -76,19 +70,19 @@ def is_master_process():
 
 
 def get_url_dict(url):
-    scheme, netloc, path, params, query, fragment = urlparse.urlparse(url)
+    scheme, netloc, path, params, query, fragment = compat.urlparse.urlparse(url)
     if ':' in netloc:
         hostname, port = netloc.split(':')
     else:
         hostname, port = (netloc, None)
     url_dict = {
-        'full': url,
+        'full': encoding.keyword_field(url),
         'protocol': scheme + ':',
-        'hostname': hostname,
-        'pathname': path,
+        'hostname': encoding.keyword_field(hostname),
+        'pathname': encoding.keyword_field(path),
     }
     if port:
         url_dict['port'] = port
     if query:
-        url_dict['search'] = '?' + query
+        url_dict['search'] = encoding.keyword_field('?' + query)
     return url_dict

--- a/elasticapm/utils/encoding.py
+++ b/elasticapm/utils/encoding.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 elasticapm.utils.encoding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -13,6 +15,7 @@ import datetime
 import uuid
 from decimal import Decimal
 
+from elasticapm.conf.constants import KEYWORD_MAX_LENGTH
 from elasticapm.utils import compat
 
 PROTECTED_TYPES = compat.integer_types + (type(None), float, Decimal, datetime.datetime, datetime.date, datetime.time)
@@ -165,3 +168,9 @@ def shorten(var, list_length=50, string_length=200):
         # TODO: when we finish the above, we should also implement this for dicts
         var = list(var)[:list_length] + ['...', '(%d more elements)' % (len(var) - list_length,)]
     return var
+
+
+def keyword_field(string):
+    if not isinstance(string, compat.string_types) or len(string) <= KEYWORD_MAX_LENGTH:
+        return string
+    return string[:KEYWORD_MAX_LENGTH - 1] + u'…'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,6 +35,7 @@ class ValidatingWSGIApp(ContentServer):
     def __init__(self, **kwargs):
         super(ValidatingWSGIApp, self).__init__(**kwargs)
         self.payloads = []
+        self.responses = []
         self.skip_validate = False
 
     def __call__(self, environ, start_response):
@@ -61,6 +62,7 @@ class ValidatingWSGIApp(ContentServer):
         response.headers.clear()
         response.headers.extend(self.headers)
         response.data = content
+        self.responses.append({'code': code, 'content': content})
         return response(environ, start_response)
 
 


### PR DESCRIPTION
this should avoid schema errors for values that are too long

closes #156

closes #159