### PR TITLE
Update urllib.py

### DIFF
--- a/elasticapm/instrumentation/packages/urllib.py
+++ b/elasticapm/instrumentation/packages/urllib.py
@@ -49,7 +49,7 @@ def request_host(request):
     scheme, host, port = parse_result.scheme, parse_result.hostname, parse_result.port
     try:
         port = int(port)
-    except ValueError:
+    except (ValueError, TypeError):
         pass
     if host == "":
         host = request.get_header("Host", "")


### PR DESCRIPTION
```python
def request_host(request):
    """Return request-host, as defined by RFC 2965.
    Variation from RFC: returned value is lowercased, for convenient
    comparison.
    """
    url = request.get_full_url()
    parse_result = compat.urlparse.urlparse(url)
    scheme, host, port = parse_result.scheme, parse_result.hostname, parse_result.port
    try:
        port = int(port)
    except ValueError:
        pass
    if host == "":
        host = request.get_header("Host", "")

    if port != default_ports.get(scheme):
        host = "%s:%s" % (host, port)
    return host
```
if port is None, the int(port) will raise a TypeError, which is not caught by the exception.Adding TypeError can solve this problem.