### PR TITLE
Handle empty response from APM Server's config endpoint more gracefully

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -117,7 +117,8 @@ class Transport(HTTPTransportBase):
                         "environment": "bar"
                     }
                 }
-        :return: a three-tuple of new version, config dictionary and validity in seconds, or None
+        :return: a three-tuple of new version, config dictionary and validity in seconds.
+                 Any element of the tuple can be None.
         """
         url = self._config_url
         data = json_encoder.dumps(keys).encode("utf-8")

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -106,6 +106,19 @@ class Transport(HTTPTransportBase):
                 response.close()
 
     def get_config(self, current_version=None, keys=None):
+        """
+        Gets configuration from a remote APM Server
+
+        :param current_version: version of the current configuration
+        :param keys: a JSON-serializable dict to identify this instance, e.g.
+                {
+                    "service": {
+                        "name": "foo",
+                        "environment": "bar"
+                    }
+                }
+        :return: a three-tuple of new version, config dictionary and validity in seconds, or None
+        """
         url = self._config_url
         data = json_encoder.dumps(keys).encode("utf-8")
         headers = self._headers.copy()
@@ -124,13 +137,17 @@ class Transport(HTTPTransportBase):
             try:
                 max_age = int(next(re.finditer(r"max-age=(\d+)", response.headers["Cache-Control"])).groups()[0])
             except StopIteration:
-                logger.debug("Could not parse Cache-Control header: %s", response["Cache-Control"])
+                logger.debug("Could not parse Cache-Control header: %s", response.headers["Cache-Control"])
         if response.status == 304:
             # config is unchanged, return
             logger.debug("Configuration unchanged")
             return current_version, None, max_age
         elif response.status >= 400:
             return None, None, max_age
+
+        if not body:
+            logger.debug("APM Server answered with empty body and status code %s", response.status)
+            return current_version, None, max_age
 
         return response.headers.get("Etag"), json_encoder.loads(body.decode("utf-8")), max_age
 

--- a/elasticapm/transport/http_base.py
+++ b/elasticapm/transport/http_base.py
@@ -83,7 +83,8 @@ class HTTPTransportBase(Transport):
                         "environment": "bar"
                     }
                 }
-        :return: a three-tuple of new version, config dictionary and validity in seconds, or None
+        :return: a three-tuple of new version, config dictionary and validity in seconds.
+                 Any element of the tuple can be None.
         """
         raise NotImplementedError()
 

--- a/elasticapm/transport/http_base.py
+++ b/elasticapm/transport/http_base.py
@@ -75,6 +75,7 @@ class HTTPTransportBase(Transport):
         """
         Gets configuration from a remote APM Server
 
+        :param current_version: version of the current configuration
         :param keys: a JSON-serializable dict to identify this instance, e.g.
                 {
                     "service": {
@@ -82,8 +83,7 @@ class HTTPTransportBase(Transport):
                         "environment": "bar"
                     }
                 }
-        :param current_version: version of the current configuration
-        :return: dictionary or None
+        :return: a three-tuple of new version, config dictionary and validity in seconds, or None
         """
         raise NotImplementedError()
 

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -225,6 +225,14 @@ def test_ssl_cert_pinning_fails(waiting_httpsserver):
     assert "Fingerprints did not match" in exc_info.value.args[0]
 
 
+def test_config_url():
+    transport = Transport("http://example.com/" + constants.EVENTS_API_PATH)
+    try:
+        assert transport._config_url == "http://example.com/" + constants.AGENT_CONFIG_PATH
+    finally:
+        transport.close()
+
+
 def test_get_config(waiting_httpserver):
     waiting_httpserver.serve_content(
         code=200, content=b'{"x": "y"}', headers={"Cache-Control": "max-age=5", "Etag": "2"}


### PR DESCRIPTION
also, add a bunch of tests that went forgotten in the original PR

fixes #562