### PR TITLE
fix traceparent header propagation for older versions of requests

### DIFF
--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -8,7 +8,10 @@ from elasticapm.utils.disttracing import TracingOptions
 class Urllib3Instrumentation(AbstractInstrumentedModule):
     name = "urllib3"
 
-    instrument_list = [("urllib3.connectionpool", "HTTPConnectionPool.urlopen")]
+    instrument_list = [
+        ("urllib3.connectionpool", "HTTPConnectionPool.urlopen"),
+        ("requests.packages.urllib3.connectionpool", "HTTPConnectionPool.urlopen"),
+    ]
 
     def call(self, module, method, wrapped, instance, args, kwargs):
         if "method" in kwargs:


### PR DESCRIPTION
until fairly recently, requests used to vendor urllib3. To make
header propagation work, we need to instrument than vendored urllib3 as
well.