### PR TITLE
remove old requests builds from test matrix

### DIFF
--- a/tests/.jenkins_framework_full.yml
+++ b/tests/.jenkins_framework_full.yml
@@ -24,8 +24,6 @@ FRAMEWORK:
   - twisted-17
   - twisted-16
   - twisted-15
-  - requests-1.2
-  - requests-2.0
   - requests-newest
   - boto3-1.0
   - boto3-1.5

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -16,7 +16,6 @@ pathlib==1.0.1
 py-cpuinfo==3.3.0
 statistics==1.0.3.5
 
-# requests <= 2.19 is incompatible with urllib3>=1.24, see https://github.com/requests/requests/issues/4830
 urllib3
 certifi
 Jinja2

--- a/tests/requirements/requirements-requests-1.2.txt
+++ b/tests/requirements/requirements-requests-1.2.txt
@@ -1,3 +1,0 @@
-requests>=1.2,<1.3
-urllib3<1.24
--r requirements-base.txt

--- a/tests/requirements/requirements-requests-2.0.txt
+++ b/tests/requirements/requirements-requests-2.0.txt
@@ -1,3 +1,0 @@
-requests>=2.0,<2.1
-urllib3<1.24
--r requirements-base.txt


### PR DESCRIPTION
unfortunately, due to an incompatibility, it's no longer possible to
have a secure urllib3 version with older versions of requests