### PR TITLE
don't overwrite existing transaction name with None

### DIFF
--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -232,10 +232,10 @@ class TransactionsStore(object):
         transaction = get_transaction(clear=True)
         if transaction:
             transaction.end_transaction()
-            if self._should_ignore(transaction_name):
+            if transaction.name is None:
+                transaction.name = transaction_name if transaction_name is not None else ''
+            if self._should_ignore(transaction.name):
                 return
-            if not transaction.name:
-                transaction.name = transaction_name
             if transaction.result is None:
                 transaction.result = result
             self.add_transaction(transaction.to_dict())

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -455,6 +455,16 @@ def test_ignore_patterns(should_collect, elasticapm_client):
     assert transactions[0]['name'] == 'GET views.users'
 
 
+@pytest.mark.parametrize('elasticapm_client', [{'transactions_ignore_patterns': [
+        '^OPTIONS',
+        'views.api.v2'
+    ]}], indirect=True)
+def test_ignore_patterns_with_none_transaction_name(elasticapm_client):
+    elasticapm_client.begin_transaction("web")
+    t = elasticapm_client.end_transaction(None, 200)
+    assert t.name == ''
+
+
 @pytest.mark.parametrize('sending_elasticapm_client', [{'disable_send': True}], indirect=True)
 def test_disable_send(sending_elasticapm_client):
     assert sending_elasticapm_client.config.disable_send

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -247,3 +247,15 @@ def test_set_user_context_merge(elasticapm_client):
     transactions = elasticapm_client.instrumentation_store.get_all()
 
     assert transactions[0]['context']['user'] == {'username': 'foo', 'email': 'foo@example.com', 'id': 42}
+
+
+def test_transaction_name_none_is_converted_to_empty_string(elasticapm_client):
+    elasticapm_client.begin_transaction('test')
+    transaction = elasticapm_client.end_transaction(None, 200)
+    assert transaction.name == ''
+
+
+def test_transaction_without_name_result(elasticapm_client):
+    elasticapm_client.begin_transaction('test')
+    transaction = elasticapm_client.end_transaction()
+    assert transaction.name == ''


### PR DESCRIPTION
also, if `transaction.name` is set to `None`, convert it to empty string