### PR TITLE
check if `os.getppid` is available before using it

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -374,7 +374,7 @@ class Client(object):
     def get_process_info(self):
         return {
             'pid': os.getpid(),
-            'ppid': os.getppid(),
+            'ppid': os.getppid() if hasattr(os, 'getppid') else None,
             'argv': sys.argv,
             'title': None,  # Note: if we implement this, the value needs to be wrapped with keyword_field
         }


### PR DESCRIPTION
in Windows and Python 2.7, `os.getppid` is not available