### PR TITLE
ci(jenkins): revert none agent

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,13 +2,6 @@
 @Library('apm@current') _
 
 import co.elastic.matrix.*
-import groovy.transform.Field
-
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
-*/
-@Field def gitCommit
 
 pipeline {
   agent none
@@ -49,9 +42,6 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}")
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              gitCommit = env.GIT_SHA
-            }
           }
         }
         stage('Sanity checks') {
@@ -70,35 +60,36 @@ pipeline {
                 docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
-                    preCommit(commit: "${gitCommit}", junit: true, registry: '')
+                    preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
                   }
                 }
               }
             }
           }
         }
-        /**
-        Execute unit tests.
-        */
-        stage('Test') {
-          options {
-            timeout(time: 1, unit: 'HOURS')
-            skipDefaultCheckout()
-          }
-          steps {
-            withGithubNotify(context: 'Test', tab: 'tests') {
-              deleteDir()
-              unstash "source"
-              dir("${BASE_DIR}"){
-                script {
-                  def node = readYaml(file: '.ci/.jenkins_python.yml')
-                  def parallelTasks = [:]
-                  node['PYTHON_VERSION'].each{ version ->
-                    parallelTasks["${version}"] = generateStep(version)
-                  }
-                  parallel(parallelTasks)
-                }
-              }
+      }
+    }
+    /**
+    Execute unit tests.
+    */
+    stage('Test') {
+      agent { label 'linux && immutable' }
+      options {
+        timeout(time: 1, unit: 'HOURS')
+        skipDefaultCheckout()
+      }
+      steps {
+        withGithubNotify(context: 'Test', tab: 'tests') {
+        deleteDir()
+        unstash "source"
+        dir("${BASE_DIR}"){
+          script {
+            def node = readYaml(file: '.ci/.jenkins_python.yml')
+            def parallelTasks = [:]
+            node['PYTHON_VERSION'].each{ version ->
+              parallelTasks["${version}"] = generateStep(version)
+            }
+            parallel(parallelTasks)
             }
           }
         }
@@ -186,7 +177,7 @@ def generateStep(version){
     build(job: "apm-agent-python/apm-agent-python-downstream/${branch}",
       parameters: [
         string(name: 'PYTHON_VERSION', value: version),
-        string(name: 'BRANCH_SPECIFIER', value: gitCommit),
+        string(name: 'BRANCH_SPECIFIER', value: env.GIT_BASE_COMMIT),
         string(name: 'MERGE_TARGET', value: branch),
       ],
       propagate: true,

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,7 +4,7 @@
 import co.elastic.matrix.*
 
 pipeline {
-  agent none
+  agent any
   environment {
     BASE_DIR="src/github.com/elastic/apm-agent-python"
     PIPELINE_LOG_LEVEL='INFO'

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def pythonTasksGen
 
 pipeline {
-  agent none
+  agent any
   environment {
     REPO="git@github.com:elastic/apm-agent-python.git"
     BASE_DIR="src/github.com/elastic/apm-agent-python"
@@ -89,19 +89,17 @@ pipeline {
   }
   post {
     cleanup {
-      node('linux && immutable') {
-        script{
-          if(pythonTasksGen?.results){
-            writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
-            def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
-            def processor = new ResultsProcessor()
-            processor.processResults(mapResults)
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-            catchError(buildResult: 'SUCCESS') {
-              def datafile = readFile(file: "results.json")
-              def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
-              sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
-            }
+      script{
+        if(pythonTasksGen?.results){
+          writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
+          def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
+          def processor = new ResultsProcessor()
+          processor.processResults(mapResults)
+          archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
+          catchError(buildResult: 'SUCCESS') {
+            def datafile = readFile(file: "results.json")
+            def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
+            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
           }
         }
       }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent none
+  agent any
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def pythonTasksGen
 
 pipeline {
-  agent none
+  agent any
   environment {
     REPO = 'apm-agent-python'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -196,19 +196,17 @@ pipeline {
   }
   post {
     cleanup {
-      node('linux && immutable') {
-        script{
-          if(pythonTasksGen?.results){
-            writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
-            def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
-            def processor = new ResultsProcessor()
-            processor.processResults(mapResults)
-            archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-            catchError(buildResult: 'SUCCESS') {
-              def datafile = readFile(file: "results.json")
-              def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
-              sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
-            }
+      script{
+        if(pythonTasksGen?.results){
+          writeJSON(file: 'results.json', json: toJSON(pythonTasksGen.results), pretty: 2)
+          def mapResults = ["${params.agent_integration_test}": pythonTasksGen.results]
+          def processor = new ResultsProcessor()
+          processor.processResults(mapResults)
+          archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
+          catchError(buildResult: 'SUCCESS') {
+            def datafile = readFile(file: "results.json")
+            def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
+            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
           }
         }
       }


### PR DESCRIPTION
This reverts https://github.com/elastic/apm-agent-python/pull/569 and https://github.com/elastic/apm-agent-python/pull/568

## Highlights
- As long as we use the share step `gitCheckout` we might need to use the agent top-level to share the env variables between stages.
- It's not ideal but even though the changes were quite straight, its behavior was not as expected. 
- Let's keep the pipeline stable for now and we will figure out what's going on.