### PR TITLE
Fix zerorpc tests, move them to separate test env

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -154,3 +154,16 @@ exclude:
   # eventlet
   - PYTHON_VERSION: pypy-2  #currently fails on pypy2
     FRAMEWORK: eventlet-newest
+  # zerorpc - only run on py2
+  - PYTHON_VERSION: pypy-3
+    FRAMEWORK: zerorpc-0.4
+  - PYTHON_VERSION: python-3.4
+    FRAMEWORK: zerorpc-0.4
+  - PYTHON_VERSION: python-3.5
+    FRAMEWORK: zerorpc-0.4
+  - PYTHON_VERSION: python-3.6
+    FRAMEWORK: zerorpc-0.4
+  - PYTHON_VERSION: python-3.7
+    FRAMEWORK: zerorpc-0.4
+  - PYTHON_VERSION: python-3.8-rc
+    FRAMEWORK: zerorpc-0.4

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -28,4 +28,5 @@ FRAMEWORK:
   - cassandra-newest
   - psutil-newest
   - eventlet-newest
+  - zerorpc-0.4
 

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -59,3 +59,4 @@ FRAMEWORK:
   - elasticsearch-5
   - elasticsearch-6
   - elasticsearch-7
+  - zerorpc-0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugfixes
  * fixed an issue with http server_url and `'VERIFY_SERVER_CERT': False` (#570, #578)
+ * fixed zerorpc tests (#581)
 
 ## v5.1.1 
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.0...v5.1.1)

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ tests_require = [
 ]
 
 if sys.version_info[0] == 2:
-    tests_require += ["unittest2", "gevent", "zerorpc>=0.4.0,<0.5", "python-memcached"]
+    tests_require += ["unittest2", "python-memcached"]
 else:
     tests_require += ["python3-memcached"]
 
@@ -136,8 +136,6 @@ else:
 try:
     import __pypy__
 except ImportError:
-    if sys.version_info[0] == 2 and "SKIP_ZERORPC" not in os.environ:
-        tests_require += ["zerorpc>=0.4.0,<0.5"]
     tests_require += ["psycopg2"]
 
 if sys.version_info >= (3, 5):

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -39,7 +39,4 @@ aiohttp ; python_version >= '3.5'
 pytest-asyncio ; python_version >= '3.5'
 asynctest==0.12.2 ; python_version >= '3.5'
 
-pyzmq==16.0.2 ; python_version == '2.7'
-gevent==1.2.2 ; python_version == '2.7'
-zerorpc>=0.4.0,<0.5 ; python_version == '2.7'
 cachetools==2.0.1 ; python_version == '2.7'

--- a/tests/requirements/requirements-zerorpc-0.4.txt
+++ b/tests/requirements/requirements-zerorpc-0.4.txt
@@ -1,0 +1,4 @@
+pyzmq==16.0.2 ; python_version == '2.7'
+gevent<1.2.0 ; python_version == '2.7'
+zerorpc>=0.4.0,<0.5 ; python_version == '2.7'
+-r requirements-base.txt

--- a/tests/scripts/envs/zerorpc.sh
+++ b/tests/scripts/envs/zerorpc.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m zerorpc"


### PR DESCRIPTION
zerorpc tests are currently being skipped all of the time because of an incorrect gevent version specified. The line `zerorpc = pytest.importorskip("zerorpc")` actually raises an `ImportError` on it's dependency `gevent`, NOT on `zerorpc` itself:

```
___________________________________________ ERROR collecting tests/contrib/zerorpc/zeropc_tests.py ___________________________________________
ImportError while importing test module '/app/tests/contrib/zerorpc/zeropc_tests.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python2.7/site-packages/six.py:709: in exec_
    exec("""exec _code_ in _globs_, _locs_""")
tests/contrib/zerorpc/zeropc_tests.py:40: in <module>
    import zerorpc
/usr/local/lib/python2.7/site-packages/zerorpc/__init__.py:28: in <module>
    from .socket import *
/usr/local/lib/python2.7/site-packages/zerorpc/socket.py:27: in <module>
    from .events import Events
/usr/local/lib/python2.7/site-packages/zerorpc/events.py:31: in <module>
    import gevent.coros
E   ImportError: No module named coros
```

(Running python-2.7 tests on this branch to demonstrate - https://github.com/ramshaw888/apm-agent-python/commits/broken/zerorpc-tests )

`gevent.coros` was removed in v1.2.0, so I've pinned the version required for these tests to <1.2.0


Additionally, this moves the `zerorpc` tests out into a separate test env  (not sure of the nomenclature) `zerorpc-0.4`. 