### PR TITLE
[APM-CI] remove changelog generation from logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,9 +51,6 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}")
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            dir("${BASE_DIR}"){
-              sh "git log origin/${env.CHANGE_TARGET}...${env.GIT_SHA}"
-            }
           }
         }
         /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,9 +240,9 @@ def runScript(Map params = [:]){
   log(level: 'INFO', text: "${label}")
   env.HOME = "${env.WORKSPACE}"
   env.PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-  env.PIP_CACHE = "${WORKSPACE}/.pip"
+  env.PIP_CACHE = "${env.WORKSPACE}/.cache"
   deleteDir()
-  sh "mkdir ${PIP_CACHE}"
+  sh "mkdir ${env.PIP_CACHE}"
   unstash 'source'
   dir("${BASE_DIR}"){
     retry(2){

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -16,7 +16,7 @@ if [ $# -lt 2 ]; then
   exit 2
 fi
 
-pip_cache=${PIP_CACHE:-"$HOME/.cache"}
+pip_cache="$HOME/.cache"
 docker_pip_cache="/tmp/cache/pip"
 
 cd tests


### PR DESCRIPTION
* This code was a test to generate a changelog between two commits and show the info in the log of the job, it is not needed and breaks the build on the master branch because CHANGE_TARGET is only defined on PRs.

* Do not use PIP_CACHE environment variable on run_test.sh, it breaks the old CI, the path value in the old job is relative, it should be absolute.
