### PR TITLE
flask: use request.get_data() instead of request.data

### DIFF
--- a/elasticapm/contrib/flask/utils.py
+++ b/elasticapm/contrib/flask/utils.py
@@ -26,7 +26,7 @@ def get_data_from_request(request, capture_body=False):
                 }
         else:
             try:
-                body = request.data
+                body = request.get_data(as_text=True)
             except ClientDisconnected:
                 pass
 


### PR DESCRIPTION
fixes #286

unfortunately, due to apm-server master already using the new API, the tests will not pass. I tested this change locally.