### PR TITLE
ci: remove the documentation stage

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -94,38 +94,6 @@ pipeline {
         }
       }
     }
-    /**
-    Build the documentation.
-    */
-    stage('Documentation') {
-      agent { label 'docker && linux && immutable' }
-      options { skipDefaultCheckout() }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-        ELASTIC_DOCS = "${env.WORKSPACE}/elastic/docs"
-      }
-      when {
-        beforeAgent true
-        allOf {
-          anyOf {
-            branch 'master'
-            branch "\\d+\\.\\d+"
-            branch "v\\d?"
-            tag "v\\d+\\.\\d+\\.\\d+*"
-            expression { return params.Run_As_Master_Branch }
-          }
-          expression { return params.doc_ci }
-        }
-      }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          buildDocs(docsDir: "docs", archive: true)
-        }
-      }
-    }
     stage('Building packages') {
       agent { label 'docker && linux && immutable' }
       options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,38 +112,6 @@ pipeline {
         }
       }
     }
-    /**
-    Build the documentation.
-    */
-    stage('Documentation') {
-      agent { label 'docker && linux && immutable' }
-      options { skipDefaultCheckout() }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-        ELASTIC_DOCS = "${env.WORKSPACE}/elastic/docs"
-      }
-      when {
-        beforeAgent true
-        allOf {
-          anyOf {
-            branch 'master'
-            branch "\\d+\\.\\d+"
-            branch "v\\d?"
-            tag "v\\d+\\.\\d+\\.\\d+*"
-            expression { return params.Run_As_Master_Branch }
-          }
-          expression { return params.doc_ci }
-        }
-      }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          buildDocs(docsDir: "docs", archive: true)
-        }
-      }
-    }
     stage('Building packages') {
       agent { label 'docker && linux && immutable' }
       options { skipDefaultCheckout() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
-    booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build docs.')
   }
   stages {
     stage('Initializing'){


### PR DESCRIPTION
Since the documentation team has elastic-ci/docs build in place for all our PRs, our Documentation stage lose sense, we are doing the same and we have to maintain it. Because of that, we will start to remove this stage from all projects.