### PR TITLE
remove custom context of botocore instrumentation

### DIFF
--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -17,12 +17,11 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
         target_endpoint = instance._endpoint.host
         parsed_url = urlparse.urlparse(target_endpoint)
         if "." in parsed_url.hostname:
-            service, region = parsed_url.hostname.split(".", 2)[:2]
+            service = parsed_url.hostname.split(".", 2)[0]
         else:
-            service, region = parsed_url.hostname, None
+            service = parsed_url.hostname
 
         signature = "{}:{}".format(service, operation_name)
-        extra_data = {"service": service, "region": region, "operation": operation_name}
 
-        with capture_span(signature, "ext.http.aws", extra_data, leaf=True):
+        with capture_span(signature, "ext.http.aws", leaf=True):
             return wrapped(*args, **kwargs)

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -24,9 +24,6 @@ def test_botocore_instrumentation(mock_make_request, instrument, elasticapm_clie
     span = elasticapm_client.events[SPAN][0]
 
     assert span["name"] == "ec2:DescribeInstances"
-    assert span["context"]["service"] == "ec2"
-    assert span["context"]["region"] == "us-west-2"
-    assert span["context"]["operation"] == "DescribeInstances"
 
 
 def test_nonstandard_endpoint_url(instrument, elasticapm_client):
@@ -39,6 +36,3 @@ def test_nonstandard_endpoint_url(instrument, elasticapm_client):
     span = elasticapm_client.events[SPAN][0]
 
     assert span["name"] == "example:DescribeInstances"
-    assert span["context"]["service"] == "example"
-    assert span["context"]["region"] is None
-    assert span["context"]["operation"] == "DescribeInstances"


### PR DESCRIPTION
specifically, the `service` property clashes with the existing `context.service` property in the Elasticsearch storage backend