### PR TITLE
Execution context - correctly check if gevent has patched threading.local

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -167,3 +167,6 @@ exclude:
     FRAMEWORK: zerorpc-0.4
   - PYTHON_VERSION: python-3.8-rc
     FRAMEWORK: zerorpc-0.4
+  # gevent
+  - PYTHON_VERSION: pypy-2  # see https://github.com/gevent/gevent/issues/1380, fix will be in gevent 1.5
+    FRAMEWORK: gevent-newest

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -28,4 +28,4 @@ FRAMEWORK:
   - cassandra-newest
   - psutil-newest
   - eventlet-newest
-
+  - gevent-newest

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -59,3 +59,4 @@ FRAMEWORK:
   - elasticsearch-5
   - elasticsearch-6
   - elasticsearch-7
+  - gevent-newest

--- a/tests/context/gevent_threading_tests.py
+++ b/tests/context/gevent_threading_tests.py
@@ -29,38 +29,21 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-def init_execution_context():
-    # If _threading_local has been monkeypatched (by gevent or eventlet), then
-    # we should assume it's use as this will be the most "green-thread safe"
-    if threading_local_monkey_patched():
-        from elasticapm.context.threadlocal import execution_context
+import pytest
 
-        return execution_context
+import elasticapm.context
+from elasticapm.context.threadlocal import ThreadLocalContext
 
-    try:
-        from elasticapm.context.contextvars import execution_context
-    except ImportError:
-        from elasticapm.context.threadlocal import execution_context
-    return execution_context
+gevent = pytest.importorskip("gevent")
+pytestmark = pytest.mark.gevent
 
 
-def threading_local_monkey_patched():
-    # Returns True if thread locals have been patched by either gevent of
-    # eventlet
-    try:
-        from gevent.monkey import is_object_patched
-    except ImportError:
-        pass
-    else:
-        if is_object_patched("threading", "local"):
-            return True
+def test_gevent_thread_monkeypatched():
+    gevent.monkey.patch_thread()
+    assert gevent.monkey.is_object_patched("threading", "local")
 
-    try:
-        from eventlet.patcher import is_monkey_patched
-    except ImportError:
-        pass
-    else:
-        if is_monkey_patched("thread"):
-            return True
+    execution_context = elasticapm.context.init_execution_context()
 
-    return False
+    # Should always use ThreadLocalContext when gevent has patched
+    # threading.local
+    assert isinstance(execution_context, ThreadLocalContext)

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -19,7 +19,7 @@ statistics==1.0.3.5
 urllib3
 certifi
 Jinja2
-Logbook==1.3.0
+Logbook
 MarkupSafe
 WebOb
 Werkzeug

--- a/tests/requirements/requirements-gevent-newest.txt
+++ b/tests/requirements/requirements-gevent-newest.txt
@@ -1,0 +1,2 @@
+gevent
+-r requirements-base.txt

--- a/tests/scripts/envs/gevent.sh
+++ b/tests/scripts/envs/gevent.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m gevent"


### PR DESCRIPTION
Typo in call to `is_object_patched`. Correct module to check is `threading`, not `_threading` - https://docs.python.org/3/library/threading.html#threading.local