### PR TITLE
fix an issue in boto3 instrumentation with nonstandard endpoint URLs

### DIFF
--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -18,7 +18,10 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
 
         target_endpoint = instance._endpoint.host
         parsed_url = urlparse.urlparse(target_endpoint)
-        service, region, _ = parsed_url.hostname.split('.', 2)
+        if '.' in parsed_url.hostname:
+            service, region = parsed_url.hostname.split('.', 2)[:2]
+        else:
+            service, region = parsed_url.hostname, None
 
         signature = '{}:{}'.format(service, operation_name)
         extra_data = {

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -1,7 +1,7 @@
 import boto3
 import mock
 
-from elasticapm.traces import capture_span
+from elasticapm.instrumentation.packages.botocore import BotocoreInstrumentation
 
 
 @mock.patch("botocore.endpoint.Endpoint.make_request")
@@ -11,14 +11,32 @@ def test_botocore_instrumentation(mock_make_request, elasticapm_client):
     mock_make_request.return_value = (mock_response, {})
 
     elasticapm_client.begin_transaction("transaction.test")
-    with capture_span("test_pipeline", "test"):
-        session = boto3.Session(aws_access_key_id='foo',
-                                aws_secret_access_key='bar',
-                                region_name='us-west-2')
-        ec2 = session.client('ec2')
-        ec2.describe_instances()
-    elasticapm_client.end_transaction("MyView")
+    session = boto3.Session(aws_access_key_id='foo',
+                            aws_secret_access_key='bar',
+                            region_name='us-west-2')
+    ec2 = session.client('ec2')
+    ec2.describe_instances()
+    transaction = elasticapm_client.end_transaction("MyView")
+    span = transaction.spans[0]
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
-    spans = transactions[0]['spans']
-    assert 'ec2:DescribeInstances' in map(lambda x: x['name'], spans)
+    assert span.name == 'ec2:DescribeInstances'
+    assert span.context['service'] == 'ec2'
+    assert span.context['region'] == 'us-west-2'
+    assert span.context['operation'] == 'DescribeInstances'
+
+
+
+def test_nonstandard_endpoint_url(elasticapm_client):
+    instrument = BotocoreInstrumentation()
+    elasticapm_client.begin_transaction('test')
+    module, method = BotocoreInstrumentation.instrument_list[0]
+    instance = mock.Mock(_endpoint=mock.Mock(host='https://example'))
+    instrument.call(module, method, lambda *args, **kwargs: None, instance,
+                    ('DescribeInstances',), {})
+    transaction = elasticapm_client.end_transaction('test', 'test')
+    span = transaction.spans[0]
+
+    assert span.name == 'example:DescribeInstances'
+    assert span.context['service'] == 'example'
+    assert span.context['region'] is None
+    assert span.context['operation'] == 'DescribeInstances'


### PR DESCRIPTION
Specifically, this handles the case where the endpoint has no dots

closes #176