### PR TITLE
initial cassandra instrumentation

### DIFF
--- a/elasticapm/instrumentation/packages/cassandra.py
+++ b/elasticapm/instrumentation/packages/cassandra.py
@@ -1,0 +1,36 @@
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+from elasticapm.instrumentation.packages.dbapi2 import extract_signature
+from elasticapm.traces import capture_span
+from elasticapm.utils import compat
+
+
+class CassandraInstrumentation(AbstractInstrumentedModule):
+    name = 'cassandra'
+
+    instrument_list = [
+        ("cassandra.cluster", "Session.execute"),
+        ("cassandra.cluster", "Cluster.connect"),
+    ]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        name = self.get_wrapped_name(wrapped, instance, method)
+        context = None
+        if method == "Cluster.connect":
+            span_type = 'db.cassandra.connect'
+        else:
+            span_type = 'db.cassandra.query'
+            query = args[0] if args else kwargs.get('query')
+            if hasattr(query, 'query_string'):
+                query_str = query.query_string
+            elif hasattr(query, 'prepared_statement') and hasattr(query.prepared_statement, 'query'):
+                query_str = query.prepared_statement.query
+            elif isinstance(query, compat.string_types):
+                query_str = query
+            else:
+                query_str = None
+            if query_str:
+                name = extract_signature(query_str)
+                context = {'db': {"type": "sql", "statement": query_str}}
+
+        with capture_span(name, span_type, context):
+            return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -18,6 +18,7 @@ _cls_register = {
     'elasticapm.instrumentation.packages.urllib3.Urllib3Instrumentation',
     'elasticapm.instrumentation.packages.elasticsearch.ElasticsearchConnectionInstrumentation',
     'elasticapm.instrumentation.packages.elasticsearch.ElasticsearchInstrumentation',
+    'elasticapm.instrumentation.packages.cassandra.CassandraInstrumentation',
 
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateInstrumentation',
     'elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation',

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ multi_line_output=0
 known_standard_library=importlib,types,asyncio
 known_django=django
 known_first_party=elasticapm,tests
-known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,logbook,twisted,celery,zope,urllib3,redis,jinja2,requests,certifi,mock,jsonschema,werkzeug,pytest_localserver,psycopg2,async_timeout
+known_third_party=pytest,flask,aiohttp,urllib3_mock,webob,memcache,pymongo,boto3,cassandra,logbook,twisted,celery,zope,urllib3,redis,jinja2,requests,certifi,mock,jsonschema,werkzeug,pytest_localserver,psycopg2,async_timeout
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 

--- a/tests/.jenkins_framework.yml
+++ b/tests/.jenkins_framework.yml
@@ -19,3 +19,5 @@ FRAMEWORK:
   - elasticsearch-2
   - elasticsearch-5
   - elasticsearch-6
+  - cassandra-newest
+

--- a/tests/.jenkins_framework_full.yml
+++ b/tests/.jenkins_framework_full.yml
@@ -44,4 +44,7 @@ FRAMEWORK:
   - psycopg2-newest
   - memcached-1.51
   - memcached-newest
+  - cassandra-3.4
+  - cassandra-newest
+
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -17,6 +17,14 @@ services:
       timeout: 30s
       retries: 3
 
+  cassandra3:
+    image: cassandra:3
+    volumes:
+      - cassandradata3:/var/lib/cassandra
+    environment:
+      MAX_HEAP_SIZE: "1G"
+      HEAP_NEWSIZE: 400m
+
   mongodb30:
     image: mongo:3.0
     volumes:
@@ -118,4 +126,6 @@ volumes:
   pyesdata5:
     driver: local
   pyesdata2:
+    driver: local
+  cassandradata3:
     driver: local

--- a/tests/instrumentation/cassandra_tests.py
+++ b/tests/instrumentation/cassandra_tests.py
@@ -1,0 +1,106 @@
+import pytest  # isort:skip
+pytest.importorskip("cassandra")  # isort:skip
+
+import os
+
+from cassandra.cluster import Cluster
+from cassandra.query import SimpleStatement
+
+from elasticapm.instrumentation.packages.dbapi2 import extract_signature
+
+pytestmark = pytest.mark.cassandra
+
+
+@pytest.fixture()
+def cassandra_cluster():
+    cluster = Cluster(
+        [os.environ.get('CASSANDRA_HOST', 'localhost')]
+    )
+    yield cluster
+    del cluster
+
+
+@pytest.fixture()
+def cassandra_session(cassandra_cluster):
+    session = cassandra_cluster.connect()
+    session.execute("""
+        CREATE KEYSPACE testkeyspace
+        WITH REPLICATION = { 'class' : 'SimpleStrategy' ,'replication_factor' : 1 }
+    """)
+    session.execute('USE testkeyspace;')
+    session.execute('CREATE TABLE testkeyspace.users ( id UUID PRIMARY KEY, name text);')
+    yield session
+    session.execute('DROP KEYSPACE testkeyspace;')
+
+
+def test_cassandra_connect(instrument, elasticapm_client, cassandra_cluster):
+    elasticapm_client.begin_transaction("transaction.test")
+    sess = cassandra_cluster.connect()
+    elasticapm_client.end_transaction("test")
+
+    transactions = elasticapm_client.instrumentation_store.get_all()
+    span = transactions[0]['spans'][0]
+
+    assert span['type'] == 'db.cassandra.connect'
+    assert span['duration'] > 0
+    assert span['name'] == 'Cluster.connect'
+
+
+def test_select_query_string(instrument, cassandra_session, elasticapm_client):
+    elasticapm_client.begin_transaction("transaction.test")
+    cassandra_session.execute('SELECT name from users')
+    elasticapm_client.end_transaction("test")
+    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    span = transaction['spans'][0]
+    assert span['type'] == 'db.cassandra.query'
+    assert span['name'] == 'SELECT FROM users'
+    assert span['context'] == {'db': {'statement': 'SELECT name from users', 'type': 'sql'}}
+
+
+def test_select_simple_statement(instrument, cassandra_session, elasticapm_client):
+    statement = SimpleStatement('SELECT name from users')
+    elasticapm_client.begin_transaction("transaction.test")
+    cassandra_session.execute(statement)
+    elasticapm_client.end_transaction("test")
+    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    span = transaction['spans'][0]
+    assert span['type'] == 'db.cassandra.query'
+    assert span['name'] == 'SELECT FROM users'
+    assert span['context'] == {'db': {'statement': 'SELECT name from users', 'type': 'sql'}}
+
+
+def test_select_prepared_statement(instrument, cassandra_session, elasticapm_client):
+    prepared_statement = cassandra_session.prepare('SELECT name from users')
+    elasticapm_client.begin_transaction("transaction.test")
+    cassandra_session.execute(prepared_statement)
+    elasticapm_client.end_transaction("test")
+    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    span = transaction['spans'][0]
+    assert span['type'] == 'db.cassandra.query'
+    assert span['name'] == 'SELECT FROM users'
+    assert span['context'] == {'db': {'statement': 'SELECT name from users', 'type': 'sql'}}
+
+
+def test_signature_create_keyspace():
+    assert extract_signature(
+        "CREATE KEYSPACE testkeyspace WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 3 };"
+    ) == 'CREATE KEYSPACE'
+
+
+def test_signature_create_columnfamily():
+    assert extract_signature(
+        """CREATE COLUMNFAMILY users (
+  userid text PRIMARY KEY,
+  first_name text,
+  last_name text,
+  emails set<text>,
+  top_scores list<int>,
+  todo map<timestamp, text>
+);"""
+    ) == 'CREATE COLUMNFAMILY'
+
+
+def test_select_from_collection():
+    assert extract_signature(
+        "SELECT first, last FROM a.b WHERE id = 1;"
+    ) == "SELECT FROM a.b"

--- a/tests/requirements/requirements-cassandra-3.4.txt
+++ b/tests/requirements/requirements-cassandra-3.4.txt
@@ -1,0 +1,2 @@
+cassandra-driver>=3.4.0,<3.5.0
+-r requirements-base.txt

--- a/tests/requirements/requirements-cassandra-newest.txt
+++ b/tests/requirements/requirements-cassandra-newest.txt
@@ -1,0 +1,2 @@
+cassandra-driver>=3.14.0
+-r requirements-base.txt

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -42,11 +42,14 @@ then
     PYTHON_VERSION=${1} docker-compose up -d ${DOCKER_DEPS}
 fi
 
+# CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
+# as this can take several minutes
 docker build --pull --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e LOCAL_USER_ID=$UID \
   -e PYTHONDONTWRITEBYTECODE=1 -e WEBFRAMEWORK=$2 -e PIP_CACHE=${docker_pip_cache} \
   -e WITH_COVERAGE=true \
+  -e CASS_DRIVER_NO_EXTENSIONS=1 \
   -e PYTEST_JUNIT="--junitxml=/app/tests/python-agent-junit.xml" \
   -v ${pip_cache}:$(dirname ${docker_pip_cache}) \
   -v "$(dirname $(pwd))":/app \

--- a/tests/scripts/envs/cassandra-3.4.sh
+++ b/tests/scripts/envs/cassandra-3.4.sh
@@ -1,0 +1,6 @@
+export PYTEST_MARKER="-m cassandra"
+export DOCKER_DEPS="cassandra3"
+export CASSANDRA_HOST="cassandra3"
+export WAIT_FOR_HOST="cassandra3"
+export WAIT_FOR_PORT=9042
+export CASS_DRIVER_BUILD_CONCURRENCY=4

--- a/tests/scripts/envs/cassandra-newest.sh
+++ b/tests/scripts/envs/cassandra-newest.sh
@@ -1,0 +1,6 @@
+export PYTEST_MARKER="-m cassandra"
+export DOCKER_DEPS="cassandra3"
+export CASSANDRA_HOST="cassandra3"
+export WAIT_FOR_HOST="cassandra3"
+export WAIT_FOR_PORT=9042
+export CASS_DRIVER_BUILD_CONCURRENCY=4

--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -21,6 +21,12 @@ else
     fi
 fi
 
+export PATH=${HOME}/.local/bin:${PATH}
+python -m pip install --user -U pip --cache-dir "${PIP_CACHE}"
+python -m pip install --user -r "tests/requirements/requirements-${WEBFRAMEWORK}.txt" --cache-dir "${PIP_CACHE}"
+
+export PYTHON_VERSION=$(python -c "import platform; pv=platform.python_version_tuple(); print('pypy' + ('' if pv[0] == 2 else str(pv[0])) if platform.python_implementation() == 'PyPy' else '.'.join(map(str, platform.python_version_tuple()[:2])))")
+
 make update-json-schema
 
 if [[ -n $WAIT_FOR_HOST ]]


### PR DESCRIPTION
This instruments `Cluster.connect` and `Session.execute`.
The test matrix only includes version 3.4 and 3.14+, as earlier versions of the client [don't work](https://issues.apache.org/jira/browse/CASSANDRA-11850) on Python 2.7.11+.

Open questions:

- [ ] our SQL parser (used to get a significant span name from the query) seems to cope quite well with CQL. I'm not a huge Cassandra expert though, so it would be great if somebody with more expertise could contribute some interesting test cases (the more it doesn't look like SQL, the better).
 - [ ] there's also a commercial variant of Cassandra, called Datastax Enterprise. The parts of the driver that is interesting to us seems to be more or less identical to the open source cassandra driver, so theoretically we could just instrument it as well (by instrumenting the same methods in the `dse` namespace). However, we should probably test this. There is a docker image for DSE available, so we might be able to use that, if we deem it necessary to support DSE.