### PR TITLE
add default SECRET_KEY to test suite

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,6 +42,7 @@ def pytest_configure(config):
     if settings is not None and not settings.configured:
         import django
         settings_dict = dict(
+            SECRET_KEY='42',
             DATABASES={
                 'default': {
                     'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
https://github.com/django/django/pull/9876 removed the default
SECRET_KEY, leading to an error when we try to access it in the
tests