### PR TITLE
fix copyright header check with new grep versions

### DIFF
--- a/tests/scripts/license_headers_check.sh
+++ b/tests/scripts/license_headers_check.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 if [[ $# -eq 0 ]]
-  then
+then
     FILES=$(find . -iname "*.py" -not -path "./elasticapm/utils/wrapt/*" -not -path "./dist/*" -not -path "./build/*" -not -path "./tests/utils/stacks/linenos.py")
 else
     FILES=$@
 fi
 
-echo ${FILES} | xargs -n 1 grep --files-without-match "Copyright (c) [0-9]..., Elastic"
+MISSING=$(grep --files-without-match "Copyright (c) [0-9]..., Elastic" ${FILES})
+
+if [[ -z "$MISSING" ]]
+then
+    exit 0
+else
+    echo "Files with missing copyright header:"
+    echo $MISSING
+    exit 1
+fi


### PR DESCRIPTION
with grep 3.2, a change was introduced that essentially inverts the
exit code returned by grep when using the --files-without-match flag.
To get around this, we calculate our own exit code based on the stdout
output from grep.