### PR TITLE
ci(jenkins): decouple linting from the main CI pipeline

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -45,6 +45,12 @@ pipeline {
           }
         }
         stage('Sanity checks') {
+          when {
+            beforeAgent true
+            not {
+              changeRequest()
+            }
+          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()

--- a/.ci/jobs/apm-agent-python-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-python-linting-mbp.yml
@@ -16,16 +16,13 @@
         discover-pr-origin: merge-current
         discover-tags: false
         notification-context: 'apm-ci/linting'
+        head-filter-regex: '^PR-.*$'
         repo: apm-agent-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
-        - regular-branches: true
         - change-request:
             ignore-target-only-changes: false
         clean:

--- a/.ci/jobs/apm-agent-python-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-python-linting-mbp.yml
@@ -1,13 +1,13 @@
 ---
 - job:
-    name: apm-agent-python/apm-agent-python-mbp0
-    display-name: APM Agent Python (New version)
-    description: APM Agent Python
+    name: apm-agent-python/apm-agent-python-linting-mbp
+    display-name: APM Agent Python Linting
+    description: APM Agent Python Linting
     view: APM-CI
     project-type: multibranch
     concurrent: true
     node: linux
-    script-path: .ci/Jenkinsfile
+    script-path: .ci/linting.groovy
     scm:
     - github:
         branch-discovery: no-pr
@@ -15,6 +15,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
+        notification-context: 'apm-ci/linting'
         repo: apm-agent-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
@@ -25,6 +26,8 @@
             ignore-tags-older-than: -1
             ignore-tags-newer-than: -1
         - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
         clean:
           after: true
           before: true

--- a/.ci/jobs/apm-agent-python-mbp.yml
+++ b/.ci/jobs/apm-agent-python-mbp.yml
@@ -10,7 +10,7 @@
     script-path: Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -1,0 +1,34 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+pipeline {
+  agent any
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?lint(?:\\W+please)?.*')
+  }
+  stages {
+    stage('Sanity checks') {
+      agent { label 'docker && linux && immutable' }
+      environment {
+        HOME = "${env.WORKSPACE}"
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+      }
+      steps {
+        script {
+          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+            preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,12 @@ pipeline {
           }
         }
         stage('Sanity checks') {
+          when {
+            beforeAgent true
+            not {
+              changeRequest()
+            }
+          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()


### PR DESCRIPTION
## Highlights
- The main pipeline has been split into two `pipelines`.
- The main pipeline will evaluate the `sanity check` stage in the branches only.
- The new pipeline will run the `sanity-check` for the PRs only.
- The new pipeline will create a new GitHub check called `apm-ci/linting/pr-merge`

@beniwohli, not sure whether this approach could help to get some quick feedback independently whether the PRs are coming from someone with write privileges in this repo or a contributor. 