### PR TITLE
docs: update branch for 4.x

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,5 @@
-:branch: current
-:server-branch: 6.5
+:branch: 7.3
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
* Updates `4.x` documentation to no longer point to current. It will forever point to APM Server / ES/ Kib `7.3`.
* Removes a very old/unused `server-branch` attribute