### PR TITLE
Test setup and documentation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ coverage
 /testdb.sql
 venv
 benchmarks/result*
+coverage.xml
+tests/python-agent-junit.xml

--- a/docs/run-tests-locally.asciidoc
+++ b/docs/run-tests-locally.asciidoc
@@ -55,5 +55,18 @@ We run the test suite on different combinations of Python versions and web frame
 ----
 $ ./tests/scripts/docker/run_tests.sh python-version framework-version <pip-cache-dir>
 ----
-NOTE: The `python-version` must be of format `python:version`, e.g. `python:3.6` or `pypy:2`.
+NOTE: The `python-version` must be of format `python-version`, e.g. `python-3.6` or `pypy-2`.
 The `framework` must be of format `framework-version`, e.g. `django-1.10` or `flask-0.12`.
+
+==== Integration testing
+
+Check out https://github.com/elastic/apm-integration-testing for resources for
+setting up full end-to-end testing environments. For example, to spin up
+an environment with the https://github.com/basepi/opbeans-python[opbeans Django app],
+with version 7.3 of the elastic stack and the apm-python-agent from your local
+checkout, you might do something like this:
+
+[source,bash]
+----
+$ ./scripts/compose.py start 7.3 --with-agent-python-django --with-opbeans-python --opbeans-python-agent-local-repo=~/elastic/apm-agent-python 
+----

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -250,6 +250,7 @@ def test_send_remote_failover_sync_non_transport_exception_error(should_try, htt
         secret_token="secret",
         transport_class="elasticapm.transport.http.Transport",
         metrics_interval="0ms",
+        metrics_sets=[],
     )
     # test error
     http_send.side_effect = ValueError("oopsie")

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -33,6 +33,7 @@ msgpack-python
 pep8
 urllib3-mock
 pytz
+psutil
 
 
 aiohttp ; python_version >= '3.5'

--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -33,7 +33,6 @@ msgpack-python
 pep8
 urllib3-mock
 pytz
-psutil
 
 
 aiohttp ; python_version >= '3.5'

--- a/tests/scripts/download_json_schema.sh
+++ b/tests/scripts/download_json_schema.sh
@@ -7,7 +7,11 @@ download_schema()
     rm -rf ${1} && mkdir -p ${1}
     for run in 1 2 3 4 5
     do
-        curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        if [ -x "$(command -v gtar)" ]; then
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        else
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+        fi
         result=$?
         if [ $result -eq 0 ]; then break; fi
         sleep 1


### PR DESCRIPTION
* Need to use `gtar` on macOS to get `--wildcard` support for `make json schema`
* ~Add psutil to requirement-base.txt for `test_send_remote_failover_sync_non_transport_exception_error`~
  * Turns I just needed to fix the test properly, by disabling `metrics_sets` for that test.
* Update .gitignore with a couple of testing artifacts
* Fix a documentation bug around syntax for `tests/scripts/docker/run_tests.sh`
* Add a note about apm-integration-testing