### PR TITLE
rename Client.instrumentation_store to Client.transaction_store

### DIFF
--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -397,7 +397,7 @@ def test_metrics_collection(should_collect, sending_elasticapm_client):
         sending_elasticapm_client.begin_transaction("transaction.test")
         sending_elasticapm_client.end_transaction('test-transaction', 200)
 
-    assert len(sending_elasticapm_client.instrumentation_store) == 7
+    assert len(sending_elasticapm_client.transaction_store) == 7
     assert len(sending_elasticapm_client.httpserver.requests) == 0
     should_collect.return_value = True
 
@@ -449,7 +449,7 @@ def test_ignore_patterns(should_collect, elasticapm_client):
     elasticapm_client.begin_transaction("web")
     elasticapm_client.end_transaction('GET views.users', 200)
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert len(transactions) == 1
     assert transactions[0]['name'] == 'GET views.users'
@@ -583,7 +583,7 @@ def test_collect_local_variables_transactions(should_collect, elasticapm_client)
         a_long_local_list = list(range(100))
         pass
     elasticapm_client.end_transaction('test', 'ok')
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     frame = transaction['spans'][0]['stacktrace'][0]
     if mode in ('transactions', 'all'):
         assert 'vars' in frame, mode
@@ -609,7 +609,7 @@ def test_collect_source_transactions(should_collect, elasticapm_client):
     with elasticapm.capture_span('foo'):
         pass
     elasticapm_client.end_transaction('test', 'ok')
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     in_app_frame = transaction['spans'][0]['stacktrace'][0]
     library_frame = transaction['spans'][0]['stacktrace'][1]
     assert not in_app_frame['library_frame']
@@ -659,7 +659,7 @@ def test_transaction_sampling(should_collect, elasticapm_client, not_so_random):
             pass
         elasticapm_client.end_transaction('test')
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     # seed is fixed by not_so_random fixture
     assert len([t for t in transactions if t['sampled']]) == 5
@@ -681,7 +681,7 @@ def test_transaction_max_spans(should_collect, elasticapm_client):
             pass
     transaction_obj = elasticapm_client.end_transaction('test')
 
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
 
     assert transaction_obj.max_spans == 5
     assert transaction_obj.dropped_spans == 10
@@ -702,7 +702,7 @@ def test_transaction_span_frames_min_duration(should_collect, elasticapm_client)
         time.sleep(0.040)
     elasticapm_client.end_transaction('test')
 
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     spans = transaction['spans']
 
     assert len(spans) == 2
@@ -724,7 +724,7 @@ def test_transaction_span_frames_min_duration_no_limit(should_collect, elasticap
         time.sleep(0.040)
     elasticapm_client.end_transaction('test')
 
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     spans = transaction['spans']
 
     assert len(spans) == 2
@@ -756,7 +756,7 @@ def test_transaction_max_span_nested(should_collect, elasticapm_client):
         pass
     transaction_obj = elasticapm_client.end_transaction('test')
 
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
 
     assert transaction_obj.dropped_spans == 6
     assert len(transaction['spans']) == 3

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -128,7 +128,7 @@ def test_instrumentation(flask_apm_client):
 
     assert resp.status_code == 200, resp.response
 
-    transactions = flask_apm_client.client.instrumentation_store.get_all()
+    transactions = flask_apm_client.client.transaction_store.get_all()
 
     assert len(transactions) == 1
     transaction = transactions[0]
@@ -161,10 +161,10 @@ def test_instrumentation(flask_apm_client):
 
 def test_instrumentation_debug(flask_apm_client):
     flask_apm_client.app.debug = True
-    assert len(flask_apm_client.client.instrumentation_store) == 0
+    assert len(flask_apm_client.client.transaction_store) == 0
     resp = flask_apm_client.app.test_client().post('/users/', data={'foo': 'bar'})
     resp.close()
-    assert len(flask_apm_client.client.instrumentation_store) == 0
+    assert len(flask_apm_client.client.transaction_store) == 0
 
 
 @pytest.mark.parametrize('elasticapm_client', [
@@ -172,10 +172,10 @@ def test_instrumentation_debug(flask_apm_client):
 ], indirect=True)
 def test_instrumentation_debug_client_debug(flask_apm_client):
     flask_apm_client.app.debug = True
-    assert len(flask_apm_client.client.instrumentation_store) == 0
+    assert len(flask_apm_client.client.transaction_store) == 0
     resp = flask_apm_client.app.test_client().post('/users/', data={'foo': 'bar'})
     resp.close()
-    assert len(flask_apm_client.client.instrumentation_store) == 1
+    assert len(flask_apm_client.client.transaction_store) == 1
 
 
 def test_instrumentation_404(flask_apm_client):
@@ -186,7 +186,7 @@ def test_instrumentation_404(flask_apm_client):
 
     assert resp.status_code == 404, resp.response
 
-    transactions = flask_apm_client.client.instrumentation_store.get_all()
+    transactions = flask_apm_client.client.transaction_store.get_all()
 
     assert len(transactions) == 1
     spans = transactions[0]['spans']
@@ -203,7 +203,7 @@ def test_non_standard_http_status(flask_apm_client):
     assert resp.status == "0 fail", resp.response
     assert resp.status_code == 0, resp.response
 
-    transactions = flask_apm_client.client.instrumentation_store.get_all()
+    transactions = flask_apm_client.client.transaction_store.get_all()
     assert transactions[0]['result'] == '0 fail'  # "0" is prepended by Werkzeug BaseResponse
     assert transactions[0]['context']['response']['status_code'] == 0
 
@@ -250,7 +250,7 @@ def test_post_files(flask_apm_client):
 def test_options_request(flask_apm_client):
     resp = flask_apm_client.app.test_client().options('/')
     resp.close()
-    transactions = flask_apm_client.client.instrumentation_store.get_all()
+    transactions = flask_apm_client.client.transaction_store.get_all()
     assert transactions[0]['context']['request']['method'] == 'OPTIONS'
 
 
@@ -258,7 +258,7 @@ def test_streaming_response(flask_apm_client):
     resp = flask_apm_client.app.test_client().get('/streaming/')
     assert resp.data == b'01234'
     resp.close()
-    transaction = flask_apm_client.client.instrumentation_store.get_all()[0]
+    transaction = flask_apm_client.client.transaction_store.get_all()[0]
     assert transaction['duration'] > 50
     assert len(transaction['spans']) == 5
 
@@ -269,7 +269,7 @@ def test_response_close_wsgi(flask_wsgi_server):
     url = flask_wsgi_server.url + '/streaming/'
     response = urlopen(url)
     response.read()
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     assert transaction['duration'] > 50
     assert len(transaction['spans']) == 5
 
@@ -277,6 +277,6 @@ def test_response_close_wsgi(flask_wsgi_server):
 def test_set_transaction_name(flask_apm_client):
     resp = flask_apm_client.app.test_client().get('/transaction-name/')
     resp.close()
-    transaction = flask_apm_client.client.instrumentation_store.get_all()[0]
+    transaction = flask_apm_client.client.transaction_store.get_all()[0]
     assert transaction['name'] == 'foo'
     assert transaction['result'] == 'okydoky'

--- a/tests/instrumentation/cassandra_tests.py
+++ b/tests/instrumentation/cassandra_tests.py
@@ -38,7 +38,7 @@ def test_cassandra_connect(instrument, elasticapm_client, cassandra_cluster):
     sess = cassandra_cluster.connect()
     elasticapm_client.end_transaction("test")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = transactions[0]['spans'][0]
 
     assert span['type'] == 'db.cassandra.connect'
@@ -50,7 +50,7 @@ def test_select_query_string(instrument, cassandra_session, elasticapm_client):
     elasticapm_client.begin_transaction("transaction.test")
     cassandra_session.execute('SELECT name from users')
     elasticapm_client.end_transaction("test")
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     span = transaction['spans'][0]
     assert span['type'] == 'db.cassandra.query'
     assert span['name'] == 'SELECT FROM users'
@@ -62,7 +62,7 @@ def test_select_simple_statement(instrument, cassandra_session, elasticapm_clien
     elasticapm_client.begin_transaction("transaction.test")
     cassandra_session.execute(statement)
     elasticapm_client.end_transaction("test")
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     span = transaction['spans'][0]
     assert span['type'] == 'db.cassandra.query'
     assert span['name'] == 'SELECT FROM users'
@@ -74,7 +74,7 @@ def test_select_prepared_statement(instrument, cassandra_session, elasticapm_cli
     elasticapm_client.begin_transaction("transaction.test")
     cassandra_session.execute(prepared_statement)
     elasticapm_client.end_transaction("test")
-    transaction = elasticapm_client.instrumentation_store.get_all()[0]
+    transaction = elasticapm_client.transaction_store.get_all()[0]
     span = transaction['spans'][0]
     assert span['type'] == 'db.cassandra.query'
     assert span['name'] == 'SELECT FROM users'

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -46,7 +46,7 @@ def test_template_rendering(should_collect, instrument, django_elasticapm_client
         client.get(reverse('render-heavy-template'))
         client.get(reverse('render-heavy-template'))
 
-    transactions = django_elasticapm_client.instrumentation_store.get_all()
+    transactions = django_elasticapm_client.transaction_store.get_all()
 
     assert len(transactions) == 3
     spans = transactions[0]['spans']
@@ -78,7 +78,7 @@ def test_template_rendering_django18_jinja2(should_collect, instrument, django_e
         client.get(reverse('render-jinja2-template'))
         client.get(reverse('render-jinja2-template'))
 
-    transactions = django_elasticapm_client.instrumentation_store.get_all()
+    transactions = django_elasticapm_client.transaction_store.get_all()
 
     assert len(transactions) == 3
     spans = transactions[0]['spans']

--- a/tests/instrumentation/jinja2_tests/jinja2_tests.py
+++ b/tests/instrumentation/jinja2_tests/jinja2_tests.py
@@ -21,7 +21,7 @@ def test_from_file(should_collect, instrument, jinja_env, elasticapm_client):
     template.render()
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'mytemplate.html'}
@@ -38,7 +38,7 @@ def test_from_string(instrument, elasticapm_client):
     template.render()
     elasticapm_client.end_transaction("test")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'<template>'}

--- a/tests/instrumentation/psycopg2_tests.py
+++ b/tests/instrumentation/psycopg2_tests.py
@@ -232,7 +232,7 @@ def test_psycopg2_register_type(postgres_connection, elasticapm_client):
         elasticapm_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the spans for the other tests.
-        elasticapm_client.instrumentation_store.get_all()
+        elasticapm_client.transaction_store.get_all()
 
     assert new_type is not None
 
@@ -257,7 +257,7 @@ def test_psycopg2_register_json(postgres_connection, elasticapm_client):
         elasticapm_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the traces for the other tests.
-        elasticapm_client.instrumentation_store.get_all()
+        elasticapm_client.transaction_store.get_all()
 
 
 @pytest.mark.integrationtest
@@ -268,7 +268,7 @@ def test_psycopg2_tracing_outside_of_elasticapm_transaction(instrument, postgres
     # transaction
     assert isinstance(cursor, PGCursorProxy)
     cursor.execute('SELECT 1')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     assert transactions == []
 
 
@@ -289,7 +289,7 @@ def test_psycopg2_select_LIKE(instrument, postgres_connection, elasticapm_client
         elasticapm_client.end_transaction(None, "test-transaction")
     finally:
         # make sure we've cleared out the spans for the other tests.
-        transactions = elasticapm_client.instrumentation_store.get_all()
+        transactions = elasticapm_client.transaction_store.get_all()
         spans = transactions[0]['spans']
         span = spans[0]
         assert span['name'] == 'SELECT FROM test'
@@ -320,7 +320,7 @@ def test_psycopg2_composable_query_works(instrument, postgres_connection, elasti
     finally:
         # make sure we've cleared out the spans for the other tests.
         assert [(2, 'two'), (3, 'three')] == result
-        transactions = elasticapm_client.instrumentation_store.get_all()
+        transactions = elasticapm_client.transaction_store.get_all()
         spans = transactions[0]['spans']
         span = spans[0]
         assert span['name'] == 'SELECT FROM test'

--- a/tests/instrumentation/pylibmc_tests.py
+++ b/tests/instrumentation/pylibmc_tests.py
@@ -22,7 +22,7 @@ def test_pylibmc(instrument, elasticapm_client):
         assert {"mykey": "a"} == conn.get_multi(["mykey", "myotherkey"])
     elasticapm_client.end_transaction("BillingView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_memcached',

--- a/tests/instrumentation/pymongo_tests.py
+++ b/tests/instrumentation/pymongo_tests.py
@@ -34,7 +34,7 @@ def test_collection_bulk_write(instrument, elasticapm_client, mongo_database):
     assert result.deleted_count == 1
     assert result.upserted_count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.bulk_write'
@@ -45,12 +45,12 @@ def test_collection_count(instrument, elasticapm_client, mongo_database):
     blogpost = {'author': 'Tom', 'text': 'Foo',
                 'date': datetime.datetime.utcnow()}
     mongo_database.blogposts.insert(blogpost)
-    elasticapm_client.instrumentation_store.get_all()
+    elasticapm_client.transaction_store.get_all()
     elasticapm_client.begin_transaction('transaction.test')
     count = mongo_database.blogposts.count()
     assert count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.count'
@@ -66,7 +66,7 @@ def test_collection_delete_one(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.delete_one({'author': 'Tom'})
     assert r.deleted_count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.delete_one'
@@ -82,7 +82,7 @@ def test_collection_delete_many(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.delete_many({'author': 'Tom'})
     assert r.deleted_count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.delete_many'
@@ -96,7 +96,7 @@ def test_collection_insert(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.insert(blogpost)
     assert r is not None
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.insert'
@@ -111,7 +111,7 @@ def test_collection_insert_one(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.insert_one(blogpost)
     assert r.inserted_id is not None
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.insert_one'
@@ -126,7 +126,7 @@ def test_collection_insert_many(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.insert_many([blogpost])
     assert len(r.inserted_ids) == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
@@ -142,12 +142,12 @@ def test_collection_find(instrument, elasticapm_client, mongo_database):
         blogposts.append({'author': 'Tom', 'comments': i})
     mongo_database.blogposts.insert(blogposts)
     r = mongo_database.blogposts.insert(blogpost)
-    elasticapm_client.instrumentation_store.get_all()
+    elasticapm_client.transaction_store.get_all()
     elasticapm_client.begin_transaction('transaction.test')
     r = list(mongo_database.blogposts.find({'comments': {'$gt': 995}}))
 
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.cursor.refresh'
@@ -163,7 +163,7 @@ def test_collection_find_one(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.find_one({'author': 'Tom'})
     assert r['author'] == 'Tom'
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.find_one'
@@ -178,7 +178,7 @@ def test_collection_remove(instrument, elasticapm_client, mongo_database):
     r = mongo_database.blogposts.remove({'author': 'Tom'})
     assert r['n'] == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.remove'
@@ -194,7 +194,7 @@ def test_collection_update(instrument, elasticapm_client, mongo_database):
                                  {'$set': {'author': 'Jerry'}})
     assert r['n'] == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.update'
@@ -211,7 +211,7 @@ def test_collection_update_one(instrument, elasticapm_client, mongo_database):
                                  {'$set': {'author': 'Jerry'}})
     assert r.modified_count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.update_one'
@@ -228,7 +228,7 @@ def test_collection_update_many(instrument, elasticapm_client, mongo_database):
                                  {'$set': {'author': 'Jerry'}})
     assert r.modified_count == 1
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.blogposts.update_many'
@@ -244,7 +244,7 @@ def test_bulk_execute(instrument, elasticapm_client, mongo_database):
     bulk.find({'x': 'y'}).replace_one({'x': 'z'})
     bulk.execute()
     elasticapm_client.end_transaction('transaction.test')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     span = _get_pymongo_trace(transactions[0]['spans'])
     assert span['type'] == 'db.mongodb.query'
     assert span['name'] == 'elasticapm_test.test_bulk.bulk.execute'

--- a/tests/instrumentation/pymssql_tests.py
+++ b/tests/instrumentation/pymssql_tests.py
@@ -38,7 +38,7 @@ def test_pymssql_select(instrument, pymssql_connection, elasticapm_client):
         assert cursor.fetchall() == [(2, 'two'), (3, 'three')]
         elasticapm_client.end_transaction(None, "test-transaction")
     finally:
-        transactions = elasticapm_client.instrumentation_store.get_all()
+        transactions = elasticapm_client.transaction_store.get_all()
         spans = transactions[0]['spans']
         span = spans[0]
         assert span['name'] == 'SELECT FROM test'

--- a/tests/instrumentation/python_memcached_tests.py
+++ b/tests/instrumentation/python_memcached_tests.py
@@ -21,7 +21,7 @@ def test_memcached(instrument, elasticapm_client):
         assert {"mykey": "a"} == conn.get_multi(["mykey", "myotherkey"])
     elasticapm_client.end_transaction("BillingView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_memcached',

--- a/tests/instrumentation/redis_tests.py
+++ b/tests/instrumentation/redis_tests.py
@@ -32,7 +32,7 @@ def test_pipeline(instrument, elasticapm_client, redis_conn):
         pipeline.execute()
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
@@ -62,7 +62,7 @@ def test_rq_patches_redis(instrument, elasticapm_client, redis_conn):
         pipeline.execute()
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_pipeline', 'StrictPipeline.execute'}
@@ -86,7 +86,7 @@ def test_redis_client(instrument, elasticapm_client, redis_conn):
         redis_conn.expire("mykey", 1000)
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_redis_client', 'RPUSH', 'EXPIRE'}

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -29,7 +29,7 @@ def test_requests_instrumentation(instrument, elasticapm_client):
         requests.get('http://example.com', allow_redirects=False)
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
     assert 'GET example.com' == spans[0]['name']
     assert 'http://example.com/' == spans[0]['context']['url']
@@ -42,7 +42,7 @@ def test_requests_instrumentation_via_session(instrument, elasticapm_client):
         s.get('http://example.com', allow_redirects=False)
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
     assert 'GET example.com' == spans[0]['name']
     assert 'http://example.com/' == spans[0]['context']['url']
@@ -57,7 +57,7 @@ def test_requests_instrumentation_via_prepared_request(instrument, elasticapm_cl
         s.send(pr, allow_redirects=False)
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
     assert 'GET example.com' == spans[0]['name']
     assert 'http://example.com/' == spans[0]['context']['url']

--- a/tests/instrumentation/sqlite_tests.py
+++ b/tests/instrumentation/sqlite_tests.py
@@ -13,7 +13,7 @@ def test_connect(instrument, elasticapm_client):
 
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'sqlite3.connect :memory:',

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -183,7 +183,7 @@ def test_tags_merge(elasticapm_client):
     elasticapm.tag(foo=1, bar='baz')
     elasticapm.tag(bar=3, boo='biz')
     elasticapm_client.end_transaction('test', 'OK')
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert transactions[0]['context']['tags'] == {'foo': '1', 'bar': '3', 'boo': 'biz'}
 
@@ -198,7 +198,7 @@ def test_set_transaction_name(elasticapm_client):
 
     elasticapm_client.end_transaction('test_name', 200)
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     assert transactions[0]['name'] == 'test_name'
     assert transactions[1]['name'] == 'another_name'
 
@@ -209,7 +209,7 @@ def test_set_transaction_custom_data(elasticapm_client):
     elasticapm.set_custom_context({'foo': 'bar'})
 
     elasticapm_client.end_transaction('foo', 200)
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert transactions[0]['context']['custom'] == {'foo': 'bar'}
 
@@ -221,7 +221,7 @@ def test_set_transaction_custom_data_merge(elasticapm_client):
     elasticapm.set_custom_context({'bar': 'bie', 'boo': 'biz'})
 
     elasticapm_client.end_transaction('foo', 200)
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert transactions[0]['context']['custom'] == {'foo': 'bar', 'bar': 'bie', 'boo': 'biz'}
 
@@ -232,7 +232,7 @@ def test_set_user_context(elasticapm_client):
     elasticapm.set_user_context(username='foo', email='foo@example.com', user_id=42)
 
     elasticapm_client.end_transaction('foo', 200)
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert transactions[0]['context']['user'] == {'username': 'foo', 'email': 'foo@example.com', 'id': 42}
 
@@ -244,7 +244,7 @@ def test_set_user_context_merge(elasticapm_client):
     elasticapm.set_user_context(email='foo@example.com', user_id=42)
 
     elasticapm_client.end_transaction('foo', 200)
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
 
     assert transactions[0]['context']['user'] == {'username': 'foo', 'email': 'foo@example.com', 'id': 42}
 

--- a/tests/instrumentation/urllib3_tests.py
+++ b/tests/instrumentation/urllib3_tests.py
@@ -21,7 +21,7 @@ def test_urllib3(should_collect, instrument, elasticapm_client, httpserver):
 
     elasticapm_client.end_transaction("MyView")
 
-    transactions = elasticapm_client.instrumentation_store.get_all()
+    transactions = elasticapm_client.transaction_store.get_all()
     spans = transactions[0]['spans']
 
     expected_signatures = {'test_pipeline', expected_sig}


### PR DESCRIPTION
instrumentation_store was always a bit of a misnomer

Signed-off-by: Benjamin Wohlwend <beni@elastic.co>