### PR TITLE
fix issue when message has `%` character, but no params (#175)

### DIFF
--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -140,8 +140,8 @@ class Message(BaseEvent):
     def capture(client, param_message=None, message=None, level=None, logger_name=None, **kwargs):
         if message:
             param_message = {'message': message}
-        params = param_message.get('params', ())
-        message = param_message['message'] % params
+        params = param_message.get('params')
+        message = param_message['message'] % params if params else param_message['message']
         data = kwargs.get('data', {})
         message_data = {
             'id': str(uuid.uuid4()),

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -363,6 +363,24 @@ def test_message_event(elasticapm_client):
     assert frame['vars']['a_long_local_list'][-1] == "(90 more elements)"
 
 
+def test_param_message_event(elasticapm_client):
+    elasticapm_client.capture('Message', param_message={'message': 'test %s %d', 'params': ('x', 1)})
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['log']['message'] == 'test x 1'
+    assert event['log']['param_message'] == 'test %s %d'
+
+
+def test_message_with_percent(elasticapm_client):
+    elasticapm_client.capture('Message', message='This works 100% of the time')
+
+    assert len(elasticapm_client.events) == 1
+    event = elasticapm_client.events.pop(0)['errors'][0]
+    assert event['log']['message'] == 'This works 100% of the time'
+    assert event['log']['param_message'] == 'This works 100% of the time'
+
+
 def test_logger(elasticapm_client):
     elasticapm_client.capture('Message', message='test', logger_name='test')
 


### PR DESCRIPTION
closes #171
closes #175