### PR TITLE
moved Twisted test to test matrix

### DIFF
--- a/tests/.jenkins_exclude.yml
+++ b/tests/.jenkins_exclude.yml
@@ -29,6 +29,9 @@ exclude:
     FRAMEWORK: flask-1.0
   - PYTHON_VERSION: python-3.3
     FRAMEWORK: flask-master
+  # Twisted
+  - PYTHON_VERSION: python-3.3
+    FRAMEWORK: twisted-18
   # requests
   - PYTHON_VERSION: python-3.3
     FRAMEWORK: requests-1.2

--- a/tests/.jenkins_framework.yml
+++ b/tests/.jenkins_framework.yml
@@ -5,6 +5,7 @@ FRAMEWORK:
   - django-2.0
   - flask-0.12
   - flask-1.0
+  - twisted-18
   - requests-newest
   - boto3-newest
   - pymongo-newest

--- a/tests/.jenkins_framework_full.yml
+++ b/tests/.jenkins_framework_full.yml
@@ -11,6 +11,10 @@ FRAMEWORK:
   - flask-0.11
   - flask-0.12
   - flask-1.0
+  - twisted-18
+  - twisted-17
+  - twisted-16
+  - twisted-15
   - requests-1.2
   - requests-2.0
   - requests-newest

--- a/tests/contrib/twisted/tests.py
+++ b/tests/contrib/twisted/tests.py
@@ -1,12 +1,16 @@
-from __future__ import absolute_import
+import pytest  # isort:skip
+pytest.importorskip("twisted")  # isort:skip
 
 from twisted.python.failure import Failure
 
 from elasticapm.contrib.twisted import LogObserver
 
+pytestmark = pytest.mark.twisted
+
 
 def test_twisted_log_observer(elasticapm_client):
     observer = LogObserver(client=elasticapm_client)
+    failure = None
     try:
         1 / 0
     except ZeroDivisionError:

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -34,7 +34,6 @@ mock
 msgpack-python
 pep8
 urllib3-mock
-Twisted
 pytz
 
 

--- a/tests/requirements/requirements-twisted-15.txt
+++ b/tests/requirements/requirements-twisted-15.txt
@@ -1,0 +1,2 @@
+Twisted>=15,<16
+-r requirements-base.txt

--- a/tests/requirements/requirements-twisted-16.txt
+++ b/tests/requirements/requirements-twisted-16.txt
@@ -1,0 +1,2 @@
+Twisted>=16,<17
+-r requirements-base.txt

--- a/tests/requirements/requirements-twisted-17.txt
+++ b/tests/requirements/requirements-twisted-17.txt
@@ -1,0 +1,2 @@
+Twisted>=17,<18
+-r requirements-base.txt

--- a/tests/requirements/requirements-twisted-18.txt
+++ b/tests/requirements/requirements-twisted-18.txt
@@ -1,0 +1,2 @@
+Twisted>=18.4,<19
+-r requirements-base.txt

--- a/tests/scripts/envs/twisted.sh
+++ b/tests/scripts/envs/twisted.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m twisted"


### PR DESCRIPTION
This became necessary after Twisted stopped supporting Python 3.3
in Twisted 18.4