### PR TITLE
initial elasticsearch-py instrumentation support, alternative implementation

### DIFF
--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -1,0 +1,144 @@
+from __future__ import absolute_import
+
+import json
+import logging
+
+import elasticapm
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+
+logger = logging.getLogger(__name__)
+
+
+API_METHOD_KEY_NAME = '__elastic_apm_api_method_name'
+BODY_REF_NAME = '__elastic_apm_body_ref'
+
+
+class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
+    name = 'elasticsearch_connection'
+
+    instrument_list = [
+        ("elasticsearch.connection.http_urllib3", "Urllib3HttpConnection.perform_request"),
+        ("elasticsearch.connection.http_requests", "RequestsHttpConnection.perform_request"),
+    ]
+
+    query_methods = (
+        'Elasticsearch.search',
+        'Elasticsearch.count',
+        'Elasticsearch.delete_by_query'
+    )
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        args_len = len(args)
+        http_method = args[0] if args_len else kwargs.get('method')
+        http_path = args[1] if args_len > 1 else kwargs.get('url')
+        params = args[2] if args_len > 2 else kwargs.get('params')
+        body = params.pop(BODY_REF_NAME, None)
+
+        api_method = params.pop(API_METHOD_KEY_NAME, None)
+
+        signature = 'ES %s %s' % (http_method, http_path)
+        context = {'db': {'type': 'elasticsearch'}}
+        if api_method in self.query_methods:
+            query = []
+            # using both q AND body is allowed in some API endpoints / ES versions,
+            # but not in others. We simply capture both if they are there so the
+            # user can see it.
+            if 'q' in params:
+                # 'q' is already encoded to a byte string at this point
+                query.append('q=' + params['q'].decode('utf-8'))
+            if isinstance(body, dict) and 'query' in body:
+                query.append(json.dumps(body['query']))
+            context['db']['statement'] = '\n\n'.join(query)
+        if api_method == 'Elasticsearch.update':
+            if isinstance(body, dict) and 'script' in body:
+                context['db']['statement'] = json.dumps(body)
+        # TODO: add instance.base_url to context once we agreed on a format
+        with elasticapm.capture_span(signature, "db.elasticsearch", extra=context, skip_frames=2, leaf=True):
+            return wrapped(*args, **kwargs)
+
+
+class ElasticsearchInstrumentation(AbstractInstrumentedModule):
+    name = 'elasticsearch'
+
+    body_positions = {
+        2: {
+            'count_percolate': 3,
+            'create': 2,
+            'field_stats': 1,
+            'mpercolate': 0,
+            'percolate': 3,
+            'put_script': 2,
+            'search_exists': 2,
+            'suggest': 0,
+        },
+        5: {
+            'count_percolate': 3,
+            'create': 3,
+            'field_stats': 1,
+            'mpercolate': 0,
+            'percolate': 3,
+            'put_script': 2,
+            'suggest': 0
+        },
+        6: {
+            'create': 3,
+            'put_script': 1
+        },
+        'all': {
+            'bulk': 0,
+            'clear_scroll': 1,
+            'count': 2,
+            'delete_by_query': 1,
+            'explain': 3,
+            'field_caps': 1,
+            'index': 2,
+            'mget': 0,
+            'msearch': 0,
+            'msearch_template': 0,
+            'mtermvectors': 2,
+            'put_template': 1,
+            'reindex': 0,
+            'render_search_template': 1,
+            'scroll': 1,
+            'search': 2,
+            'search_template': 2,
+            'termvectors': 3,
+            'update': 3,
+            'update_by_query': 2
+        },
+    }
+
+    instrument_list = [
+        ("elasticsearch.client", "Elasticsearch.delete_by_query"),
+        ("elasticsearch.client", "Elasticsearch.search"),
+        ("elasticsearch.client", "Elasticsearch.count"),
+        ("elasticsearch.client", "Elasticsearch.update"),
+    ]
+
+    def __init__(self):
+        super(ElasticsearchInstrumentation, self).__init__()
+        try:
+            from elasticsearch import VERSION
+            self.version = VERSION[0]
+        except ImportError:
+            self.version = None
+
+    def instrument(self):
+        if self.version and not 2 <= self.version < 7:
+            logger.debug("Instrumenting version %s of Elasticsearch is not supported by Elastic APM", self.version)
+            return
+        super(ElasticsearchInstrumentation, self).instrument()
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        params = kwargs.pop('params', {})
+        cls_name, method_name = method.split('.', 1)
+        body_pos = (self.body_positions['all'].get(method_name) or
+                    self.body_positions[self.version].get(method_name) or None)
+
+        # store a reference to the non-serialized body so we can use it in the connection layer
+        body = args[body_pos] if (body_pos is not None and len(args) > body_pos) else kwargs.get('body')
+        params[BODY_REF_NAME] = body
+        params[API_METHOD_KEY_NAME] = method
+
+        kwargs['params'] = params
+        return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -130,7 +130,8 @@ class ElasticsearchInstrumentation(AbstractInstrumentedModule):
         super(ElasticsearchInstrumentation, self).instrument()
 
     def call(self, module, method, wrapped, instance, args, kwargs):
-        params = kwargs.pop('params', {})
+        # make a copy of params in case the caller reuses them for some reason
+        params = kwargs.pop('params', {}).copy()
         cls_name, method_name = method.split('.', 1)
         body_pos = (self.body_positions['all'].get(method_name) or
                     self.body_positions[self.version].get(method_name) or None)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -16,6 +16,8 @@ _cls_register = {
     'elasticapm.instrumentation.packages.requests.RequestsInstrumentation',
     'elasticapm.instrumentation.packages.sqlite.SQLiteInstrumentation',
     'elasticapm.instrumentation.packages.urllib3.Urllib3Instrumentation',
+    'elasticapm.instrumentation.packages.elasticsearch.ElasticsearchConnectionInstrumentation',
+    'elasticapm.instrumentation.packages.elasticsearch.ElasticsearchInstrumentation',
 
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateInstrumentation',
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation',

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ markers =
     integrationtest: mark a test as integration test that accesses a service (like postgres, mongodb etc.)
     requests: mark a test as test of the requests library instrumentation
     boto3: mark a test as test of the boto3 library instrumentation
+    elasticsearch: mark a test as elasticsearch test
 
 [isort]
 line_length=80

--- a/tests/.jenkins_framework.yml
+++ b/tests/.jenkins_framework.yml
@@ -16,4 +16,6 @@ FRAMEWORK:
   - redis-newest
   - psycopg2-newest
   - memcached-newest
-
+  - elasticsearch-2
+  - elasticsearch-5
+  - elasticsearch-6

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -55,8 +55,60 @@ services:
     ports:
       - "6379:6379"
 
+  elasticsearch6:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata6:/usr/share/elasticsearch/data
+
+  elasticsearch5:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata5:/usr/share/elasticsearch/data
+
+  elasticsearch2:
+    image: elasticsearch:2
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "network.host="
+      - "transport.host=127.0.0.1"
+      - "http.host=0.0.0.0"
+      - "xpack.security.enabled=false"
+    volumes:
+      - pyesdata2:/usr/share/elasticsearch/data
+
   run_tests:
     image: apm-agent-python:${PYTHON_VERSION}
+    environment:
+      ES_6_URL: 'http://elasticsearch6:9200'
+      ES_5_URL: 'http://elasticsearch5:9200'
+      ES_2_URL: 'http://elasticsearch2:9200'
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mongodb:
+        condition: service_started
+      memcached:
+        condition: service_started
+      redis:
+        condition: service_started
 
 
 volumes:
@@ -69,4 +121,10 @@ volumes:
   pymongodata34:
     driver: local
   pymongodata36:
+    driver: local
+  pyesdata6:
+    driver: local
+  pyesdata5:
+    driver: local
+  pyesdata2:
     driver: local

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -100,15 +100,6 @@ services:
       ES_6_URL: 'http://elasticsearch6:9200'
       ES_5_URL: 'http://elasticsearch5:9200'
       ES_2_URL: 'http://elasticsearch2:9200'
-    depends_on:
-      postgres:
-        condition: service_healthy
-      mongodb:
-        condition: service_started
-      memcached:
-        condition: service_started
-      redis:
-        condition: service_started
 
 
 volumes:

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -1,0 +1,311 @@
+import pytest  # isort:skip
+pytest.importorskip("elasticsearch")  # isort:skip
+
+import os
+
+from elasticsearch import VERSION as ES_VERSION
+from elasticsearch import Elasticsearch
+
+pytestmark = pytest.mark.elasticsearch
+
+
+@pytest.fixture
+def elasticsearch(request):
+    """Elasticsearch client fixture."""
+    client = Elasticsearch(hosts=os.environ['ES_URL'])
+    yield client
+    client.indices.delete(index='*')
+
+
+@pytest.mark.integrationtest
+def test_ping(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.ping()
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES HEAD /'
+    assert span.type == 'db.elasticsearch'
+
+
+@pytest.mark.integrationtest
+def test_info(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.info()
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /'
+    assert span.type == 'db.elasticsearch'
+
+
+@pytest.mark.integrationtest
+def test_create(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    if ES_VERSION[0] < 5:
+        r1 = elasticsearch.create('tweets', 'doc', {'user': 'kimchy', 'text': 'hola'}, 1)
+    else:
+        r1 = elasticsearch.create('tweets', 'doc', 1, body={'user': 'kimchy', 'text': 'hola'})
+    r2 = elasticsearch.create(index='tweets', doc_type='doc', id=2, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for i, span in enumerate(transaction_obj.spans):
+        if ES_VERSION[0] >= 5:
+            assert span.name == 'ES PUT /tweets/doc/%d/_create' % (i + 1)
+        else:
+            assert span.name == 'ES PUT /tweets/doc/%d' % (i + 1)
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_index(instrument, elasticapm_client, elasticsearch):
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.index('tweets', 'doc', {'user': 'kimchy', 'text': 'hola'})
+    r2 = elasticsearch.index(index='tweets', doc_type='doc', body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES POST /tweets/doc'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_exists(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.exists(id=1, index='tweets', doc_type='doc')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES HEAD /tweets/doc/1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_exists_source(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    assert elasticsearch.exists_source('tweets', 'doc', 1) is True
+    assert elasticsearch.exists_source(index='tweets', doc_type='doc', id=1) is True
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES HEAD /tweets/doc/1/_source'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_get(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    if ES_VERSION[0] >= 6:
+        r1 = elasticsearch.get('tweets', 'doc', 1)
+    else:
+        r1 = elasticsearch.get('tweets', 1, 'doc')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    for r in (r1, r2):
+        assert r['found']
+        assert r['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES GET /tweets/doc/1'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_get_source(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.get_source('tweets', 'doc', 1)
+    r2 = elasticsearch.get_source(index='tweets', doc_type='doc', id=1)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+
+    for r in (r1, r2):
+        assert r == {'user': 'kimchy', 'text': 'hola'}
+
+    assert len(transaction_obj.spans) == 2
+
+    for span in transaction_obj.spans:
+        assert span.name == 'ES GET /tweets/doc/1/_source'
+        assert span.type == 'db.elasticsearch'
+        assert span.context['db']['type'] == 'elasticsearch'
+        assert 'statement' not in span.context['db']
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_update_script(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.update('tweets', 'doc', 1, {'script': "ctx._source.text = 'adios'"}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    assert r1['result'] == 'updated'
+    assert r2['_source'] == {'user': 'kimchy', 'text': 'adios'}
+    assert len(transaction_obj.spans) == 1
+
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES POST /tweets/doc/1/_update'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"script": "ctx._source.text = \'adios\'"}'
+
+
+@pytest.mark.integrationtest
+def test_update_document(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    r1 = elasticsearch.update('tweets', 'doc', 1, {'doc': {'text': 'adios'}}, refresh=True)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    r2 = elasticsearch.get(index='tweets', doc_type='doc', id=1)
+    assert r2['_source'] == {'user': 'kimchy', 'text': 'adios'}
+    assert len(transaction_obj.spans) == 1
+
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES POST /tweets/doc/1/_update'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert 'statement' not in span.context['db']
+
+
+@pytest.mark.integrationtest
+def test_search_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.search(body=search_query)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /_search'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_search_querystring(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = 'user:kimchy'
+    result = elasticsearch.search(q=search_query, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /tweets/_search'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=user:kimchy'
+
+
+@pytest.mark.integrationtest
+def test_search_both(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_querystring = 'text:hola'
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.search(body=search_query, q=search_querystring, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert len(result['hits']['hits']) == 1
+    assert result['hits']['hits'][0]['_source'] == {'user': 'kimchy', 'text': 'hola'}
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /tweets/_search'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=text:hola\n\n{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_count_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = {"query": {"term": {"user": "kimchy"}}}
+    result = elasticsearch.count(body=search_query)
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['count'] == 1
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /_count'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_count_querystring(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    search_query = 'user:kimchy'
+    result = elasticsearch.count(q=search_query, index='tweets')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert result['count'] == 1
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /tweets/_count'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == 'q=user:kimchy'
+
+
+@pytest.mark.integrationtest
+def test_delete(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.delete(id=1, index='tweets', doc_type='doc')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES DELETE /tweets/doc/1'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+
+
+@pytest.mark.skipif(ES_VERSION[0] < 5, reason='unsupported method')
+@pytest.mark.integrationtest
+def test_delete_by_query_body(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='doc', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.delete_by_query(index='tweets', body={"query": {"term": {"user": "kimchy"}}})
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES POST /tweets/_delete_by_query'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'
+    assert span.context['db']['statement'] == '{"term": {"user": "kimchy"}}'
+
+
+@pytest.mark.integrationtest
+def test_multiple_indexes_doctypes(instrument, elasticapm_client, elasticsearch):
+    elasticsearch.create(index='tweets', doc_type='users', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticsearch.create(index='snaps', doc_type='posts', id=1, body={'user': 'kimchy', 'text': 'hola'}, refresh=True)
+    elasticapm_client.begin_transaction('test')
+    result = elasticsearch.search(index=['tweets','snaps'], doc_type=['users','posts'], q='user:kimchy')
+    transaction_obj = elasticapm_client.end_transaction('test', 'OK')
+    assert len(transaction_obj.spans) == 1
+    span = transaction_obj.spans[0]
+    assert span.name == 'ES GET /tweets,snaps/users,posts/_search'
+    assert span.type == 'db.elasticsearch'
+    assert span.context['db']['type'] == 'elasticsearch'

--- a/tests/requirements/requirements-elasticsearch-2.txt
+++ b/tests/requirements/requirements-elasticsearch-2.txt
@@ -1,0 +1,2 @@
+elasticsearch>=2.0,<3.0
+-r requirements-base.txt

--- a/tests/requirements/requirements-elasticsearch-5.txt
+++ b/tests/requirements/requirements-elasticsearch-5.txt
@@ -1,0 +1,2 @@
+elasticsearch>=5.0,<6.0
+-r requirements-base.txt

--- a/tests/requirements/requirements-elasticsearch-6.txt
+++ b/tests/requirements/requirements-elasticsearch-6.txt
@@ -1,0 +1,2 @@
+elasticsearch>=6.0,<7.0
+-r requirements-base.txt

--- a/tests/scripts/envs/elasticsearch-2.sh
+++ b/tests/scripts/envs/elasticsearch-2.sh
@@ -1,3 +1,5 @@
 export PYTEST_MARKER="-m elasticsearch"
-export ES_URL=$ES_2_URL
+export ES_URL="http://elasticsearch2:9200"
 export DOCKER_DEPS="elasticsearch2"
+export WAIT_FOR_HOST="elasticsearch2"
+export WAIT_FOR_PORT=9200

--- a/tests/scripts/envs/elasticsearch-2.sh
+++ b/tests/scripts/envs/elasticsearch-2.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_2_URL
+export DOCKER_DEPS="elasticsearch2"

--- a/tests/scripts/envs/elasticsearch-5.sh
+++ b/tests/scripts/envs/elasticsearch-5.sh
@@ -1,3 +1,5 @@
 export PYTEST_MARKER="-m elasticsearch"
-export ES_URL=$ES_5_URL
+export ES_URL="http://elasticsearch5:9200"
 export DOCKER_DEPS="elasticsearch5"
+export WAIT_FOR_HOST="elasticsearch5"
+export WAIT_FOR_PORT=9200

--- a/tests/scripts/envs/elasticsearch-5.sh
+++ b/tests/scripts/envs/elasticsearch-5.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_5_URL
+export DOCKER_DEPS="elasticsearch5"

--- a/tests/scripts/envs/elasticsearch-6.sh
+++ b/tests/scripts/envs/elasticsearch-6.sh
@@ -1,3 +1,5 @@
 export PYTEST_MARKER="-m elasticsearch"
-export ES_URL=$ES_6_URL
+export ES_URL="http://elasticsearch6:9200"
 export DOCKER_DEPS="elasticsearch6"
+export WAIT_FOR_HOST="elasticsearch6"
+export WAIT_FOR_PORT=9200

--- a/tests/scripts/envs/elasticsearch-6.sh
+++ b/tests/scripts/envs/elasticsearch-6.sh
@@ -1,0 +1,3 @@
+export PYTEST_MARKER="-m elasticsearch"
+export ES_URL=$ES_6_URL
+export DOCKER_DEPS="elasticsearch6"

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+
 export PATH=${HOME}/.local/bin:${PATH}
 python -m pip install --user -U pip --cache-dir "${PIP_CACHE}"
 python -m pip install --user -r "tests/requirements/requirements-${WEBFRAMEWORK}.txt" --cache-dir "${PIP_CACHE}"


### PR DESCRIPTION
This adds instrumentation for an initial set of methods of the
elasticsearch client library, as well as matrix tests for version
2, 5 and 6.

This is an alternative implementation to #169. It moves most of the
work onto a wrapper of `Connection.perform_request`. This has several
benefits:

 * we instrument everything by default, and can do more specific instrumentations
   for other some API methods (e.g. capture the query in the body for `search`)
 * we know which specific ES instance we connect to
 * if connections get retried, they appear as separate spans (more smartness, like
   storing retry information on the span will come later)

There is also one draw back: if we manage to instrument the Elasticsearch object,
but not the pooled Connection object, we could cause errors, because the former
instrumentation adds stuff into the `params` dict that the latter instrumentation
removes again. If the removal doesn't happen, things get messy. I haven't found
a workaround for this yet.