### PR TITLE
ci: enable pre-commit stage within the Jenkins pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,7 +53,6 @@ pipeline {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     sh script: '''
-                      env | sort
                       curl https://pre-commit.com/install-local.py | python -
                       git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
                     ''', label: 'pre-commit run'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
         }
         stage('Sanity checks') {
           steps {
-            withGithubNotify(context: 'Sanity checks') {
+            withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
               unstash 'source'
               script {
@@ -63,6 +63,7 @@ pipeline {
           }
           post {
             always {
+              preCommitToJunit(input: "${BASE_DIR}/pre-commit.out", output: "${BASE_DIR}/pre-commit-junit.xml")
               archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
               junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -50,10 +50,9 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e HOME=/app -v ${WORKSPACE}/${BASE_DIR}:/app"){
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   sh script: '''
                     env | sort
-                    pwd
                     curl https://pre-commit.com/install-local.py | python -
                     git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
                   ''', label: 'pre-commit run'

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,9 +44,9 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        stage('Check pre-commit') {
+        stage('Sanity checks') {
           steps {
-            withGithubNotify(context: 'Check pre-commit') {
+            withGithubNotify(context: 'Sanity checks') {
               deleteDir()
               unstash 'source'
               script {
@@ -54,7 +54,7 @@ pipeline {
                   dir("${BASE_DIR}"){
                     sh script: '''
                       curl https://pre-commit.com/install-local.py | python -
-                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files | tee pre-commit.out
                     ''', label: 'pre-commit run'
                   }
                 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -61,6 +61,12 @@ pipeline {
               }
             }
           }
+          post {
+            always {
+              archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
+              junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
+            }
+          }
         }
       }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,24 +44,16 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        /**
-        Build the project from code..
-        */
-        stage('Lint') {
+        stage('Check pre-commit') {
           steps {
-            withGithubNotify(context: 'Lint') {
+            withGithubNotify(context: 'Check pre-commit') {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh script: """
-                ./tests/scripts/docker/cleanup.sh
-                ./tests/scripts/docker/isort.sh
-                """, label: "isort import sorting"
-                sh script: """
-                ./tests/scripts/docker/cleanup.sh
-                ./tests/scripts/docker/black.sh
-                """, label: "Black code formatting"
-                sh script: './tests/scripts/license_headers_check.sh', label: "Copyright notice"
+                sh script: '''
+                  curl https://pre-commit.com/install-local.py | python -
+                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                ''', label: 'pre-commit run'
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,11 +49,15 @@ pipeline {
             withGithubNotify(context: 'Check pre-commit') {
               deleteDir()
               unstash 'source'
-              docker.image('python:3.7-stretch').inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
-                sh script: '''
-                  curl https://pre-commit.com/install-local.py | python -
-                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
-                ''', label: 'pre-commit run'
+              script {
+                docker.image('python:3.7-stretch').inside("-e HOME=/app -v ${WORKSPACE}/${BASE_DIR}:/app"){
+                  sh script: '''
+                    env | sort
+                    pwd
+                    curl https://pre-commit.com/install-local.py | python -
+                    git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                  ''', label: 'pre-commit run'
+                }
               }
             }
           }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -51,11 +51,13 @@ pipeline {
               unstash 'source'
               script {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-                  sh script: '''
-                    env | sort
-                    curl https://pre-commit.com/install-local.py | python -
-                    git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
-                  ''', label: 'pre-commit run'
+                  dir("${BASE_DIR}"){
+                    sh script: '''
+                      env | sort
+                      curl https://pre-commit.com/install-local.py | python -
+                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                    ''', label: 'pre-commit run'
+                  }
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             withGithubNotify(context: 'Check pre-commit') {
               deleteDir()
               unstash 'source'
-              dir("${BASE_DIR}"){
+              docker.image('python:3.7-stretch').inside("-v ${WORKSPACE}/${BASE_DIR}:/app"){
                 sh script: '''
                   curl https://pre-commit.com/install-local.py | python -
                   git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3
+    -   id: black
+        language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:
@@ -24,6 +24,6 @@ repos:
         name: License header check
         description: Checks the existance of license headers in all Python files
         entry: ./tests/scripts/license_headers_check.sh
-        exclude: "(elasticapm\/utils\/wrapt\/.*|tests\/utils\/stacks\/linenos.py)"
+        exclude: "(elasticapm/utils/wrapt/.*|tests/utils/stacks/linenos.py)"
         language: script
         types: [python]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,9 +58,9 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        stage('Check pre-commit') {
+        stage('Sanity checks') {
           steps {
-            withGithubNotify(context: 'Check pre-commit') {
+            withGithubNotify(context: 'Sanity checks') {
               deleteDir()
               unstash 'source'
               script {
@@ -68,7 +68,7 @@ pipeline {
                   dir("${BASE_DIR}"){
                     sh script: '''
                       curl https://pre-commit.com/install-local.py | python -
-                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files | tee pre-commit.out
                     ''', label: 'pre-commit run'
                   }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,11 +63,15 @@ pipeline {
             withGithubNotify(context: 'Check pre-commit') {
               deleteDir()
               unstash 'source'
-              dir("${BASE_DIR}"){
-                sh script: '''
-                  curl https://pre-commit.com/install-local.py | python -
-                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
-                ''', label: 'pre-commit run'
+              script {
+                docker.image('python:3.7-stretch').inside("-e HOME=/app -v ${WORKSPACE}/${BASE_DIR}:/app"){
+                  sh script: '''
+                    env | sort
+                    pwd
+                    curl https://pre-commit.com/install-local.py | python -
+                    git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                  ''', label: 'pre-commit run'
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,10 +64,9 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e HOME=/app -v ${WORKSPACE}/${BASE_DIR}:/app"){
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   sh script: '''
                     env | sort
-                    pwd
                     curl https://pre-commit.com/install-local.py | python -
                     git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
                   ''', label: 'pre-commit run'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,7 @@ pipeline {
           }
           post {
             always {
+              preCommitToJunit(input: "${BASE_DIR}/pre-commit.out", output: "${BASE_DIR}/pre-commit-junit.xml")
               archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
               junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,6 @@ pipeline {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     sh script: '''
-                      env | sort
                       curl https://pre-commit.com/install-local.py | python -
                       git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
                     ''', label: 'pre-commit run'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
         }
         stage('Sanity checks') {
           steps {
-            withGithubNotify(context: 'Sanity checks') {
+            withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
               unstash 'source'
               script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,12 @@ pipeline {
               }
             }
           }
+          post {
+            always {
+              archiveArtifacts artifacts: "${BASE_DIR}/pre-commit.out", allowEmptyArchive: true, defaultExcludes: false
+              junit testResults: "${BASE_DIR}/pre-commit-junit.xml", allowEmptyResults: true, keepLongStdio: true
+            }
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,24 +58,16 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }
-        /**
-        Build the project from code..
-        */
-        stage('Lint') {
+        stage('Check pre-commit') {
           steps {
-            withGithubNotify(context: 'Lint') {
+            withGithubNotify(context: 'Check pre-commit') {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh script: """
-                ./tests/scripts/docker/cleanup.sh
-                ./tests/scripts/docker/isort.sh
-                """, label: "isort import sorting"
-                sh script: """
-                ./tests/scripts/docker/cleanup.sh
-                ./tests/scripts/docker/black.sh
-                """, label: "Black code formatting"
-                sh script: './tests/scripts/license_headers_check.sh', label: "Copyright notice"
+                sh script: '''
+                  curl https://pre-commit.com/install-local.py | python -
+                  git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                ''', label: 'pre-commit run'
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,11 +65,13 @@ pipeline {
               unstash 'source'
               script {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-                  sh script: '''
-                    env | sort
-                    curl https://pre-commit.com/install-local.py | python -
-                    git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
-                  ''', label: 'pre-commit run'
+                  dir("${BASE_DIR}"){
+                    sh script: '''
+                      env | sort
+                      curl https://pre-commit.com/install-local.py | python -
+                      git diff-tree --no-commit-id --name-only -r ${GIT_BASE_COMMIT} | xargs pre-commit run --files
+                    ''', label: 'pre-commit run'
+                  }
                 }
               }
             }

--- a/docs/run-tests-locally.asciidoc
+++ b/docs/run-tests-locally.asciidoc
@@ -1,10 +1,16 @@
 [[run-tests-locally]]
 === Run Tests Locally
 
-To run tests locally you can make use of the docker images also used when running the whole test suite with Jenkins. 
+To run tests locally you can make use of the docker images also used when running the whole test suite with Jenkins.
 Running the full test suite first does some linting and then runs the actual tests with different versions of Python and different web frameworks.
 For a full overview of the test matrix and supported versions have a look at
 https://github.com/elastic/apm-agent-python/blob/master/Jenkinsfile[Jenkins Configuration].
+
+[float]
+[[pre-commit]]
+==== Pre Commit
+We run our git hooks on every commit to automatically point out issues in code. Those issues are also detected within the Jenkins pipeline.
+Please follow the installation steps stated in https://pre-commit.com/#install.
 
 [float]
 [[coder-linter]]
@@ -22,12 +28,22 @@ $ ./tests/scripts/docker/flake8.sh <pip-cache-dir>
 ----
 
 [float]
-[[test-documentation]]
-==== Test Documentation
-We test that the documentation can be generated without errors. You can trigger this check by running: 
+[[coder-formatter]]
+==== Code Formatter
+We test that the code is formatted using `black`. You can trigger this check by running:
+
 [source,bash]
 ----
-$ ./tests/scripts/docker/docs.sh 
+$ ./tests/scripts/docker/black.sh <pip-cache-dir>
+----
+
+[float]
+[[test-documentation]]
+==== Test Documentation
+We test that the documentation can be generated without errors. You can trigger this check by running:
+[source,bash]
+----
+$ ./tests/scripts/docker/docs.sh
 ----
 
 [float]
@@ -41,4 +57,3 @@ $ ./tests/scripts/docker/run_tests.sh python-version framework-version <pip-cach
 ----
 NOTE: The `python-version` must be of format `python:version`, e.g. `python:3.6` or `pypy:2`.
 The `framework` must be of format `framework-version`, e.g. `django-1.10` or `flask-0.12`.
-


### PR DESCRIPTION
## Highlights
- Use `pre-commit` as the single source of truth.
- Enable `pre-commit` stage in the CI pipeline.
- Enable GitHub check 
![image](https://user-images.githubusercontent.com/2871786/61880779-6c5c9600-aeed-11e9-8bac-81c5da13155f.png)

- Update docs.
- Fix .pre-commit.yml file `(<unknown>): found unknown escape character while parsing a quoted scalar at line 27 column 18`
- Test output for the pre-commit lint rules in JUnit format.
![image](https://user-images.githubusercontent.com/2871786/61962004-80bd9300-afc0-11e9-9585-12cb29f3164f.png)
