### PR TITLE
add some randomness to actual time between requests

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -465,6 +465,9 @@ A higher value also impacts the time until data is indexed and searchable in Ela
 This setting is useful to limit memory consumption if you experience a sudden spike of traffic.
 It has to be provided in *<<config-format-duration, duration format>>*.
 
+NOTE: The actual time will vary between 90-110% of the given value,
+to avoid stampedes of instances that start at the same time.
+
 [float]
 [[config-processors]]
 ==== `processors`

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -85,7 +85,7 @@ def test_flush_time(mock_send, caplog):
         time.sleep(0.2)
         transport.close()
     record = caplog.records[0]
-    assert "0.1" in record.message
+    assert "due to time since last flush" in record.message
     assert mock_send.call_count == 0
 
 


### PR DESCRIPTION
this should avoid stampedes when multiple workers are booted up at the
same time.