### PR TITLE
move queue size logic into a lock-protected block

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -427,7 +427,8 @@ A higher value also impacts the time until data is indexed and searchable in Ela
 This setting is useful to limit memory consumption if you experience a sudden spike of traffic.
 It has to be provided in *<<config-format-size, size format>>*.
 
-NOTE: by default, the APM Server limits request payload size to 1 MByte.
+NOTE: Due to internal buffering of gzip, the actual request size can be a few kilobites larger than the given limit.
+By default, the APM Server limits request payload size to 1 MByte.
 
 [float]
 [[config-api-request-time]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -427,7 +427,7 @@ A higher value also impacts the time until data is indexed and searchable in Ela
 This setting is useful to limit memory consumption if you experience a sudden spike of traffic.
 It has to be provided in *<<config-format-size, size format>>*.
 
-NOTE: Due to internal buffering of gzip, the actual request size can be a few kilobites larger than the given limit.
+NOTE: Due to internal buffering of gzip, the actual request size can be a few kilobytes larger than the given limit.
 By default, the APM Server limits request payload size to 1 MByte.
 
 [float]

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -62,7 +62,7 @@ class Transport(object):
             queued_data = self.queued_data
             queued_data.write((self._json_serializer({event_type: data}) + "\n").encode("utf-8"))
             since_last_flush = timeit.default_timer() - self._last_flush
-            queue_size = 0 if queued_data is None or queued_data.fileobj is None else queued_data.fileobj.tell()
+            queue_size = 0 if queued_data.fileobj is None else queued_data.fileobj.tell()
         if flush:
             logger.debug("forced flush")
             self.flush()
@@ -86,7 +86,8 @@ class Transport(object):
     def queued_data(self):
         if self._queued_data is None:
             self._queued_data = gzip.GzipFile(fileobj=BytesIO(), mode="w", compresslevel=self._compress_level)
-            self._queued_data.write((self._json_serializer({"metadata": self._metadata}) + "\n").encode("utf-8"))
+            data = (self._json_serializer({"metadata": self._metadata}) + "\n").encode("utf-8")
+            self._queued_data.write(data)
         return self._queued_data
 
     def flush(self, sync=False, start_flush_timer=True):

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -1,3 +1,4 @@
+import gzip
 import random
 import string
 import timeit
@@ -6,7 +7,6 @@ import mock
 import pytest
 
 from elasticapm.transport.base import AsyncTransport, Transport, TransportException, TransportState
-from elasticapm.utils import compat
 
 
 def test_transport_state_should_try_online():
@@ -62,9 +62,7 @@ def test_metadata_prepended(mock_send):
     transport.queue("error", {}, flush=True)
     assert mock_send.call_count == 1
     args, kwargs = mock_send.call_args
-    data = args[0]
-    if compat.PY3:
-        data = data.tobytes()
+    data = gzip.decompress(args[0])
     data = data.decode("utf-8").split("\n")
     assert "metadata" in data[0]
 
@@ -157,3 +155,9 @@ def test_send_timer(sending_elasticapm_client, caplog):
     assert "Starting flush timer" in caplog.records[0].message
     assert "Cancelling flush timer" in caplog.records[1].message
     assert "Sent request" in caplog.records[2].message
+
+
+def test_compress_level_sanitization():
+    assert Transport(compress_level=None)._compress_level == 0
+    assert Transport(compress_level=-1)._compress_level == 0
+    assert Transport(compress_level=10)._compress_level == 9

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -7,6 +7,7 @@ import mock
 import pytest
 
 from elasticapm.transport.base import AsyncTransport, Transport, TransportException, TransportState
+from elasticapm.utils import compat
 
 
 def test_transport_state_should_try_online():
@@ -62,7 +63,10 @@ def test_metadata_prepended(mock_send):
     transport.queue("error", {}, flush=True)
     assert mock_send.call_count == 1
     args, kwargs = mock_send.call_args
-    data = gzip.decompress(args[0])
+    if compat.PY2:
+        data = gzip.GzipFile(fileobj=compat.StringIO(args[0])).read()
+    else:
+        data = gzip.decompress(args[0])
     data = data.decode("utf-8").split("\n")
     assert "metadata" in data[0]
 


### PR DESCRIPTION
This is a shot in the dark to fix #348 as I wasn't able to reproduce.

The idea is to move the size check into a code block that is protected by the thread lock, and also to make sure to check that `fileobj` exists.