### PR TITLE
Add instrumentation for SUDS (Soap Client library)

### DIFF
--- a/elasticapm/instrumentation/packages/suds.py
+++ b/elasticapm/instrumentation/packages/suds.py
@@ -1,0 +1,14 @@
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+from elasticapm.traces import capture_span
+
+
+class SUDSInstrumentation(AbstractInstrumentedModule):
+    name = "suds"
+
+    instrument_list = [("suds.client", "SoapClient.invoke")]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        signature = 'suds.service.' + instance.method.name
+        with capture_span(signature, "suds"):
+            return wrapped(*args, **kwargs)
+

--- a/elasticapm/instrumentation/packages/suds.py
+++ b/elasticapm/instrumentation/packages/suds.py
@@ -5,10 +5,14 @@ from elasticapm.traces import capture_span
 class SUDSInstrumentation(AbstractInstrumentedModule):
     name = "suds"
 
-    instrument_list = [("suds.client", "SoapClient.invoke")]
+    instrument_list = [("suds.client", "SoapClient.invoke"), ("suds.client", "Client.__init__")]
 
     def call(self, module, method, wrapped, instance, args, kwargs):
-        signature = 'suds.service.' + instance.method.name
+        signature = ''
+        if method == 'Client.__init__':
+            signature = 'Parse WSDL ' + args[0]
+        elif method == 'SoapClient.invoke':
+            signature = instance.method.name
+
         with capture_span(signature, "suds"):
             return wrapped(*args, **kwargs)
-

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -15,6 +15,7 @@ _cls_register = {
     "elasticapm.instrumentation.packages.redis.RedisPipelineInstrumentation",
     "elasticapm.instrumentation.packages.requests.RequestsInstrumentation",
     "elasticapm.instrumentation.packages.sqlite.SQLiteInstrumentation",
+    "elasticapm.instrumentation.packages.suds.SUDSInstrumentation",
     "elasticapm.instrumentation.packages.urllib3.Urllib3Instrumentation",
     "elasticapm.instrumentation.packages.elasticsearch.ElasticsearchConnectionInstrumentation",
     "elasticapm.instrumentation.packages.elasticsearch.ElasticsearchInstrumentation",


### PR DESCRIPTION
Adds support for SUDS: https://pypi.org/project/suds/
It captures each SOAP call as a span named suds.service.[ServiceName]