### PR TITLE
add wrappers for psycopg2's connection/cursor context managers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+[Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.1...master)
+
+### Bugfixes
+ * fixed instrumenting of psycopg2 when using their context manager interface (#577, #580)
+
 ## v5.1.1 
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.0...v5.1.1)
 

--- a/elasticapm/instrumentation/packages/psycopg2.py
+++ b/elasticapm/instrumentation/packages/psycopg2.py
@@ -51,9 +51,15 @@ class PGCursorProxy(CursorProxy):
     def extract_signature(self, sql):
         return extract_signature(sql)
 
+    def __enter__(self):
+        return PGCursorProxy(self.__wrapped__.__enter__())
+
 
 class PGConnectionProxy(ConnectionProxy):
     cursor_proxy = PGCursorProxy
+
+    def __enter__(self):
+        return PGConnectionProxy(self.__wrapped__.__enter__())
 
 
 class Psycopg2Instrumentation(DbApi2Instrumentation):


### PR DESCRIPTION
this ensures that the connection/cursor used in the context manager are
wrapped instances

fixes #577