### PR TITLE
Cython is now apparently needed to install pymssql on PyPy3

### DIFF
--- a/tests/requirements/requirements-pymssql-newest.txt
+++ b/tests/requirements/requirements-pymssql-newest.txt
@@ -1,3 +1,3 @@
 cython ; python_version >= '3.7'
-pymssql
+pymssql<2.1.4
 -r requirements-base.txt


### PR DESCRIPTION
¯\_(ツ)_/¯