### PR TITLE
feat(jenkins): support check license with go-licenser

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,13 @@ pipeline {
                 ./tests/scripts/docker/black.sh
                 """, label: "Black code formatting"
                 sh script: './tests/scripts/license_headers_check.sh', label: "Copyright notice"
+                catchError(
+                    buildResult: 'SUCCESS',
+                    stageResult: 'UNSTABLE',
+                    message: 'Some files does not contain license'
+                    ) {
+                  checkLicenses(skip: true, junit: true, ext: '.py', licensor: 'Elasticsearch BV')
+                }
               }
             }
           }

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,11 @@ docs:
 update-json-schema:
 	bash ./tests/scripts/download_json_schema.sh
 
-.PHONY: isort flake8 test coverage docs update-json-schema
+check-licenses:
+	@go get -u github.com/elastic/go-licenser
+	@go-licenser -ext .py .
+
+docker-check-licenses:
+	docker run --rm -v "$$PWD":/usr/src -w /usr/src golang:1.12 make check-licenses
+
+.PHONY: isort flake8 test coverage docs update-json-schema check-licenses


### PR DESCRIPTION
## Highlights
- Enable the go-licenser stage in the pipeline
- Enable the go-licenser goal in the makefile.

## Tasks
- [ ] Agree whether this is the approach to go
- [ ] It requires https://github.com/elastic/go-licenser/issues/24 to support the python headers.
- [ ] Makefile and Pipeline could potentially use the same scripts somehow.
- [ ] Pre-commit should be adapted to the go-licenser