### PR TITLE
try to fix flaky appveyor tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,8 @@ import sys
 from os.path import abspath, dirname, join
 
 from tests.fixtures import (elasticapm_client, instrument, not_so_random,
-                            sending_elasticapm_client, validating_httpserver)
+                            sending_elasticapm_client, validating_httpserver,
+                            waiting_httpserver)
 from tests.utils.compat import middleware_setting
 
 try:

--- a/tests/instrumentation/urllib3_tests.py
+++ b/tests/instrumentation/urllib3_tests.py
@@ -6,10 +6,10 @@ from elasticapm.utils.compat import urlparse
 
 
 @mock.patch("elasticapm.traces.TransactionsStore.should_collect")
-def test_urllib3(should_collect, instrument, elasticapm_client, httpserver):
+def test_urllib3(should_collect, instrument, elasticapm_client, waiting_httpserver):
     should_collect.return_value = False
-    httpserver.serve_content('')
-    url = httpserver.url + '/hello_world'
+    waiting_httpserver.serve_content('')
+    url = waiting_httpserver.url + '/hello_world'
     parsed_url = urlparse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = 'GET {0}'.format(parsed_url.netloc)


### PR DESCRIPTION
test_urllib3 is quite flaky on appveyor. The assumption is that due to
the slow executor machine, the http server used in this test isn't
quick enough to boot up. Now we wait for the server to boot up.