### PR TITLE
Use native string for disttracing header

### DIFF
--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -56,7 +56,7 @@ class Urllib3Instrumentation(AbstractInstrumentedModule):
                 trace_parent = transaction.trace_parent.copy_from(
                     span_id=parent_id, trace_options=TracingOptions(recorded=True)
                 )
-                headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_ascii()
+                headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_str()
             return wrapped(*args, **kwargs)
 
     def mutate_unsampled_call_args(self, module, method, wrapped, instance, args, kwargs, transaction):
@@ -69,5 +69,5 @@ class Urllib3Instrumentation(AbstractInstrumentedModule):
             if headers is None:
                 headers = {}
                 kwargs["headers"] = headers
-            headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_ascii()
+            headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_str()
         return args, kwargs

--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -56,7 +56,7 @@ class Urllib3Instrumentation(AbstractInstrumentedModule):
                 trace_parent = transaction.trace_parent.copy_from(
                     span_id=parent_id, trace_options=TracingOptions(recorded=True)
                 )
-                headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_str()
+                headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_string()
             return wrapped(*args, **kwargs)
 
     def mutate_unsampled_call_args(self, module, method, wrapped, instance, args, kwargs, transaction):
@@ -69,5 +69,5 @@ class Urllib3Instrumentation(AbstractInstrumentedModule):
             if headers is None:
                 headers = {}
                 kwargs["headers"] = headers
-            headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_str()
+            headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent.to_string()
         return args, kwargs

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -22,9 +22,7 @@ class TraceParent(object):
         )
 
     def to_string(self):
-        return "{:02x}-{}-{}-{:02x}".format(
-            self.version, self.trace_id, self.span_id, self.trace_options.asByte
-        )
+        return "{:02x}-{}-{}-{:02x}".format(self.version, self.trace_id, self.span_id, self.trace_options.asByte)
 
     @classmethod
     def from_string(cls, traceparent_string):

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -22,9 +22,9 @@ class TraceParent(object):
         )
 
     def to_str(self):
-        return str("{:02x}-{}-{}-{:02x}".format(
+        return "{:02x}-{}-{}-{:02x}".format(
             self.version, self.trace_id, self.span_id, self.trace_options.asByte
-        ))
+        )
 
     @classmethod
     def from_string(cls, traceparent_string):

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -21,7 +21,7 @@ class TraceParent(object):
             trace_options or self.trace_options,
         )
 
-    def to_str(self):
+    def to_string(self):
         return "{:02x}-{}-{}-{:02x}".format(
             self.version, self.trace_id, self.span_id, self.trace_options.asByte
         )

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -21,10 +21,10 @@ class TraceParent(object):
             trace_options or self.trace_options,
         )
 
-    def to_ascii(self):
-        return u"{:02x}-{}-{}-{:02x}".format(
+    def to_str(self):
+        return str("{:02x}-{}-{}-{:02x}".format(
             self.version, self.trace_id, self.span_id, self.trace_options.asByte
-        ).encode("ascii")
+        ))
 
     @classmethod
     def from_string(cls, traceparent_string):

--- a/tests/utils/test_disttracing_header.py
+++ b/tests/utils/test_disttracing_header.py
@@ -13,13 +13,13 @@ def test_tracing_options(tracing_bits, expected):
 def test_unknown_header_components_ignored():
     header = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03-xyz"
     trace_parent = TraceParent.from_string(header)
-    assert trace_parent.to_str() == "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
+    assert trace_parent.to_string() == "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
 
 
 def test_trace_parent_to_str():
     header = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
     trace_parent = TraceParent.from_string(header)
-    result = trace_parent.to_str()
+    result = trace_parent.to_string()
     assert isinstance(result, str)
     assert header == result
 

--- a/tests/utils/test_disttracing_header.py
+++ b/tests/utils/test_disttracing_header.py
@@ -1,6 +1,5 @@
 import pytest
 
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 
 
@@ -14,15 +13,15 @@ def test_tracing_options(tracing_bits, expected):
 def test_unknown_header_components_ignored():
     header = "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03-xyz"
     trace_parent = TraceParent.from_string(header)
-    assert trace_parent.to_ascii().decode("ascii") == "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
+    assert trace_parent.to_str() == "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
 
 
-def test_trace_parent_to_ascii():
+def test_trace_parent_to_str():
     header = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
     trace_parent = TraceParent.from_string(header)
-    result = trace_parent.to_ascii()
-    assert isinstance(result, compat.binary_type)
-    assert header.encode("ascii") == result
+    result = trace_parent.to_str()
+    assert isinstance(result, str)
+    assert header == result
 
 
 def test_trace_parent_wrong_version(caplog):


### PR DESCRIPTION
The value of `TRACEPARENT_HEADER_NAME` is set as a byte string. This causes the header dict in `requests` to have mixed string and byte values on Python 3. The expected behaviour is for both keys and values to be native strings, that is the `str` type for both Python 2 and 3.

This behaviour causes our application to crash due to us doing `json.dumps` on `request.headers`:

`TypeError: Object of type bytes is not JSON serializable`
```python
{
"Accept": '*/*',
"Accept-Encoding": 'gzip, deflate',
"Authorization": 'Filtered',
"Connection": 'keep-alive',
"elastic-apm-traceparent": b'00-706eb5e0137e6d165e10d964b00ea43c-70016c1f38b65b27-01',
"User-Agent": 'python-requests/2.19.1'
}
```
