### PR TITLE
test: remove deleted APM Server JSON schema files

### DIFF
--- a/tests/scripts/download_json_schema.sh
+++ b/tests/scripts/download_json_schema.sh
@@ -6,22 +6,20 @@ set -x
 basedir=$(dirname "$0")/..
 
 FILES=( \
-	"context.json" \
-	"errors/error.json" \
-	"errors/payload.json" \
-	"meta.json" \
-	"process.json" \
-	"request.json" \
-	"schema.json" \
-	"service.json" \
-	"sourcemaps/payload.json" \
-	"stacktrace_frame.json" \
-	"system.json" \
-	"transactions/mark.json" \
-	"transactions/payload.json" \
-	"transactions/span.json" \
-	"transactions/transaction.json" \
-	"user.json" \
+    "errors/error.json" \
+    "errors/payload.json" \
+    "sourcemaps/payload.json" \
+    "transactions/mark.json" \
+    "transactions/payload.json" \
+    "transactions/span.json" \
+    "transactions/transaction.json" \
+    "context.json" \
+    "process.json" \
+    "request.json" \
+    "service.json" \
+    "stacktrace_frame.json" \
+    "system.json" \
+    "user.json" \
 )
 
 mkdir -p ${basedir}/.schemacache/errors ${basedir}/.schemacache/transactions ${basedir}/.schemacache/sourcemaps


### PR DESCRIPTION
The removed files are:
- `meta.json`
- `schema.json`

I also changed tabs to spaces as you used a combination of both in the same file. So now it's aligned. I hope that was ok?