### PR TITLE
ignore codecov errors

### DIFF
--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -6,7 +6,7 @@ function cleanup {
 
     if [[ $CODECOV_TOKEN ]]; then
         cd ..
-        bash <(curl -s https://codecov.io/bash) -e PYTHON_VERSION,WEBFRAMEWORK
+        bash <(curl -s https://codecov.io/bash) -e PYTHON_VERSION,WEBFRAMEWORK || true
     fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
this avoids the whole test run failing if codecov is temporarily unavailable