### PR TITLE
initial elasticsearch-py instrumentation support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ flake8:
 
 test:
 	if [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6|nightly|pypy3)$$ ]] ; then \
-	py.test -v $(PYTEST_ARGS); \
-	else py.test -v $(PYTEST_ARGS) --ignore=tests/asyncio; fi
+	py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER); \
+	else py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) --ignore=tests/asyncio; fi
 
 coverage: PYTEST_ARGS=--cov --cov-report xml:coverage.xml
 coverage: test

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import
+
+import json
+import logging
+
+import elasticapm
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+from elasticapm.utils import compat
+
+logger = logging.getLogger(__name__)
+
+
+class ElasticsearchIndicesIntrumentation(AbstractInstrumentedModule):
+    name = 'elasticsearch.index'
+
+    instrument_list = [
+        ("elasticsearch.client.indices", "IndicesClient.create"),
+        ("elasticsearch.client.indices", "IndicesClient.get"),
+        ("elasticsearch.client.indices", "IndicesClient.open"),
+        ("elasticsearch.client.indices", "IndicesClient.close"),
+        ("elasticsearch.client.indices", "IndicesClient.delete"),
+        ("elasticsearch.client.indices", "IndicesClient.exists"),
+        ("elasticsearch.client.indices", "IndicesClient.analyze"),
+        ("elasticsearch.client.indices", "IndicesClient.refresh"),
+        ("elasticsearch.client.indices", "IndicesClient.flush"),
+    ]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        cls_name, method_name = method.split('.', 1)
+        signature = '.'.join([instance.full_name, method_name])
+        with elasticapm.capture_span(signature, "db.elasticsearch.index", leaf=True):
+            return wrapped(*args, **kwargs)
+
+
+class ElasticsearchInstrumentation(AbstractInstrumentedModule):
+    name = 'elasticsearch'
+
+    # The positional arguments between Elasticsearch major versions do
+    # change some times, and are not discoverable at runtime due to
+    # a decorator hiding the real signatures. Unfortunately, this leaves
+    # us only with the option of keeping our own lookup table for the different
+    # versions
+    method_args = {
+        2: {
+            'count_percolate': ['index', 'doc_type', 'id', 'body', 'params'],
+            'create': ['index', 'doc_type', 'body', 'id', 'params'],
+            'delete_script': ['lang', 'id', 'params'],
+            'delete_template': ['id', 'params'],
+            'field_stats': ['index', 'body', 'params'],
+            'get': ['index', 'id', 'doc_type', 'params'],
+            'get_script': ['lang', 'id', 'params'],
+            'mpercolate': ['body', 'index', 'doc_type', 'params'],
+            'percolate': ['index', 'doc_type', 'id', 'body', 'params'],
+            'put_script': ['lang', 'id', 'body', 'params'],
+            'search_exists': ['index', 'doc_type', 'body', 'params'],
+            'suggest': ['body', 'index', 'params'],
+        },
+        5: {
+            'count_percolate': ['index', 'doc_type', 'id', 'body', 'params'],
+            'create': ['index', 'doc_type', 'id', 'body', 'params'],
+            'delete_script': ['lang', 'id', 'params'],
+            'delete_template': ['id', 'params'],
+            'field_stats': ['index', 'body', 'params'],
+            'get': ['index', 'id', 'doc_type', 'params'],
+            'get_script': ['lang', 'id', 'params'],
+            'mpercolate': ['body', 'index', 'doc_type', 'params'],
+            'percolate': ['index', 'doc_type', 'id', 'body', 'params'],
+            'put_script': ['lang', 'id', 'body', 'params'],
+            'suggest': ['body', 'index', 'params'],
+        },
+        6: {
+            'create': ['index', 'doc_type', 'id', 'body', 'params'],
+            'delete_script': ['id', 'params'],
+            'get': ['index', 'doc_type', 'id', 'params'],
+            'get_script': ['id', 'params'],
+            'put_script': ['id', 'body', 'context', 'params'],
+        },
+        'all': {
+            'bulk': ['body', 'index', 'doc_type', 'params'],
+            'clear_scroll': ['scroll_id', 'body', 'params'],
+            'count': ['index', 'doc_type', 'body', 'params'],
+            'delete': ['index', 'doc_type', 'id', 'params'],
+            'delete_by_query': ['index', 'body', 'doc_type', 'params'],
+            'exists': ['index', 'doc_type', 'id', 'params'],
+            'exists_source': ['index', 'doc_type', 'id', 'params'],
+            'explain': ['index', 'doc_type', 'id', 'body', 'params'],
+            'field_caps': ['index', 'body', 'params'],
+            'get_source': ['index', 'doc_type', 'id', 'params'],
+            'get_template': ['id', 'params'],
+            'index': ['index', 'doc_type', 'body', 'id', 'params'],
+            'info': ['params'],
+            'mget': ['body', 'index', 'doc_type', 'params'],
+            'msearch': ['body', 'index', 'doc_type', 'params'],
+            'msearch_template': ['body', 'index', 'doc_type', 'params'],
+            'mtermvectors': ['index', 'doc_type', 'body', 'params'],
+            'ping': ['params'],
+            'put_template': ['id', 'body', 'params'],
+            'reindex': ['body', 'params'],
+            'reindex_rethrottle': ['task_id', 'params'],
+            'render_search_template': ['id', 'body', 'params'],
+            'scroll': ['scroll_id', 'body', 'params'],
+            'search': ['index', 'doc_type', 'body', 'params'],
+            'search_shards': ['index', 'doc_type', 'params'],
+            'search_template': ['index', 'doc_type', 'body', 'params'],
+            'termvectors': ['index', 'doc_type', 'id', 'body', 'params'],
+            'update': ['index', 'doc_type', 'id', 'body', 'params'],
+            'update_by_query': ['index', 'doc_type', 'body', 'params'],
+        }
+    }
+
+    query_methods = ('search', 'count', 'delete_by_query')
+
+    instrument_list = [
+        ("elasticsearch.client", "Elasticsearch.ping"),
+        ("elasticsearch.client", "Elasticsearch.info"),
+        ("elasticsearch.client", "Elasticsearch.create"),
+        ("elasticsearch.client", "Elasticsearch.index"),
+        ("elasticsearch.client", "Elasticsearch.count"),
+        ("elasticsearch.client", "Elasticsearch.delete"),
+        ("elasticsearch.client", "Elasticsearch.delete_by_query"),
+        ("elasticsearch.client", "Elasticsearch.exists"),
+        ("elasticsearch.client", "Elasticsearch.exists_source"),
+        ("elasticsearch.client", "Elasticsearch.get"),
+        ("elasticsearch.client", "Elasticsearch.get_source"),
+        ("elasticsearch.client", "Elasticsearch.search"),
+        ("elasticsearch.client", "Elasticsearch.update"),
+
+        # TODO:
+        # ("elasticsearch.client", "Elasticsearch.update_by_query"),
+        # ("elasticsearch.client", "Elasticsearch.search_shards"),
+        # ("elasticsearch.client", "Elasticsearch.put_script"),
+        # ("elasticsearch.client", "Elasticsearch.get_script"),
+        # ("elasticsearch.client", "Elasticsearch.delete_script"),
+        # ("elasticsearch.client", "Elasticsearch.put_template"),
+        # ("elasticsearch.client", "Elasticsearch.get_template"),
+        # ("elasticsearch.client", "Elasticsearch.explain"),
+        # ("elasticsearch.client", "Elasticsearch.termvectors"),
+        # ("elasticsearch.client", "Elasticsearch.mtermvectors"),
+    ]
+
+    def __init__(self):
+        super(ElasticsearchInstrumentation, self).__init__()
+        try:
+            from elasticsearch import VERSION
+            self.version = VERSION[0]
+        except ImportError:
+            self.version = None
+
+    def instrument(self):
+        if self.version and not 2 <= self.version < 7:
+            logger.debug("Instrumenting version %s of Elasticsearch is not supported by Elastic APM", self.version)
+            return
+        super(ElasticsearchInstrumentation, self).instrument()
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        cls_name, method_name = method.split('.', 1)
+        positional_args = (self.method_args['all'].get(method_name) or
+                           self.method_args[self.version].get(method_name) or [])
+        signature = ['ES', method_name]
+        for arg_name in ('index', 'doc_type', 'id'):
+            if arg_name in kwargs:
+                arg_value = kwargs[arg_name]
+            else:
+                try:
+                    arg_value = args[positional_args.index(arg_name)]
+                    if isinstance(arg_value, (list, tuple)):
+                        arg_value = ','.join(arg_value)
+                except (IndexError, ValueError):
+                    # ValueError is raised if this method doesn't have a position
+                    # argument with arg_value
+                    # IndexError is raised if the method was called without this
+                    # positional argument
+                    arg_value = None
+            if arg_value:
+                if isinstance(arg_value, (list, tuple)):
+                    arg_value = ','.join(compat.text_type(v) for v in arg_value)
+                signature.append('='.join((arg_name, compat.text_type(arg_value))))
+        body = kwargs.get('body')
+        if not body:
+            try:
+                body = args[positional_args.index('body')]
+            except (IndexError, ValueError):
+                pass
+        context = {'db': {'type': 'elasticsearch'}}
+        if method_name in self.query_methods:
+            query = []
+            # using both q AND body is allowed in some API endpoints / ES versions,
+            # but not in others. We simply capture both if they are there so the
+            # user can see it.
+            if 'q' in kwargs:
+                query.append('q=' + kwargs['q'])
+            if isinstance(body, dict) and 'query' in body:
+                query.append(json.dumps(body['query']))
+            context['db']['statement'] = '\n\n'.join(query)
+        if method_name == 'update':
+            if isinstance(body, dict) and 'script' in body:
+                context['db']['statement'] = json.dumps(body)
+        with elasticapm.capture_span(' '.join(signature), "db.elasticsearch", context, leaf=True):
+            return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -16,6 +16,7 @@ _cls_register = {
     'elasticapm.instrumentation.packages.requests.RequestsInstrumentation',
     'elasticapm.instrumentation.packages.sqlite.SQLiteInstrumentation',
     'elasticapm.instrumentation.packages.urllib3.Urllib3Instrumentation',
+    'elasticapm.instrumentation.packages.elasticsearch.ElasticsearchInstrumentation',
 
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateInstrumentation',
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation',

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ isort_ignore=
     elasticapm/contrib/asyncio/client.py
 markers =
     integrationtest: mark a test as integration test that accesses a service (like postgres, mongodb etc.)
+    elasticsearch: mark a test as elasticsearch test
 
 [isort]
 line_length=80

--- a/tests/.jenkins_framework.yml
+++ b/tests/.jenkins_framework.yml
@@ -8,3 +8,6 @@ FRAMEWORK:
   - flask-0.10
   - flask-0.11
   - flask-0.12
+  - elasticsearch-2
+  - elasticsearch-5
+  - elasticsearch-6

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -34,6 +34,45 @@ services:
     ports:
       - "6379:6379"
 
+  elasticsearch6:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata6:/usr/share/elasticsearch/data
+
+  elasticsearch5:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata5:/usr/share/elasticsearch/data
+
+  elasticsearch2:
+    image: elasticsearch:2
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata2:/usr/share/elasticsearch/data
+
   run_tests:
     image: apm-agent-python:${PYTHON_VERSION}
     environment:
@@ -44,6 +83,9 @@ services:
       POSTGRES_DB: 'elasticapm_test'
       POSTGRES_HOST: 'postgres'
       POSTGRES_PORT: '5432'
+      ES_6_URL: 'http://elasticsearch6:9200'
+      ES_5_URL: 'http://elasticsearch5:9200'
+      ES_2_URL: 'http://elasticsearch2:9200'
     depends_on:
       postgres:
         condition: service_healthy
@@ -59,4 +101,10 @@ volumes:
   pypgdata:
     driver: local
   pymongodata:
+    driver: local
+  pyesdata6:
+    driver: local
+  pyesdata5:
+    driver: local
+  pyesdata2:
     driver: local

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -1,0 +1,325 @@
+import pytest  # isort:skip
+pytest.importorskip("elasticsearch")  # isort:skip
+
+import os
+
+from elasticsearch import VERSION as ES_VERSION
+from elasticsearch import Elasticsearch
+
+pytestmark = pytest.mark.elasticsearch
+
+
+@pytest.fixture
+def elasticsearch(request):
+    """Elasticsearch client fixture."""
+    client = Elasticsearch(hosts=os.environ['ES_URL'])
+    yield client
+    client.indices.delete(index='*')
+
+
+@pytest.mark.integrationtest
+def test_ping(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.ping()
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES ping'
+    assert span.type == 'db.elasticsearch'
+
+
+@pytest.mark.integrationtest
+def test_info(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.info()
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES info'
+    assert span.type == 'db.elasticsearch'
+
+
+@pytest.mark.integrationtest
+def test_create(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    if ES_VERSION[0] < 5:
+        r1 = elasticsearch.create('tweets', 'doc', {'user': 'kimchy', 'text': 'hola'}, 1)
+    else:
+        r1 = elasticsearch.create('tweets', 'doc', 1, body={'user': 'kimchy', 'text': 'hola'})
+    r2 = elasticsearch.create(index='tweets', doc_type='doc', id=2, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for i, span in enumerate(transaction_obj.spans):
+        assert span.name == 'ES create index=tweets doc_type=doc id=' + str(i + 1)
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_index(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.index('tweets', 'doc', {'user': 'kimchy', 'text': 'hola'})
+    r2 = elasticsearch.index(index='tweets', doc_type='doc', body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES index index=tweets doc_type=doc'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_exists(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    assert elasticsearch.exists('tweets', 'doc', 1) is True
+    assert elasticsearch.exists(index='tweets', doc_type='doc', id=1) is True
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES exists index=tweets doc_type=doc id=1'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_exists(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.exists(id=1, index='tweets', doc_type='doc')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES exists index=tweets doc_type=doc id=1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_exists_source(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    assert elasticsearch.exists_source('tweets', 'doc', 1) is True
+    assert elasticsearch.exists_source(index='tweets', doc_type='doc', id=1) is True
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES exists_source index=tweets doc_type=doc id=1'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_get(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    if ES_VERSION[0] >= 6:
+        r1 = elasticsearch.get('tweets', 'doc', 1)
+    else:
+        r1 = elasticsearch.get('tweets', 1, 'doc')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    for r in (r1, r2):
+        assert r['found']
+        assert r['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES get index=tweets doc_type=doc id=1'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_get_source(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.get_source('tweets', 'doc', 1)
+    r2 = elasticsearch.get_source(index='tweets', doc_type='doc', id=1)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    for r in (r1, r2):
+        assert r == {'user': 'kimchy', 'text': 'hola'}
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES get_source index=tweets doc_type=doc id=1'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_update_script(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.update('tweets', 'doc', 1, {'script': "ctx._source.text = 'adios'"}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    assert r1['result'] == 'updated'
+    assert r2['_source'] == {'user': 'kimchy', 'text': 'adios'}
+    assert len(transaction_obj.spans) == 1
+
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES update index=tweets doc_type=doc id=1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"script": "ctx._source.text = \'adios\'"}'
+
+
+@pytest.mark.integrationtest
+def test_update_document(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.update('tweets', 'doc', 1, {'doc': {'text': 'adios'}}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    assert r2['_source'] == {'user': 'kimchy', 'text': 'adios'}
+    assert len(transaction_obj.spans) == 1
+
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES update index=tweets doc_type=doc id=1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_search_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.search(body=search_query)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES search'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_search_querystring(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = 'user:kimchy'
+    result = elasticsearch.search(q=search_query, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES search index=tweets'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=user:kimchy'
+
+
+@pytest.mark.integrationtest
+def test_search_both(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_querystring = 'text:hola'
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.search(body=search_query, q=search_querystring, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert len(result['hits']['hits']) == 1
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES search index=tweets'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=text:hola\n\n{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_count_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.count(body=search_query)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['count'] == 1
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES count'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_count_querystring(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = 'user:kimchy'
+    result = elasticsearch.count(q=search_query, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['count'] == 1
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES count index=tweets'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=user:kimchy'
+
+
+@pytest.mark.integrationtest
+def test_delete(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.delete(id=1, index='tweets', doc_type='doc')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES delete index=tweets doc_type=doc id=1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_delete_by_query_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.delete_by_query(index='tweets', body={"query": {"term": {"user": "kimchy"}}})
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES delete_by_query index=tweets'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_multiple_indexes_doctypes(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='users', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticsearch.create(index='snaps', doc_type='posts', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.search(index=['tweets','snaps'], doc_type=['users','posts'], q='user:kimchy')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES search index=tweets,snaps doc_type=users,posts'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'

--- a/tests/requirements/requirements-elasticsearch-2.txt
+++ b/tests/requirements/requirements-elasticsearch-2.txt
@@ -1,0 +1,2 @@
+elasticsearch>=2.0,<3.0
+-r requirements-base.txt

--- a/tests/requirements/requirements-elasticsearch-5.txt
+++ b/tests/requirements/requirements-elasticsearch-5.txt
@@ -1,0 +1,2 @@
+elasticsearch>=5.0,<6.0
+-r requirements-base.txt

--- a/tests/requirements/requirements-elasticsearch-6.txt
+++ b/tests/requirements/requirements-elasticsearch-6.txt
@@ -1,0 +1,2 @@
+elasticsearch>=6.0,<7.0
+-r requirements-base.txt

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 if [ $# -lt 2 ]; then
   echo "Arguments missing"
@@ -11,7 +11,17 @@ docker_pip_cache="/tmp/cache/pip"
 
 cd tests
 
+if [[ -e "./scripts/envs/${2}.sh" ]]
+then
+    source ./scripts/envs/${2}.sh
+fi
+
 echo ${1}
+
+if [[ -n $DOCKER_DEPS ]]
+then
+    PYTHON_VERSION=${1} docker-compose up -d ${DOCKER_DEPS}
+fi
 
 docker build --pull --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
@@ -24,7 +34,7 @@ PYTHON_VERSION=${1} docker-compose run \
 	/bin/bash \
   -c "timeout 5m ./tests/scripts/run_tests.sh"
 
-docker-compose down -v
+PYTHON_VERSION=${1} docker-compose down -v
 cd ..
 
 if [[ $CODECOV_TOKEN ]]; then

--- a/tests/scripts/envs/elasticsearch-2.sh
+++ b/tests/scripts/envs/elasticsearch-2.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_2_URL
+export DOCKER_DEPS="elasticsearch2"

--- a/tests/scripts/envs/elasticsearch-5.sh
+++ b/tests/scripts/envs/elasticsearch-5.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_5_URL
+export DOCKER_DEPS="elasticsearch5"

--- a/tests/scripts/envs/elasticsearch-6.sh
+++ b/tests/scripts/envs/elasticsearch-6.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_6_URL
+export DOCKER_DEPS="elasticsearch6"

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 pip install --user -U pip --cache-dir "${PIP_CACHE}"
 pip install --user -r "tests/requirements/requirements-${WEBFRAMEWORK}.txt" --cache-dir "${PIP_CACHE}"
@@ -8,8 +8,14 @@ pip install --user -r "tests/requirements/requirements-${WEBFRAMEWORK}.txt" --ca
 export PATH=/home/user/.local/bin:$PATH
 
 export PYTHON_VERSION=$(python -c "import platform; pv=platform.python_version_tuple(); print('pypy' + ('' if pv[0] == 2 else str(pv[0])) if platform.python_implementation() == 'PyPy' else '.'.join(map(str, platform.python_version_tuple()[:2])))")
-echo $(env)
-if [ "$WITH_COVERAGE" == "true" ]
+
+if [[ -e "./tests/scripts/envs/${WEBFRAMEWORK}.sh" ]]
+then
+    echo "sourcing ./tests/scripts/envs/${WEBFRAMEWORK}.sh"
+    source ./tests/scripts/envs/${WEBFRAMEWORK}.sh
+fi
+
+if [[ "$WITH_COVERAGE" == "true" ]]
 then
     make coverage
 else


### PR DESCRIPTION
This adds instrumentation for an initial set of methods of the
elasticsearch client library, as well as matrix tests for version
2, 5 and 6.

Due to the still relatively high download numbers for elasticsearch-py 2.x, we also added instrumentation for this version. Download counts between Jan 1-Apr 5 2018:

| Major Version | Download Count|
|---|---|
|6|871349|
|5|751404|
|2|237812|
|1|152074|
|0|22718|

For many methods, we'd like to show index/doctype/id if available. Due to the ordering of these arguments changing between different versions of elasticsearch-py, we need a way to look up the ordering of the positional arguments depending on the major version. Unfortunately, this can't be done via introspection due to the `query_params` decorator "hiding" this information (see https://github.com/elastic/elasticsearch-py/issues/736).