### PR TITLE
ci(jenkins): delegate docker setup to the preCommit step

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,11 +56,8 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-                  dir("${BASE_DIR}"){
-                    // Let's disable the docker login within the docker.image closure.
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
-                  }
+                dir(BASE_DIR){
+                  preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, dockerImage: 'python:3.7-stretch')
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,8 @@ pipeline {
               script {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                    // Let's disable the docker login within the docker.image closure.
+                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
                   }
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,8 +56,8 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside {
-                  dir(BASE_DIR){
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+                  dir("${BASE_DIR}"){
                     // Let's disable the docker login within the docker.image closure.
                     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
                   }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,8 +56,8 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-                  dir("${BASE_DIR}"){
+                docker.image('python:3.7-stretch').inside {
+                  dir(BASE_DIR){
                     // Let's disable the docker login within the docker.image closure.
                     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
                   }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -25,7 +25,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+          docker.image('python:3.7-stretch').inside {
             // Let's disable the docker login within the docker.image closure.
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -25,7 +25,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside {
+          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
             // Let's disable the docker login within the docker.image closure.
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -25,10 +25,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-            // Let's disable the docker login within the docker.image closure.
-            preCommit(commit: "${sha}", junit: true, registry: '')
-          }
+          preCommit(commit: "${sha}", junit: true, dockerImage: 'python:3.7-stretch')
         }
       }
     }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -26,7 +26,8 @@ pipeline {
         script {
           def sha = getGitCommitSha()
           docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-            preCommit(commit: "${sha}", junit: true)
+            // Let's disable the docker login within the docker.image closure.
+            preCommit(commit: "${sha}", junit: true, registry: '')
           }
         }
       }


### PR DESCRIPTION
## Highlights
- preCommit step provides support to the dockerImage requirement.

## Reasons
- Docker login is not required for this particular sanity checks.
- Docker login does not work within the context of the docker.image.
