### PR TITLE
added 5 minute timeout to tests (#162)

### DIFF
--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -22,7 +22,7 @@ PYTHON_VERSION=${1} docker-compose run \
   -v "$(dirname $(pwd))":/app \
   --rm run_tests \
 	/bin/bash \
-  -c "./tests/scripts/run_tests.sh"
+  -c "timeout 5m ./tests/scripts/run_tests.sh"
 
 docker-compose down -v
 cd ..


### PR DESCRIPTION
this kills tests runs that hang for some reason and free up the Jenkins worker

closes #162