### PR TITLE
use worker_init/worker_process_init to start event processor threads in celery

### DIFF
--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -35,8 +35,6 @@ import pytest  # isort:skip
 django = pytest.importorskip("django")  # isort:skip
 celery = pytest.importorskip("celery")  # isort:skip
 
-import mock
-
 from elasticapm.conf.constants import ERROR, TRANSACTION
 from elasticapm.contrib.celery import register_exception_tracking, register_instrumentation
 from tests.contrib.django.testapp.tasks import failing_task, successful_task


### PR DESCRIPTION
Celery uses a prefork model for its worker processes. The app is loaded
in a "worker", which then forks one or more "worker processes". Similiarly
to the uwsgi prefork issues we had to work around, this fork happens
_after_ we created the event processor thread, so the worker processes
don't have an event processor thread of their own, and just fill up the
event queue without it ever being processed.

To work around this, we use worker_init and worker_process_init signals
to start the event processor thread _after_ the fork.

This only became an issue with version 4.2.0 of the agent. In earlier
versions of the agent, threads were started relatively late, after
celery already forked the worker processes.