### PR TITLE
Execution context - use thread locals if gevent/eventlet has monkey patched it

### DIFF
--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -37,6 +37,7 @@ import timeit
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import SPAN, TRANSACTION
+from elasticapm.context import init_execution_context
 from elasticapm.utils import compat, encoding, get_name_from_func
 from elasticapm.utils.disttracing import TraceParent, TracingOptions
 
@@ -51,10 +52,7 @@ _time_func = timeit.default_timer
 TAG_RE = re.compile('[.*"]')
 
 
-try:
-    from elasticapm.context.contextvars import execution_context
-except ImportError:
-    from elasticapm.context.threadlocal import execution_context
+execution_context = init_execution_context()
 
 
 class Transaction(object):

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -1,0 +1,24 @@
+import sys
+
+import elasticapm.context
+from elasticapm.context.threadlocal import ThreadLocalContext
+
+
+def test_execution_context_backing():
+    execution_context = elasticapm.context.init_execution_context()
+
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
+        from elasticapm.context.contextvars import ContextVarsContext
+
+        assert isinstance(execution_context, ContextVarsContext)
+    else:
+        assert isinstance(execution_context, ThreadLocalContext)
+
+
+def test_execution_context_monkeypatched(monkeypatch):
+    with monkeypatch.context() as m:
+        m.setattr(elasticapm.context, "threading_local_monkey_patched", lambda: True)
+        execution_context = elasticapm.context.init_execution_context()
+
+    # Should always use ThreadLocalContext when thread local is monkey patched
+    assert isinstance(execution_context, ThreadLocalContext)


### PR DESCRIPTION
* Extract out logic to decide which backing to use for `execution_context` into a function `init_execution_context`
* Check if `gevent` or `eventlet` has monkey patched `_threading.local`, if it has then use `elasticapm.context.threadlocal` as the backing.