### PR TITLE
use hardcoded logging names instead of `__name__`

### DIFF
--- a/elasticapm/contrib/django/handlers.py
+++ b/elasticapm/contrib/django/handlers.py
@@ -20,7 +20,7 @@ from django.conf import settings as django_settings
 
 from elasticapm.handlers.logging import LoggingHandler as BaseLoggingHandler
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('elasticapm.logging')
 
 
 class LoggingHandler(BaseLoggingHandler):

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -20,7 +20,7 @@ from elasticapm.utils.stacks import (get_culprit, get_stack_info,
 
 __all__ = ('BaseEvent', 'Exception', 'Message')
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('elasticapm.events')
 
 
 class BaseEvent(object):

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -12,7 +12,7 @@ from elasticapm.transport.http_base import (AsyncHTTPTransportBase,
                                             HTTPTransportBase)
 from elasticapm.utils import compat
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('elasticapm.transport.http')
 
 
 class Transport(HTTPTransportBase):


### PR DESCRIPTION
`__name__` is only the module name, so in e.g.
`elasticapm.intrumentation.packages.base`, the logger name would be `base`.

By prefixing all logger names with `elasticapm`, it should be easier to
filter/debug log messages from elasticapm itself.

Additionally, this PR also contains tests for some of our logging.