### PR TITLE
ci(jenkins): avoid using the any agent to skip running in the master-worker

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,7 +4,7 @@
 import co.elastic.matrix.*
 
 pipeline {
-  agent any
+  agent none
   environment {
     BASE_DIR="src/github.com/elastic/apm-agent-python"
     PIPELINE_LOG_LEVEL='INFO'
@@ -163,7 +163,9 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      node('linux && immutable') {
+        notifyBuildResult()
+      }
     }
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -163,9 +163,7 @@ pipeline {
   }
   post {
     cleanup {
-      node('linux && immutable') {
-        notifyBuildResult()
-      }
+      notifyBuildResult()
     }
   }
 }

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -104,8 +104,8 @@ pipeline {
             }
           }
         }
-        notifyBuildResult()
       }
+      notifyBuildResult()
     }
   }
 }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent none
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,8 +211,8 @@ pipeline {
             }
           }
         }
-        notifyBuildResult()
       }
+      notifyBuildResult()
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def pythonTasksGen
 
 pipeline {
-  agent any
+  agent none
   environment {
     REPO = 'apm-agent-python'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -196,21 +196,23 @@ pipeline {
   }
   post {
     cleanup {
-      script{
-        if(pythonTasksGen?.results){
-          writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
-          def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
-          def processor = new ResultsProcessor()
-          processor.processResults(mapResults)
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-          catchError(buildResult: 'SUCCESS') {
-            def datafile = readFile(file: "results.json")
-            def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
-            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
+      node('linux && immutable') {
+        script{
+          if(pythonTasksGen?.results){
+            writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
+            def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
+            def processor = new ResultsProcessor()
+            processor.processResults(mapResults)
+            archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
+            catchError(buildResult: 'SUCCESS') {
+              def datafile = readFile(file: "results.json")
+              def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
+              sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
+            }
           }
         }
+        notifyBuildResult()
       }
-      notifyBuildResult()
     }
   }
 }


### PR DESCRIPTION
## Highlights
- When working with ephemeral workers the only agent which might be always up is the `master` one, besides the static workers if any. So far, we don't have any after moving to windows ephemeral workers.
- This will help to avoid overloading the master, although might consume another worker which will be active from the very beginning of the pipeline until the very end as the post step happens at the `stages` level.
- This particular change will help to scale up when the build queue is long but will increase a bit the wait time.
- In other words, there are three major concepts regarding the overall time:
  - Waste of time for resources during the build
  - Waste of time for resources in the queue
  - Real build time.
- This particular fix will increase the time for the first one but will reduce the time in the queue.
