### PR TITLE
ci(jenkins): enable pull requests using the upstream repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,7 +179,7 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Python'),
-                           string(name: 'BUILD_OPTS', value: "--with-agent-python-flask --python-agent-package git+https://github.com/${env.CHANGE_FORK}/${env.REPO}.git@${env.GIT_BASE_COMMIT}"),
+                           string(name: 'BUILD_OPTS', value: "--with-agent-python-flask --python-agent-package git+https://github.com/${env.CHANGE_FORK?.trim() ?: 'elastic' }/${env.REPO}.git@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])


### PR DESCRIPTION
## Highlights
- It will enable to use the integrations tests either from pull requests which are coming from a forked repo or from this one.