### PR TITLE
ci: fix tag pattern to be REGEX based and less restrictive

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -137,7 +137,7 @@ pipeline {
         beforeAgent true
         beforeInput true
         anyOf {
-          tag "v\\d+\\.\\d+\\.\\d+*"
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
           expression { return params.Run_As_Master_Branch }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
         beforeAgent true
         beforeInput true
         anyOf {
-          tag "v\\d+\\.\\d+\\.\\d+*"
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
           expression { return params.Run_As_Master_Branch }
         }
       }


### PR DESCRIPTION
The current when implementation for the release stage in the CI uses `GLOB` rather than `REGEX` refers to:
- https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/b257a9e40fac92c9880d438a9be787f9a8d23ed8/pipeline-model-definition/src/main/java/org/jenkinsci/plugins/pipeline/modeldefinition/when/impl/TagConditional.java#L83

and [docs](https://jenkins.io/doc/book/pipeline/syntax/#when) see tag section in the [when docs](https://jenkins.io/doc/book/pipeline/syntax/#when) page.

```
The optional parameter comparator may be added after an attribute to specify how any patterns are evaluated for a match: EQUALS for a simple string comparison, GLOB (the default) for an ANT style path glob (same as for example changeset), or REGEXP for regular expression matching. For example: when { tag pattern: "release-\\d+", comparator: "REGEXP"}
```
