### PR TITLE
 Fix extract_signature when sql is a bytes object

### DIFF
--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -123,6 +123,8 @@ def extract_signature(sql):
     :param sql: the SQL statement
     :return: a string representing the signature
     """
+    if isinstance(sql, bytes):
+        sql = sql.decode()
     sql = sql.strip()
     first_space = sql.find(" ")
     if first_space < 0:

--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -7,6 +7,7 @@ import re
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.traces import capture_span
 from elasticapm.utils import compat, wrapt
+from elasticapm.utils.encoding import force_text
 
 
 class Literal(object):
@@ -123,8 +124,7 @@ def extract_signature(sql):
     :param sql: the SQL statement
     :return: a string representing the signature
     """
-    if isinstance(sql, bytes):
-        sql = sql.decode()
+    sql = force_text(sql)
     sql = sql.strip()
     first_space = sql.find(" ")
     if first_space < 0:

--- a/tests/instrumentation/dbapi2_tests.py
+++ b/tests/instrumentation/dbapi2_tests.py
@@ -1,4 +1,4 @@
-from elasticapm.instrumentation.packages.dbapi2 import Literal, scan, tokenize
+from elasticapm.instrumentation.packages.dbapi2 import Literal, scan, tokenize, extract_signature
 
 
 def test_scan_simple():
@@ -38,4 +38,18 @@ def test_scan_double_quotes_at_end():
     tokens = tokenize(sql)
     actual = [t[1] for t in scan(tokens)]
     expected = ["Hello", "Peter", "Pan", "at", "Disney", Literal("'", "World")]
+    assert actual == expected
+
+
+def test_extract_signature_string():
+    sql = "Hello 'Peter Pan' at Disney World"
+    actual = extract_signature(sql)
+    expected = "HELLO"
+    assert actual == expected
+
+
+def test_extract_signature_bytes():
+    sql = b"Hello 'Peter Pan' at Disney World"
+    actual = extract_signature(sql)
+    expected = "HELLO"
     assert actual == expected


### PR DESCRIPTION
In psycopg2's `execute_batch` and `execute_values` functions, the SQL statement is a bytes object and not a string (see psycopg2's [extras.py#L1198](https://github.com/psycopg/psycopg2/blob/60935b9b3d1a32da5ce0702f1bdb71eb148c2b34/lib/extras.py#L1198)). This may also be a problem for other database adapters but I'm only aware of this behavior with psycopg2.

`extract_signature` raises a TypeError when the `sql` parameter is a bytes object because `sql.find(" ")` expects a bytes object and `" "` is a string.

My proposed solution is to check whether `sql` is a bytes object and decode if necessary.

I have signed the CLA.