### PR TITLE
Update LoggingHandler to stringify record.msg

### DIFF
--- a/elasticapm/handlers/logbook.py
+++ b/elasticapm/handlers/logbook.py
@@ -16,6 +16,7 @@ import traceback
 import logbook
 
 from elasticapm.base import Client
+from elasticapm.utils import compat
 from elasticapm.utils.encoding import to_unicode
 
 LOOKBOOK_LEVELS = {
@@ -80,7 +81,7 @@ class LogbookHandler(logbook.Handler):
             exception = None
 
         return self.client.capture_message(
-            param_message={"message": record.msg, "params": record.args},
+            param_message={"message": compat.text_type(record.msg), "params": record.args},
             exception=exception,
             level=LOOKBOOK_LEVELS[record.level],
             logger_name=record.channel,

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -130,7 +130,7 @@ class LoggingHandler(logging.Handler):
 
         return self.client.capture(
             "Message",
-            param_message={"message": record.msg, "params": record.args},
+            param_message={"message": compat.text_type(record.msg), "params": record.args},
             stack=stack,
             custom=custom,
             exception=exception,

--- a/tests/handlers/logbook/logbook_tests.py
+++ b/tests/handlers/logbook/logbook_tests.py
@@ -143,3 +143,12 @@ def test_logbook_handler_dont_emit_elasticapm(capsys, elasticapm_client):
     handler.emit(LogRecord("elasticapm.errors", 1, "Oops"))
     out, err = capsys.readouterr()
     assert "Oops" in err
+
+
+def test_arbitrary_object(elasticapm_client, logbook_logger, logbook_handler):
+    with logbook_handler.applicationbound():
+        logbook_logger.info(["a", "list", "of", "strings"])
+    assert len(logbook_handler.client.events) == 1
+    event = logbook_handler.client.events.pop(0)["errors"][0]
+    assert "param_message" in event["log"]
+    assert event["log"]["param_message"] == "['a', 'list', 'of', 'strings']"

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -203,3 +203,11 @@ def test_logging_handler_dont_emit_elasticapm(capsys, elasticapm_client):
     handler.emit(LogRecord("elasticapm.errors", 1, "/ab/c/", 10, "Oops", [], None))
     out, err = capsys.readouterr()
     assert "Oops" in err
+
+
+def test_arbitrary_object(logger):
+    logger.error(["a", "list", "of", "strings"])
+    assert len(logger.client.events) == 1
+    event = logger.client.events.pop(0)["errors"][0]
+    assert "param_message" in event["log"]
+    assert event["log"]["param_message"] == "['a', 'list', 'of', 'strings']"


### PR DESCRIPTION
Update LoggingHandler so that it converts the log record
message to a string. The message may be any arbitrary object,
and currently non-string messages are being sent as objects,
which the APM Server rejects.

Fixes #295 