### PR TITLE
use official ES images from Docker Hub

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - "6379:6379"
 
   elasticsearch6:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.0
+    image: elasticsearch:6.5.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
     environment:
@@ -77,7 +77,7 @@ services:
       - pyesdata6:/usr/share/elasticsearch/data
 
   elasticsearch5:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.0
+    image: elasticsearch:5
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
     environment:


### PR DESCRIPTION
we sometimes experience timeouts with docker.elastic.co, maybe this
helps