### PR TITLE
fix: it does not use the gitCheckout step anymore

### DIFF
--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -24,8 +24,9 @@ pipeline {
       }
       steps {
         script {
+          def sha = getGitCommitSha()
           docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-            preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+            preCommit(commit: "${sha}", junit: true)
           }
         }
       }


### PR DESCRIPTION
# Highlights
- This pipeline does not use the gitCheckout step anymore as it does only care of the linting so not further requirements to skip the build