### PR TITLE
[docs] Add release-notes page

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -30,3 +30,5 @@ include::./api.asciidoc[API documentation]
 include::./upgrading.asciidoc[Upgrading from previous versions]
 
 include::./tuning.asciidoc[Tuning and Overhead considerations]
+
+include::./release-notes.asciidoc[Release notes]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes]]
+== Release notes
+
+Release notes are published in the https://github.com/elastic/apm-agent-python/blob/master/CHANGELOG.md[changelog].


### PR DESCRIPTION
See elastic/apm#68.

Adds a link to release notes.