### PR TITLE
updated pytest and dependencies to newest versions

### DIFF
--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -901,6 +901,7 @@ def test_django_logging_middleware(django_elasticapm_client, client):
     logger = logging.getLogger('logmiddleware')
     logger.handlers = []
     logger.addHandler(handler)
+    logger.level = logging.INFO
 
     with override_settings(**middleware_setting(django.VERSION,
                                                 ['elasticapm.contrib.django.middleware.LogMiddleware'])):

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -15,6 +15,7 @@ def logger(elasticapm_client):
     logger.handlers = []
     logger.addHandler(handler)
     logger.client = elasticapm_client
+    logger.level = logging.INFO
     return logger
 
 

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -1,8 +1,10 @@
-py==1.4.34
-pytest==3.2.4
-pytest-catchlog==1.2.2
-pytest-django==3.1.2
-coverage==4.4.2
+pytest==3.6.2
+py==1.5.3
+more-itertools==4.1.0
+pluggy==0.6.0
+pytest-django==3.3.2
+atomicwrites==1.1.5
+coverage==4.5.1
 pytest-cov==2.5.1
 pytest-localserver==0.4.1
 pytest-mock==1.6.3


### PR DESCRIPTION
with a bit of luck, this will resolve occasional test failures
due to a threading lock issue in pytest-catchlog
(which has been integrated into pytest proper)