### PR TITLE
test: make curl fail if it can't download the APM Server schemas

### DIFF
--- a/tests/scripts/download_json_schema.sh
+++ b/tests/scripts/download_json_schema.sh
@@ -26,6 +26,6 @@ mkdir -p ${basedir}/.schemacache/errors ${basedir}/.schemacache/transactions ${b
 
 for i in "${FILES[@]}"; do
     output="${basedir}/.schemacache/${i}"
-    curl -s https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} --compressed > ${output}
+    curl -sf https://raw.githubusercontent.com/elastic/apm-server/master/docs/spec/${i} --compressed > ${output} || exit $?
 done
 echo "Done."


### PR DESCRIPTION
Previously it would just write the error message inside the file it was trying to download.

This makes the tests fail if curl encounters an error as opposed to silently continue.

~~This PR should therefore fail until #215 have been merged and this PR have been rebased.~~ update: rebased