### PR TITLE
Revert "ci(jenkins): delegate docker setup to the preCommit step"

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -47,8 +47,9 @@ pipeline {
         stage('Sanity checks') {
           when {
             beforeAgent true
-            not {
-              changeRequest()
+            anyOf {
+              not { changeRequest() }
+              expression { return params.Run_As_Master_Branch }
             }
           }
           steps {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,8 +56,10 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                dir(BASE_DIR){
-                  preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, dockerImage: 'python:3.7-stretch')
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+                  dir("${BASE_DIR}"){
+                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                  }
                 }
               }
             }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,8 @@ pipeline {
               script {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true)
+                    // registry: '' will help to disable the docker login
+                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
                   }
                 }
               }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -25,7 +25,9 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          preCommit(commit: "${sha}", junit: true, dockerImage: 'python:3.7-stretch')
+          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+            preCommit(commit: "${sha}", junit: true)
+          }
         }
       }
     }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -26,7 +26,8 @@ pipeline {
         script {
           def sha = getGitCommitSha()
           docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-            preCommit(commit: "${sha}", junit: true)
+            // registry: '' will help to disable the docker login
+            preCommit(commit: "${sha}", junit: true, registry: '')
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,9 @@ pipeline {
         stage('Sanity checks') {
           when {
             beforeAgent true
-            not {
-              changeRequest()
+            anyOf {
+              not { changeRequest() }
+              expression { return params.Run_As_Master_Branch }
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,8 +70,11 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                dir(BASE_DIR){
-                  preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, dockerImage: 'python:3.7-stretch')
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+                  dir("${BASE_DIR}"){
+                    // registry: '' will help to disable the docker login
+                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
+                  }
                 }
               }
             }


### PR DESCRIPTION
Reverts elastic/apm-agent-python#557

I'm afraid the proposed approach seems to be quite problematic when running the pre-commit-venv internals. So let's keep it as it was.

For the record I managed to reproduce the same issue locally running docker:

```
docker run --rm -ti -u "$(id -u):$(id -g)" -e PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$(pwd)/bin -v $(pwd):$(pwd):rw,z python:3.7-stretch /bin/bash
I have no name!@5a742775abbd:~$ HOME=/Users/vmartinez/work/src/github.com/elastic/apm-agent-python
I have no name!@5a742775abbd:~$ PATH=$PATH:$HOME/bin
...
I have no name!@5a742775abbd:~$ env
LANG=C.UTF-8
HOSTNAME=5a742775abbd
OLDPWD=/
GPG_KEY=0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
PWD=/Users/vmartinez/work/src/github.com/elastic/apm-agent-python
PYTHON_GET_PIP_SHA256=201edc6df416da971e64cc94992d2dd24bc328bada7444f0c4f2031ae31e8dad
HOME=/Users/vmartinez/work/src/github.com/elastic/apm-agent-python
PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/0c72a3b4ece313faccb446a96c84770ccedc5ec5/get-pip.py
TERM=xterm
PYTHON_VERSION=3.7.4
SHLVL=1
PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/vmartinez/work/src/github.com/elastic/apm-agent-python/bin:/Users/vmartinez/work/src/github.com/elastic/apm-agent-python/bin
PYTHON_PIP_VERSION=19.2.2

...

I have no name!@5a742775abbd:~/.pre-commit-venv/bin$ curl https://pre-commit.com/install-local.py | python - 

...Installing setuptools, pip, wheel...done.
Traceback (most recent call last):
  File "/tmp/.virtualenv-pkg/virtualenv.py", line 2328, in <module>
    main()
  File "/tmp/.virtualenv-pkg/virtualenv.py", line 713, in main
    symlink=options.symlink)
  File "/tmp/.virtualenv-pkg/virtualenv.py", line 945, in create_environment
    download=download,
  File "/tmp/.virtualenv-pkg/virtualenv.py", line 901, in install_wheel
    call_subprocess(cmd, show_stdout=False, extra_env=env, stdin=SCRIPT)
  File "/tmp/.virtualenv-pkg/virtualenv.py", line 797, in call_subprocess
    % (cmd_desc, proc.returncode))
OSError: Command /Users/vmartinez/wor...mmit-venv/bin/python - setuptools pip wheel failed with error code 1
Traceback (most recent call last):
  File "<stdin>", line 103, in <module>
  File "<stdin>", line 80, in main
  File "/usr/local/lib/python3.7/subprocess.py", line 342, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/local/lib/python3.7/subprocess.py", line 323, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/local/lib/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/local/lib/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/vmartinez/work/src/github.com/elastic/apm-agent-python/.pre-commit-venv/bin/pip': '/Users/vmartinez/work/src/github.com/elastic/apm-agent-python/.pre-commit-venv/bin/pip'

```