### PR TITLE
Remove Inc from Elastic name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,4 +33,4 @@ License
 BSD-3-Clause
 
 
-Made with ♥️ and ☕️ by Elastic, Inc. and our community.
+Made with ♥️ and ☕️ by Elastic and our community.


### PR DESCRIPTION
The Elastic company isn't called `Elastic, Inc.` so I took the liberty to clean this up - hope it's ok 😅 If we wanted to call it by the legal name it should be `Elasticsearch BV`, but I don't see the benefit of that in a line like this