### PR TITLE
use xenial base image for testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: xenial
 language: python
 python:
 - nightly

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -5,7 +5,7 @@ import time
 
 from django.contrib.auth.models import User
 from django.http import HttpResponse, StreamingHttpResponse
-from django.shortcuts import get_object_or_404, render, render_to_response
+from django.shortcuts import get_object_or_404, render
 
 import elasticapm
 
@@ -45,7 +45,7 @@ def decorated_raise_exc(request):
 
 
 def template_exc(request):
-    return render_to_response("error.html")
+    return render(request, "error.html")
 
 
 def ignored_exception(request):


### PR DESCRIPTION
The SQLite version that comes with Ubuntu Precise is no longer supported
by new versions of Django