### PR TITLE
ci(jenkins): delegate docker setup to the preCommit step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,10 +70,8 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-                  dir("${BASE_DIR}"){
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
-                  }
+                dir(BASE_DIR){
+                  preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, dockerImage: 'python:3.7-stretch')
                 }
               }
             }


### PR DESCRIPTION
This is caused by https://github.com/elastic/apm-agent-python/pull/557 as we do have 2 Jenkinsfile so far