### PR TITLE
ci: ignore SCM triggers on downstream job

### DIFF
--- a/.ci/jobs/apm-agent-python-downstream.yml
+++ b/.ci/jobs/apm-agent-python-downstream.yml
@@ -10,11 +10,14 @@
     script-path: .ci/downstreamTests.groovy
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
+        property-strategies:
+            all-branches:
+            - suppress-scm-triggering: true
         repo: apm-agent-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken


### PR DESCRIPTION
* ignore SCM triggers on the downstream job
* do not scan PRs on the downstream job