### PR TITLE
modified SQL tokenizer to not split on dot

### DIFF
--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -60,7 +60,8 @@ def _scan_for_table_with_tokens(tokens, keyword):
 
 
 def tokenize(sql):
-    return [t for t in re.split("(\W)", sql) if t != '']
+    # split on anything that is not a word character, excluding dots
+    return [t for t in re.split("([^\w.])", sql) if t != '']
 
 
 def scan(tokens):

--- a/tests/instrumentation/psycopg2_tests.py
+++ b/tests/instrumentation/psycopg2_tests.py
@@ -215,6 +215,12 @@ def test_multi_statement_sql():
     assert "CREATE TABLE" == actual
 
 
+def test_fully_qualified_table_name():
+    sql_statement = """SELECT a.b FROM db.schema.mytable as a;"""
+    actual = extract_signature(sql_statement)
+    assert "SELECT FROM db.schema.mytable" == actual
+
+
 @pytest.mark.integrationtest
 @pytest.mark.skipif(not has_postgres_configured, reason="PostgresSQL not configured")
 def test_psycopg2_register_type(postgres_connection, elasticapm_client):


### PR DESCRIPTION
The dot is used as separator for fully qualified table names in
Postgres, which can contain the database and schema name.