### PR TITLE
ci(jenkins): the environment GIT_BASE_COMMIT is not accessible

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,34 +67,34 @@ pipeline {
             }
           }
         }
-      }
-    }
-    /**
-    Execute unit tests.
-    */
-    stage('Test') {
-      agent { label 'linux && immutable' }
-      options {
-        timeout(time: 1, unit: 'HOURS')
-        skipDefaultCheckout()
-      }
-      steps {
-        withGithubNotify(context: 'Test', tab: 'tests') {
-        deleteDir()
-        unstash "source"
-        dir("${BASE_DIR}"){
-          script {
-            def node = readYaml(file: '.ci/.jenkins_python.yml')
-            def parallelTasks = [:]
-            node['PYTHON_VERSION'].each{ version ->
-              parallelTasks["${version}"] = generateStep(version)
-            }
-            parallel(parallelTasks)
+        /**
+        Execute unit tests.
+        */
+        stage('Test') {
+          options {
+            timeout(time: 1, unit: 'HOURS')
+            skipDefaultCheckout()
+          }
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash "source"
+              dir("${BASE_DIR}"){
+                script {
+                  def node = readYaml(file: '.ci/.jenkins_python.yml')
+                  def parallelTasks = [:]
+                  node['PYTHON_VERSION'].each{ version ->
+                    parallelTasks["${version}"] = generateStep(version)
+                  }
+                  parallel(parallelTasks)
+                }
+              }
             }
           }
         }
       }
     }
+
     stage('Building packages') {
       agent { label 'docker && linux && immutable' }
       options {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,7 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
+It does store the env GIT_SHA
 */
 @Field def gitCommit
 
@@ -49,7 +50,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}")
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitCommit = env.GIT_BASE_COMMIT
+              gitCommit = env.GIT_SHA
             }
           }
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,6 +2,12 @@
 @Library('apm@current') _
 
 import co.elastic.matrix.*
+import groovy.transform.Field
+
+/**
+This is the git commit sha which it's required to be used in different stages.
+*/
+@Field def gitCommit
 
 pipeline {
   agent none
@@ -42,6 +48,9 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}")
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              gitCommit = env.GIT_BASE_COMMIT
+            }
           }
         }
         stage('Sanity checks') {
@@ -60,36 +69,35 @@ pipeline {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
+                    preCommit(commit: "${gitCommit}", junit: true, registry: '')
                   }
                 }
               }
             }
           }
         }
-      }
-    }
-    /**
-    Execute unit tests.
-    */
-    stage('Test') {
-      agent { label 'linux && immutable' }
-      options {
-        timeout(time: 1, unit: 'HOURS')
-        skipDefaultCheckout()
-      }
-      steps {
-        withGithubNotify(context: 'Test', tab: 'tests') {
-        deleteDir()
-        unstash "source"
-        dir("${BASE_DIR}"){
-          script {
-            def node = readYaml(file: '.ci/.jenkins_python.yml')
-            def parallelTasks = [:]
-            node['PYTHON_VERSION'].each{ version ->
-              parallelTasks["${version}"] = generateStep(version)
-            }
-            parallel(parallelTasks)
+        /**
+        Execute unit tests.
+        */
+        stage('Test') {
+          options {
+            timeout(time: 1, unit: 'HOURS')
+            skipDefaultCheckout()
+          }
+          steps {
+            withGithubNotify(context: 'Test', tab: 'tests') {
+              deleteDir()
+              unstash "source"
+              dir("${BASE_DIR}"){
+                script {
+                  def node = readYaml(file: '.ci/.jenkins_python.yml')
+                  def parallelTasks = [:]
+                  node['PYTHON_VERSION'].each{ version ->
+                    parallelTasks["${version}"] = generateStep(version)
+                  }
+                  parallel(parallelTasks)
+                }
+              }
             }
           }
         }
@@ -177,7 +185,7 @@ def generateStep(version){
     build(job: "apm-agent-python/apm-agent-python-downstream/${branch}",
       parameters: [
         string(name: 'PYTHON_VERSION', value: version),
-        string(name: 'BRANCH_SPECIFIER', value: env.GIT_BASE_COMMIT),
+        string(name: 'BRANCH_SPECIFIER', value: gitCommit),
         string(name: 'MERGE_TARGET', value: branch),
       ],
       propagate: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -67,34 +67,34 @@ pipeline {
             }
           }
         }
-        /**
-        Execute unit tests.
-        */
-        stage('Test') {
-          options {
-            timeout(time: 1, unit: 'HOURS')
-            skipDefaultCheckout()
-          }
-          steps {
-            withGithubNotify(context: 'Test', tab: 'tests') {
-              deleteDir()
-              unstash "source"
-              dir("${BASE_DIR}"){
-                script {
-                  def node = readYaml(file: '.ci/.jenkins_python.yml')
-                  def parallelTasks = [:]
-                  node['PYTHON_VERSION'].each{ version ->
-                    parallelTasks["${version}"] = generateStep(version)
-                  }
-                  parallel(parallelTasks)
-                }
-              }
+      }
+    }
+    /**
+    Execute unit tests.
+    */
+    stage('Test') {
+      agent { label 'linux && immutable' }
+      options {
+        timeout(time: 1, unit: 'HOURS')
+        skipDefaultCheckout()
+      }
+      steps {
+        withGithubNotify(context: 'Test', tab: 'tests') {
+        deleteDir()
+        unstash "source"
+        dir("${BASE_DIR}"){
+          script {
+            def node = readYaml(file: '.ci/.jenkins_python.yml')
+            def parallelTasks = [:]
+            node['PYTHON_VERSION'].each{ version ->
+              parallelTasks["${version}"] = generateStep(version)
+            }
+            parallel(parallelTasks)
             }
           }
         }
       }
     }
-
     stage('Building packages') {
       agent { label 'docker && linux && immutable' }
       options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,11 @@ it is need as field to store the results of the tests.
 */
 @Field def pythonTasksGen
 
+/**
+This is the git commit sha which it's required to be used in different stages.
+*/
+@Field def gitCommit
+
 pipeline {
   agent none
   environment {
@@ -56,6 +61,9 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              gitCommit = env.GIT_BASE_COMMIT
+            }
           }
         }
         stage('Sanity checks') {
@@ -74,7 +82,7 @@ pipeline {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
-                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
+                    preCommit(commit: "${gitCommit}", junit: true, registry: '')
                   }
                 }
               }
@@ -147,10 +155,10 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Python'),
-                           string(name: 'BUILD_OPTS', value: "--with-agent-python-flask --python-agent-package git+https://github.com/${env.CHANGE_FORK?.trim() ?: 'elastic' }/${env.REPO}.git@${env.GIT_BASE_COMMIT}"),
+                           string(name: 'BUILD_OPTS', value: "--with-agent-python-flask --python-agent-package git+https://github.com/${env.CHANGE_FORK?.trim() ?: 'elastic' }/${env.REPO}.git@${gitCommit}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ it is need as field to store the results of the tests.
 
 /**
 This is the git commit sha which it's required to be used in different stages.
+It does store the env GIT_SHA
 */
 @Field def gitCommit
 
@@ -62,7 +63,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitCommit = env.GIT_BASE_COMMIT
+              gitCommit = env.GIT_SHA
             }
           }
         }


### PR DESCRIPTION
## Highlights
- https://github.com/elastic/apm-agent-python/pull/568 caused a regression as the env variable is defined at the worker level.
- `@Field` helps to create global variables, therefore `gitCommit` is the new variable which does substitute the environment variable.
- Avoid using a worker for running the tests, and reuse the top-level one
- GIT_SHA rather than GIT_BASE_COMMIT as the last one is caused when doing a merge within a PR.