### PR TITLE
fixed a bug in the `instrument` config option

### DIFF
--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -308,7 +308,7 @@ class Config(_ConfigBase):
     framework_name = _ConfigValue("FRAMEWORK_NAME", default=None)
     framework_version = _ConfigValue("FRAMEWORK_VERSION", default=None)
     disable_send = _BoolConfigValue("DISABLE_SEND", default=False)
-    instrument = _BoolConfigValue("DISABLE_INSTRUMENTATION", default=True)
+    instrument = _BoolConfigValue("INSTRUMENT", default=True)
     enable_distributed_tracing = _BoolConfigValue("ENABLE_DISTRIBUTED_TRACING", default=True)
     capture_headers = _BoolConfigValue("CAPTURE_HEADERS", default=True)
     django_transaction_name_from_route = _BoolConfigValue("DJANGO_TRANSACTION_NAME_FROM_ROUTE", default=False)


### PR DESCRIPTION
this happened during a rename a while ago. The attribute was renamed,
but not the name in the `ConfigValue` constructor call. Ideally,
`ConfigValue` would get the name from the attribute name, which should
be possible by using a metaclass. Using metaclasses in a shared py2/py3
code base is somewhat cumbersome though, so let's wait with that until
we drop support for Python 2.

fixes #546