### PR TITLE
docs: use shared attributes

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -53,7 +53,7 @@ except ValueError:
  * `exc_info`: A `(type, value, traceback)` tuple as returned by https://docs.python.org/3/library/sys.html#sys.exc_info[`sys.exc_info()`]. If not provided, it will be captured automatically.
  * `date`: A `datetime.datetime` object representing the occurrence time of the error. If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the 
-    https://www.elastic.co/guide/en/apm/server/current/error-api.html#error-context-schema[Context] schema definition.
+    {apm-server-ref}/error-api.html#error-context-schema[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
  * `handled`: A boolean to indicate if this exception was handled or not.
 
@@ -91,7 +91,7 @@ client.capture_message(param_message={
  * `date`: A `datetime.datetime` object representing the occurrence time of the error.
    If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the 
-    https://www.elastic.co/guide/en/apm/server/current/error-api.html#error-context-schema[Context] schema definition.
+    {apm-server-ref}/error-api.html#error-context-schema[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
 
 Returns the id of the message as a string.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,8 @@
 = APM Python Agent Reference
 
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 [[getting-started]]
 == Getting started
 
@@ -9,8 +12,8 @@ The Elastic APM Python agent sends performance metrics and error logs to the APM
 It has built-in support for Django and Flask performance metrics and error logging, as well as generic support of other WSGI frameworks for error logging.
 The agent is only one of multiple components you need to get started with APM. Please also have a look at the documentation for
 
- * https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server]
- * https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch]
+ * {apm-server-ref}/index.html[APM Server]
+ * {ref}/index.html[Elasticsearch]
 
 ifdef::env-github[]
 NOTE: For the best reading experience, please head over to this document at https://www.elastic.co/guide/en/apm/agent/python/current/index.html[elastic.co]


### PR DESCRIPTION
Use the shared attributes provided
by elastic/docs for linking to other
product docs, forums, etc.