### PR TITLE
Fix to only add assert_hostname for https urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+[Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.1...master)
+
+### Bugfixes
+ * fixed an issue with http server_url and `'VERIFY_SERVER_CERT': False` (#570, #578)
+
 ## v5.1.1 
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.0...v5.1.1)
 

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -51,12 +51,12 @@ class Transport(HTTPTransportBase):
         super(Transport, self).__init__(url, **kwargs)
         url_parts = compat.urlparse.urlparse(url)
         pool_kwargs = {"cert_reqs": "CERT_REQUIRED", "ca_certs": certifi.where(), "block": True}
-        if self._server_cert and not url.startswith("http://"):
+        if self._server_cert and url_parts.scheme != "http":
             pool_kwargs.update(
                 {"assert_fingerprint": self.cert_fingerprint, "assert_hostname": False, "cert_reqs": ssl.CERT_NONE}
             )
             del pool_kwargs["ca_certs"]
-        elif not self._verify_server_cert and not url.startswith("http://"):
+        elif not self._verify_server_cert and url_parts.scheme != "http":
             pool_kwargs["cert_reqs"] = ssl.CERT_NONE
             pool_kwargs["assert_hostname"] = False
         proxies = compat.getproxies_environment()

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -51,12 +51,12 @@ class Transport(HTTPTransportBase):
         super(Transport, self).__init__(url, **kwargs)
         url_parts = compat.urlparse.urlparse(url)
         pool_kwargs = {"cert_reqs": "CERT_REQUIRED", "ca_certs": certifi.where(), "block": True}
-        if self._server_cert:
+        if self._server_cert and not url.startswith("http://"):
             pool_kwargs.update(
                 {"assert_fingerprint": self.cert_fingerprint, "assert_hostname": False, "cert_reqs": ssl.CERT_NONE}
             )
             del pool_kwargs["ca_certs"]
-        elif not self._verify_server_cert:
+        elif not self._verify_server_cert and not url.startswith("http://"):
             pool_kwargs["cert_reqs"] = ssl.CERT_NONE
             pool_kwargs["assert_hostname"] = False
         proxies = compat.getproxies_environment()

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -188,6 +188,16 @@ def test_ssl_verify_disable(waiting_httpsserver):
         transport.close()
 
 
+def test_ssl_verify_disable_http(waiting_httpserver):
+    waiting_httpserver.serve_content(code=202, content="", headers={"Location": "http://example.com/foo"})
+    transport = Transport(waiting_httpserver.url, verify_server_cert=False)
+    try:
+        url = transport.send(compat.b("x"))
+        assert url == "http://example.com/foo"
+    finally:
+        transport.close()
+
+
 def test_ssl_cert_pinning(waiting_httpsserver):
     waiting_httpsserver.serve_content(code=202, content="", headers={"Location": "https://example.com/foo"})
     cur_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Given an http:// server url and `'VERIFY_SERVER_CERT': False`,
don't pass in assert_hostname (it will error).

Fixes #570 