### PR TITLE
Catch TypeError if port is not set

### DIFF
--- a/elasticapm/instrumentation/packages/urllib.py
+++ b/elasticapm/instrumentation/packages/urllib.py
@@ -49,7 +49,7 @@ def request_host(request):
     scheme, host, port = parse_result.scheme, parse_result.hostname, parse_result.port
     try:
         port = int(port)
-    except ValueError:
+    except (ValueError, TypeError):
         pass
     if host == "":
         host = request.get_header("Host", "")


### PR DESCRIPTION
If the port not found in the parse result the instrumentation will fail with
`int() argument must be a string, a bytes-like object or a number, not 'NoneType'`

Reproducing

* parse url with feedparser 5.2.1
`document = feedparser.parse("https://www.python.org/jobs/feed/rss/")`
* this will raise an issue
`int() argument must be a string, a bytes-like object or a number, not 'NoneType'`

https://github.com/elastic/apm-agent-python/blob/a55ec2cdddf4867b3e07b4c1e9c4cd206636eaca/elasticapm/instrumentation/packages/urllib.py#L51

It comes from here it seems the typeerror is not handled

Our workaround in the moment is this to set directly the port.

`document = feedparser.parse("https://www.python.org:443/jobs/feed/rss/")`