### PR TITLE
fix issue with urllib3 traceparent detection and dropped spans

### DIFF
--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -45,8 +45,11 @@ class Urllib3Instrumentation(AbstractInstrumentedModule):
                 leaf_span = leaf_span.parent
 
             if headers is not None:
+                # It's possible that there are only dropped spans, e.g. if we started dropping spans.
+                # In this case, the transaction.id is used
+                parent_id = leaf_span.id if leaf_span else transaction.id
                 trace_parent = transaction.trace_parent.copy_from(
-                    span_id=leaf_span.id, trace_options=TracingOptions(recorded=True)
+                    span_id=parent_id, trace_options=TracingOptions(recorded=True)
                 )
                 headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_ascii()
             return wrapped(*args, **kwargs)

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -50,16 +50,16 @@ class Transaction(object):
 
     def begin_span(self, name, span_type, context=None, leaf=False):
         parent_span = get_span()
-        store = self._tracer
+        tracer = self._tracer
         if parent_span and parent_span.leaf:
             span = DroppedSpan(parent_span, leaf=True)
-        elif store.max_spans and self._span_counter > store.max_spans - 1:
+        elif tracer.max_spans and self._span_counter > tracer.max_spans - 1:
             self.dropped_spans += 1
             span = DroppedSpan(parent_span)
             self._span_counter += 1
         else:
             span = Span(transaction=self, name=name, span_type=span_type, context=context, leaf=leaf)
-            span.frames = store.frames_collector_func()
+            span.frames = tracer.frames_collector_func()
             span.parent = parent_span
             self._span_counter += 1
         set_span(span)

--- a/tests/instrumentation/urllib3_tests.py
+++ b/tests/instrumentation/urllib3_tests.py
@@ -1,4 +1,4 @@
-import mock
+import pytest
 import urllib3
 
 from elasticapm.conf import constants
@@ -14,7 +14,7 @@ def test_urllib3(instrument, elasticapm_client, waiting_httpserver):
     parsed_url = urlparse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
-    with capture_span("test_pipeline", "test"):
+    with capture_span("test", "test"):
         pool = urllib3.PoolManager(timeout=0.1)
 
         url = "http://{0}/hello_world".format(parsed_url.netloc)
@@ -76,3 +76,22 @@ def test_trace_parent_propagation_unsampled(instrument, elasticapm_client, waiti
     assert trace_parent.trace_id == transactions[0]["trace_id"]
     assert trace_parent.span_id == transaction_object.id
     assert not trace_parent.trace_options.recorded
+
+
+@pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 1}], indirect=True)
+def test_span_only_dropped(elasticapm_client, waiting_httpserver):
+    """test that urllib3 instrumentation does not fail if no parent span can be found"""
+    waiting_httpserver.serve_content("")
+    url = waiting_httpserver.url + "/hello_world"
+    transaction_object = elasticapm_client.begin_transaction("transaction")
+    for i in range(2):
+        with capture_span("test", "test"):
+            pool = urllib3.PoolManager(timeout=0.1)
+            pool.request("GET", url)
+    elasticapm_client.end_transaction("bla", "OK")
+    trace_parent_1 = TraceParent.from_string(waiting_httpserver.requests[0].headers[constants.TRACEPARENT_HEADER_NAME])
+    trace_parent_2 = TraceParent.from_string(waiting_httpserver.requests[1].headers[constants.TRACEPARENT_HEADER_NAME])
+
+    assert trace_parent_1.span_id != transaction_object.id
+    # second request should use transaction id as span id because there is no span
+    assert trace_parent_2.span_id == transaction_object.id


### PR DESCRIPTION
When we start dropping spans due to max spans setting, it's possible
that we can't find a parent span to get the ID from. In this case
we need to fall back to the transaction ID, which is the same
behaviour as for unsampled transactions.