### PR TITLE
implement support for asyncio [double-plus-WIP]

### DIFF
--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -25,5 +25,4 @@ from elasticapm.traces import set_transaction_name, set_user_context, tag  # noq
 from elasticapm.traces import set_transaction_result  # noqa: F401
 
 if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span #  noqa: F401
-
+    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -25,6 +25,6 @@ from elasticapm.traces import set_transaction_name, set_user_context, tag  # noq
 from elasticapm.traces import set_transaction_result  # noqa: F401
 
 if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span as capture_span # noqa: F401
+    from elasticapm.contrib.asyncio.traces import async_capture_span as capture_span #  noqa: F401
 else:
-    from elasticapm.traces import capture_span # noqa: F401
+    from elasticapm.traces import capture_span #  noqa: F401

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -8,6 +8,7 @@ Large portions are
 :copyright: (c) 2010 by the Sentry Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
+import sys
 
 __all__ = ("VERSION", "Client")
 
@@ -19,6 +20,11 @@ except Exception as e:
 from elasticapm.base import Client
 from elasticapm.conf import setup_logging  # noqa: F401
 from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
+from elasticapm.traces import set_context, set_custom_context  # noqa: F401
 from elasticapm.traces import set_transaction_name, set_user_context, tag  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
+
+if sys.version_info >= (3, 5):
+    from elasticapm.contrib.asyncio.traces import async_capture_span as capture_span # noqa: F401
+else:
+    from elasticapm.traces import capture_span # noqa: F401

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -20,11 +20,10 @@ except Exception as e:
 from elasticapm.base import Client
 from elasticapm.conf import setup_logging  # noqa: F401
 from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import set_context, set_custom_context  # noqa: F401
+from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
 from elasticapm.traces import set_transaction_name, set_user_context, tag  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
 
 if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span as capture_span #  noqa: F401
-else:
-    from elasticapm.traces import capture_span #  noqa: F401
+    from elasticapm.contrib.asyncio.traces import async_capture_span #  noqa: F401
+

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -138,10 +138,10 @@ class Client(object):
             skip_modules = ("elasticapm.",)
 
         self.transaction_store = TransactionsStore(
-            frames_collector_func=lambda: stacks.iter_stack_frames(
+            frames_collector_func=lambda: list(stacks.iter_stack_frames(
                 start_frame=inspect.currentframe(),
                 skip_top_modules=skip_modules,
-            ),
+            )),
             frames_processing_func=lambda frames: self._get_stack_info_for_trace(
                 frames,
                 library_frame_context_lines=self.config.source_lines_span_library_frames,

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -138,10 +138,9 @@ class Client(object):
             skip_modules = ("elasticapm.",)
 
         self.transaction_store = TransactionsStore(
-            frames_collector_func=lambda: list(stacks.iter_stack_frames(
-                start_frame=inspect.currentframe(),
-                skip_top_modules=skip_modules,
-            )),
+            frames_collector_func=lambda: list(
+                stacks.iter_stack_frames(start_frame=inspect.currentframe(), skip_top_modules=skip_modules)
+            ),
             frames_processing_func=lambda frames: self._get_stack_info_for_trace(
                 frames,
                 library_frame_context_lines=self.config.source_lines_span_library_frames,

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -12,6 +12,7 @@ Large portions are
 from __future__ import absolute_import
 
 import datetime
+import inspect
 import logging
 import os
 import platform
@@ -136,9 +137,13 @@ class Client(object):
         else:
             skip_modules = ("elasticapm.",)
 
-        def frames_collector_func():
-            return self._get_stack_info_for_trace(
-                stacks.iter_stack_frames(skip_top_modules=skip_modules),
+        self.transaction_store = TransactionsStore(
+            frames_collector_func=lambda: stacks.iter_stack_frames(
+                start_frame=inspect.currentframe(),
+                skip_top_modules=skip_modules,
+            ),
+            frames_processing_func=lambda frames: self._get_stack_info_for_trace(
+                frames,
                 library_frame_context_lines=self.config.source_lines_span_library_frames,
                 in_app_frame_context_lines=self.config.source_lines_span_app_frames,
                 with_locals=self.config.collect_local_variables in ("all", "transactions"),
@@ -150,10 +155,7 @@ class Client(object):
                     ),
                     local_var,
                 ),
-            )
-
-        self.transaction_store = TransactionsStore(
-            frames_collector_func=frames_collector_func,
+            ),
             collect_frequency=self.config.flush_interval,
             sample_rate=self.config.transaction_sample_rate,
             max_spans=self.config.transaction_max_spans,

--- a/elasticapm/context/contextvars.py
+++ b/elasticapm/context/contextvars.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import contextvars
+
+elasticapm_transaction_var = contextvars.ContextVar('elasticapm_transaction_var')
+elasticapm_span_var = contextvars.ContextVar('elasticapm_span_var')
+
+
+def get_transaction(clear=False):
+    try:
+        transaction = elasticapm_transaction_var.get()
+        if clear:
+            set_transaction(None)
+        return transaction
+    except LookupError:
+        return None
+
+
+def set_transaction(transaction):
+    elasticapm_transaction_var.set(transaction)
+
+
+def get_span():
+    try:
+        return elasticapm_span_var.get()
+    except LookupError:
+        return None
+
+
+def set_span(span):
+    elasticapm_span_var.set(span)

--- a/elasticapm/context/contextvars.py
+++ b/elasticapm/context/contextvars.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 import contextvars
 
-elasticapm_transaction_var = contextvars.ContextVar('elasticapm_transaction_var')
-elasticapm_span_var = contextvars.ContextVar('elasticapm_span_var')
+elasticapm_transaction_var = contextvars.ContextVar("elasticapm_transaction_var")
+elasticapm_span_var = contextvars.ContextVar("elasticapm_span_var")
 
 
 def get_transaction(clear=False):

--- a/elasticapm/context/threadlocal.py
+++ b/elasticapm/context/threadlocal.py
@@ -1,0 +1,30 @@
+import threading
+
+thread_local = threading.local()
+thread_local.transaction = None
+elasticapm_span_var = None
+
+
+def get_transaction(clear=False):
+    """
+    Get the transaction registered for the current thread.
+
+    :return:
+    :rtype: Transaction
+    """
+    transaction = getattr(thread_local, "transaction", None)
+    if clear:
+        thread_local.transaction = None
+    return transaction
+
+
+def set_transaction(transaction):
+    thread_local.transaction = transaction
+
+
+def get_span():
+    return getattr(thread_local, "span", None)
+
+
+def set_span(span):
+    thread_local.span = span

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -1,0 +1,16 @@
+from elasticapm.traces import capture_span, error_logger, get_transaction
+
+
+class async_capture_span(capture_span):
+    async def __aenter__(self):
+        transaction = get_transaction()
+        if transaction and transaction.is_sampled:
+            transaction.begin_span(self.name, self.type, context=self.extra, leaf=self.leaf)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        transaction = get_transaction()
+        if transaction and transaction.is_sampled:
+            try:
+                transaction.end_span(self.skip_frames)
+            except LookupError:
+                error_logger.info('ended non-existing span %s of type %s', self.name, self.type)

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -26,4 +26,4 @@ class async_capture_span(capture_span):
             try:
                 transaction.end_span(self.skip_frames)
             except LookupError:
-                error_logger.info('ended non-existing span %s of type %s', self.name, self.type)
+                error_logger.info("ended non-existing span %s of type %s", self.name, self.type)

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -1,4 +1,5 @@
 import functools
+
 from elasticapm.traces import capture_span, error_logger, get_transaction
 from elasticapm.utils import get_name_from_func
 

--- a/elasticapm/instrumentation/packages/aiohttp.py
+++ b/elasticapm/instrumentation/packages/aiohttp.py
@@ -1,0 +1,35 @@
+from elasticapm import async_capture_span
+from elasticapm.instrumentation.packages.asyncio_base import \
+    AsyncAbstractInstrumentedModule
+from elasticapm.utils import default_ports
+from elasticapm.utils.compat import urlparse
+
+
+def get_host_from_url(url):
+    parsed_url = urlparse.urlparse(url)
+    host = parsed_url.hostname or " "
+
+    if (
+        parsed_url.port and
+        default_ports.get(parsed_url.scheme) != parsed_url.port
+    ):
+        host += ":" + str(parsed_url.port)
+
+    return host
+
+
+class AioHttpClientInstrumentation(AsyncAbstractInstrumentedModule):
+    name = 'aiohttp_client'
+
+    instrument_list = [
+        ("aiohttp.client", "ClientSession._request"),
+    ]
+
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        method = kwargs['method'] if 'method' in kwargs else args[0]
+        url = kwargs['method'] if 'method' in kwargs else args[1]
+
+        signature = " ".join([method.upper(), get_host_from_url(url)])
+
+        async with async_capture_span(signature, "ext.http.aiohttp", {'url': url}, leaf=True):
+            return await wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/aiohttp.py
+++ b/elasticapm/instrumentation/packages/aiohttp.py
@@ -1,6 +1,5 @@
 from elasticapm import async_capture_span
-from elasticapm.instrumentation.packages.asyncio_base import \
-    AsyncAbstractInstrumentedModule
+from elasticapm.instrumentation.packages.asyncio_base import AsyncAbstractInstrumentedModule
 from elasticapm.utils import default_ports
 from elasticapm.utils.compat import urlparse
 
@@ -9,27 +8,22 @@ def get_host_from_url(url):
     parsed_url = urlparse.urlparse(url)
     host = parsed_url.hostname or " "
 
-    if (
-        parsed_url.port and
-        default_ports.get(parsed_url.scheme) != parsed_url.port
-    ):
+    if parsed_url.port and default_ports.get(parsed_url.scheme) != parsed_url.port:
         host += ":" + str(parsed_url.port)
 
     return host
 
 
 class AioHttpClientInstrumentation(AsyncAbstractInstrumentedModule):
-    name = 'aiohttp_client'
+    name = "aiohttp_client"
 
-    instrument_list = [
-        ("aiohttp.client", "ClientSession._request"),
-    ]
+    instrument_list = [("aiohttp.client", "ClientSession._request")]
 
     async def call(self, module, method, wrapped, instance, args, kwargs):
-        method = kwargs['method'] if 'method' in kwargs else args[0]
-        url = kwargs['method'] if 'method' in kwargs else args[1]
+        method = kwargs["method"] if "method" in kwargs else args[0]
+        url = kwargs["method"] if "method" in kwargs else args[1]
 
         signature = " ".join([method.upper(), get_host_from_url(url)])
 
-        async with async_capture_span(signature, "ext.http.aiohttp", {'url': url}, leaf=True):
+        async with async_capture_span(signature, "ext.http.aiohttp", {"url": url}, leaf=True):
             return await wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/asyncio_base.py
+++ b/elasticapm/instrumentation/packages/asyncio_base.py
@@ -1,0 +1,6 @@
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+
+
+class AsyncAbstractInstrumentedModule(AbstractInstrumentedModule):
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        raise NotImplementedError()

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -28,9 +28,7 @@ _cls_register = {
 }
 
 if sys.version_info >= (3, 5):
-    _cls_register.update([
-        'elasticapm.instrumentation.packages.aiohttp.AioHttpClientInstrumentation',
-    ])
+    _cls_register.update(["elasticapm.instrumentation.packages.aiohttp.AioHttpClientInstrumentation"])
 
 
 def register(cls):

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -1,3 +1,5 @@
+import sys
+
 from elasticapm.utils.module_import import import_string
 
 _cls_register = {
@@ -24,6 +26,11 @@ _cls_register = {
     "elasticapm.instrumentation.packages.django.template.DjangoTemplateInstrumentation",
     "elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation",
 }
+
+if sys.version_info >= (3, 5):
+    _cls_register.update([
+        'elasticapm.instrumentation.packages.aiohttp.AioHttpClientInstrumentation',
+    ])
 
 
 def register(cls):

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -27,12 +27,7 @@ except ImportError:
 
 
 class Transaction(object):
-    def __init__(
-        self,
-        store,
-        transaction_type="custom",
-        is_sampled=True,
-    ):
+    def __init__(self, store, transaction_type="custom", is_sampled=True):
         self.id = str(uuid.uuid4())
         self.timestamp = datetime.datetime.utcnow()
         self.start_time = _time_func()
@@ -149,7 +144,7 @@ class Span(object):
 
 
 class DroppedSpan(object):
-    __slots__ = ('leaf', 'parent')
+    __slots__ = ("leaf", "parent")
 
     def __init__(self, parent, leaf=False):
         self.parent = parent
@@ -157,8 +152,16 @@ class DroppedSpan(object):
 
 
 class TransactionsStore(object):
-    def __init__(self, frames_collector_func, frames_processing_func, collect_frequency, sample_rate=1.0, max_spans=0,
-                 max_queue_size=None, span_frames_min_duration=None, ignore_patterns=None,
+    def __init__(
+        self,
+        frames_collector_func,
+        frames_processing_func,
+        collect_frequency,
+        sample_rate=1.0,
+        max_spans=0,
+        max_queue_size=None,
+        span_frames_min_duration=None,
+        ignore_patterns=None,
     ):
         self.cond = threading.Condition()
         self.collect_frequency = collect_frequency
@@ -206,10 +209,7 @@ class TransactionsStore(object):
         :returns the Transaction object
         """
         is_sampled = self._sample_rate == 1.0 or self._sample_rate > random.random()
-        transaction = Transaction(
-            self, transaction_type,
-            is_sampled=is_sampled,
-        )
+        transaction = Transaction(self, transaction_type, is_sampled=is_sampled)
         set_transaction(transaction)
         return transaction
 

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -158,7 +158,7 @@ def iter_traceback_frames(tb):
         tb = tb.tb_next
 
 
-def iter_stack_frames(frames=None, skip=0, skip_top_modules=()):
+def iter_stack_frames(frames=None, start_frame=None, skip=0, skip_top_modules=()):
     """
     Given an optional list of frames (defaults to current stack),
     iterates over all frames that do not contain the ``__traceback_hide__``
@@ -173,12 +173,13 @@ def iter_stack_frames(frames=None, skip=0, skip_top_modules=()):
     itself.
 
     :param frames: a list of frames, or None
+    :param start_frame: a Frame object or None
     :param skip: number of frames to skip from the beginning
     :param skip_top_modules: tuple of strings
 
     """
     if not frames:
-        frame = inspect.currentframe().f_back
+        frame = start_frame if start_frame is not None else inspect.currentframe().f_back
         frames = _walk_stack(frame)
     stop_ignoring = False
     for i, frame in enumerate(frames):

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -693,7 +693,7 @@ def test_transaction_max_spans(should_collect, elasticapm_client):
 
     transaction = elasticapm_client.transaction_store.get_all()[0]
 
-    assert transaction_obj.max_spans == 5
+    assert transaction_obj._store.max_spans == 5
     assert transaction_obj.dropped_spans == 10
     assert len(transaction["spans"]) == 5
     for span in transaction["spans"]:


### PR DESCRIPTION
DO NOT TRY THIS AT HOME JUST YET

Note: in the v2 API implementation PR, we [removed](https://github.com/elastic/apm-agent-python/pull/281/commits/c2b8d7f1a886) the `AsyncIOHTTPTransport`. It might make sense to re-add it with this PR.