### PR TITLE
docs: update getting-started and file structure

### DIFF
--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -1,0 +1,10 @@
+[[advanced-topics]]
+== Advanced Topics
+
+* <<instrumenting-custom-code>>
+* <<sanitizing-data>>
+* <<run-tests-locally>>
+
+include::./custom-instrumentation.asciidoc[Custom Instrumentation]
+include::./sanitizing-data.asciidoc[Sanitizing Data]
+include::./run-tests-locally.asciidoc[Run Tests Locally]

--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -1,0 +1,30 @@
+[[getting-started]]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/python/current/getting-started.html[elastic.co]
+endif::[]
+
+== Getting started
+
+Welcome to the APM Python agent docs.
+
+The Elastic APM Python agent sends performance metrics and error logs to the APM Server.
+It has built-in support for Django and Flask performance metrics and error logging, as well as generic support of other WSGI frameworks for error logging.
+
+[float]
+[[additional-components]]
+=== Additional Components
+
+APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together.
+
+[[framework-support]]
+The Elastic APM Python Agent comes with support for the following frameworks:
+
+ * <<django-support,Django>> 1.8 - 2.1
+ * <<flask-support,Flask>> 0.10+
+ 
+For other frameworks and custom Python code, the agent exposes a set of <<api,APIs>> for integration.
+
+NOTE: The Elastic APM Python agent does currently not support asynchronous frameworks like Twisted or Tornado.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,33 +1,14 @@
-= APM Python Agent Reference
-
 :branch: current
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-[[getting-started]]
-== Getting started
-
-Welcome to the APM Python agent docs.
-
-The Elastic APM Python agent sends performance metrics and error logs to the APM Server.
-It has built-in support for Django and Flask performance metrics and error logging, as well as generic support of other WSGI frameworks for error logging.
-The agent is only one of multiple components you need to get started with APM. Please also have a look at the documentation for
-
- * {apm-server-ref}/index.html[APM Server]
- * {ref}/index.html[Elasticsearch]
-
 ifdef::env-github[]
-NOTE: For the best reading experience, please head over to this document at https://www.elastic.co/guide/en/apm/agent/python/current/index.html[elastic.co]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/python/current/index.html[elastic.co]
 endif::[]
 
-[[framework-support]]
-The Elastic APM Python Agent comes with support for the following frameworks:
+= APM Python Agent Reference
 
- * <<django-support,Django>> 1.8 - 2.1
- * <<flask-support,Flask>> 0.10+
- 
-For other frameworks and custom Python code, the agent exposes a set of <<api,APIs>> for integration.
-
-NOTE: The Elastic APM Python agent does currently not support asynchronous frameworks like Twisted or Tornado.
+include::./getting-started.asciidoc[Getting Started]
 
 include::./configuration.asciidoc[Configuration]
 
@@ -35,12 +16,10 @@ include::./django.asciidoc[Django support]
 
 include::./flask.asciidoc[Flask support]
 
-[[advanced-topics]]
-== Advanced Topics
-include::./custom-instrumentation.asciidoc[Custom Instrumentation]
-include::./sanitizing-data.asciidoc[Sanitizing Data]
-include::./run-tests-locally.asciidoc[Run Tests Locally]
+include::./advanced-topics.asciidoc[Advanced Topics]
 
 include::./api.asciidoc[API documentation]
+
 include::./upgrading.asciidoc[Upgrading from previous versions]
+
 include::./tuning.asciidoc[Tuning and Overhead considerations]


### PR DESCRIPTION
* Updated `index.asciidoc` to move `getting-started` and `advanced-topics` into their own files. 
* Updated agent `getting-started.asciidoc` per elastic/apm-dev#387
* Added bullet point links to address blank white space in `advanced-topics` (see below)
<img width="786" alt="screen shot 2018-11-26 at 11 47 39 am" src="https://user-images.githubusercontent.com/5618806/49038218-276f3c80-f171-11e8-8a64-d30c41cb8d21.png">
