### PR TITLE
Add logging integrations with logging and structlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased changes
+[Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.2...master)
+
+### New Features
+ * added `logging` filter for adding transaction and trace_parent IDs (#520, #586)
+ * added `structlog` processor for adding transaction and trace_parent IDs (#520, #586)
+ * added new public API calls for getting transaction ID and trace_parent ID (#520, #586)
+
 ## v5.1.2
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.1...v5.1.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.1.2...master)
 
 ### New Features
+ * added automatic tagging of LogRecord objects with transaction, trace, and span IDs via a LogRecordFactory (Python 3.2+) (#520, #586)
  * added `logging` filter and record factory for adding transaction, trace, and span IDs (#520, #586)
  * added `structlog` processor for adding transaction, trace, and span IDs (#520, #586)
  * added new public API calls for getting transaction, trace, and span IDs (#520, #586)

--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -8,3 +8,4 @@
 include::./custom-instrumentation.asciidoc[Custom Instrumentation]
 include::./sanitizing-data.asciidoc[Sanitizing Data]
 include::./run-tests-locally.asciidoc[Run Tests Locally]
+include::./logging.asciidoc[Logging Integrations]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -212,7 +212,7 @@ transaction_id = elasticapm.get_transaction_id()
 [[api-get-trace-id]]
 ==== `elasticapm.get_trace_id()`
 
-Get the parent_id of the current transaction's trace. Example:
+Get the `trace_id` of the current transaction's trace. Example:
 
 [source,python]
 ----

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -174,7 +174,6 @@ elasticapm.set_transaction_name('myapp.billing_process')
  * `override`: if `True` (the default), overrides any previously set transaction name.
     If `False`, only sets the name if the transaction name hasn't already been set.
 
-
 [float]
 [[api-set-transaction-result]]
 ==== `elasticapm.set_transaction_result()`
@@ -193,6 +192,35 @@ elasticapm.set_transaction_result('SUCCESS')
  * `result`: (*required*) A string describing the result of the transaction, e.g. `HTTP 2xx` or `SUCCESS`
  * `override`: if `True` (the default), overrides any previously set result.
     If `False`, only sets the result if the result hasn't already been set.
+
+
+[float]
+[[api-get-transaction-id]]
+==== `elasticapm.get_transaction_id()`
+
+Get the id of the current transaction. Example:
+
+[source,python]
+----
+import elasticapm
+
+transaction_id = elasticapm.get_transaction_id()
+----
+
+
+[float]
+[[api-get-transaction-trace-parent-id]]
+==== `elasticapm.get_transaction_trace_parent_id()`
+
+Get the parent_id of the current transaction's trace. Example:
+
+[source,python]
+----
+import elasticapm
+
+trace_parent_id = elasticapm.get_transaction_trace_parent_id()
+----
+
 
 [float]
 [[api-set-custom-context]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -218,7 +218,7 @@ Get the parent_id of the current transaction's trace. Example:
 ----
 import elasticapm
 
-trace_parent_id = elasticapm.get_trace_id()
+trace_id = elasticapm.get_trace_id()
 ----
 
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -209,8 +209,8 @@ transaction_id = elasticapm.get_transaction_id()
 
 
 [float]
-[[api-get-transaction-trace-parent-id]]
-==== `elasticapm.get_transaction_trace_parent_id()`
+[[api-get-trace-id]]
+==== `elasticapm.get_trace_id()`
 
 Get the parent_id of the current transaction's trace. Example:
 
@@ -218,7 +218,7 @@ Get the parent_id of the current transaction's trace. Example:
 ----
 import elasticapm
 
-trace_parent_id = elasticapm.get_transaction_trace_parent_id()
+trace_parent_id = elasticapm.get_trace_id()
 ----
 
 

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -223,6 +223,20 @@ trace_parent_id = elasticapm.get_trace_id()
 
 
 [float]
+[[api-get-span-id]]
+==== `elasticapm.get_span_id()`
+
+Get the id of the current span. Example:
+
+[source,python]
+----
+import elasticapm
+
+span_id = elasticapm.get_span_id()
+----
+
+
+[float]
 [[api-set-custom-context]]
 ==== `elasticapm.set_custom_context()`
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -680,6 +680,18 @@ Any labels set by application via the API will override global labels with the s
 NOTE: This feature requires APM Server >= 7.2.
 
 [float]
+[[config-generic-disable-log-record-factory]]
+==== `disable_log_record_factory`
+|============
+| Environment                              | Django/Flask                 | Default
+| `ELASTIC_APM_DISABLE_LOG_RECORD_FACTORY` | `DISABLE_LOG_RECORD_FACTORY` | `False`
+|============
+
+By default in python 3, the agent will install a <<logging,LogRecord factory>> that
+automatically adds tracing fields to your log records. You can disable this
+behavior by setting this to `True`.
+
+[float]
 [[config-django-specific]]
 === Django-specific configuration
 
@@ -764,11 +776,3 @@ The unit is provided as suffix directly after the number, without and separation
  * `gb` (gigabytes)
 
 NOTE: we use the power-of-two sizing convention, e.g. `1 kilobyte == 1024 bytes`
-
-[float]
-[[config-generic-disable-log-record-factory]]
-==== `DISABLE_LOG_RECORD_FACTORY
-
-By default in python 3, the agent will install a <<logging,LogRecord factory>> that
-automatically adds tracing fields to your log records. You can disable this
-behavior by setting `DISABLE_LOG_RECORD_FACTOR` to `True`.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -764,3 +764,11 @@ The unit is provided as suffix directly after the number, without and separation
  * `gb` (gigabytes)
 
 NOTE: we use the power-of-two sizing convention, e.g. `1 kilobyte == 1024 bytes`
+
+[float]
+[[config-generic-disable-log-record-factory]]
+==== `DISABLE_LOG_RECORD_FACTORY
+
+By default in python 3, the agent will install a <<logging,LogRecord factory>> that
+automatically adds tracing fields to your log records. You can disable this
+behavior by setting `DISABLE_LOG_RECORD_FACTOR` to `True`.

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -1,0 +1,52 @@
+[[logging-integrations]]
+=== Logging Integrations
+
+`elasticapm` provides integrations with both the default python logging library,
+as well as http://www.structlog.org/en/stable/[`structlog`].
+
+[[logging]]
+==== `logging`
+
+We provide a https://docs.python.org/3/library/logging.html#filter-objects[filter]
+which will add two new attributes to any filtered `LogRecord`:
+
+* `elasticapm_transaction_id`
+* `elasticapm_transaction_trace_parent_id`
+
+Note that because https://docs.python.org/3/library/logging.html#filter-objects[filters
+are not propagated to descendent loggers], you should add the filter to each of
+your log handlers, as handlers are propagated, along with their attached filters.
+
+[source,python]
+----
+import logging
+from elasticapm.handlers.logging import LoggingFilter
+
+console = logging.StreamHandler()
+console.addFilter(LoggingFilter())
+# add the handler to the root logger
+logging.getLogger("").addHandler(console)
+----
+
+
+[[structlog]]
+==== `structlog`
+
+We provide a http://www.structlog.org/en/stable/processors.html[processor] for
+http://www.structlog.org/en/stable/[`structlog`] which will add two new keys
+to the event_dict of any processed event:
+
+* `"elasticapm_transaction_id"`
+* `"elasticapm_transaction_trace_parent_id"`
+
+[source,python]
+----
+from structlog import PrintLogger, wrap_logger
+from elasticapm.handlers.logging import structlog_processor
+
+wrapped_logger = PrintLogger()
+logger = wrap_logger(wrapped_logger, processors=[structlog_processor])
+log = logger.new()
+log.msg("some_event")
+----
+

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -79,7 +79,7 @@ identifiers:
 If you're using structured logging, either https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging[with a custom solution]
 or with http://www.structlog.org/en/stable/[structlog] (recommended), then this
 is fairly easy. Throw the http://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer[JSONRenderer]
-in, and use {blog-ref}/structured-logging-filebeat[Filebeat]
+in, and use {blog-ref}structured-logging-filebeat[Filebeat]
 to pull these logs into Elasticsearch.
 
 Without structured logging the task gets a little trickier. Here we

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -18,9 +18,9 @@ each LogRecord object:
 This factory also adds these fields to a dictionary attribute,
 `elasticapm_labels`, using the official ECS https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html[tracing fields].
 
-You can disable this automatic behavior by setting
-<<config-generic-disable-log-record-factory,`"DISABLE_LOG_RECORD_FACTORY": True`>>
-in the config.
+You can disable this automatic behavior by using the
+<<config-generic-disable-log-record-factory,`disable_log_record_factory`>> setting
+in your configuration
 
 For Python versions <3.2, we also provide a
 https://docs.python.org/3/library/logging.html#filter-objects[filter] which will

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -18,7 +18,8 @@ each LogRecord object:
 This factory also adds these fields to a dictionary attribute,
 `elasticapm_labels`, using the official ECS {ecs-ref}/ecs-tracing[tracing fields].
 
-You can disable this automatic behavior by setting `DISABLE_LOG_RECORD_FACTORY=True`
+You can disable this automatic behavior by setting
+<<config-generic-disable-log-record-factory,`"DISABLE_LOG_RECORD_FACTORY": True`>>
 in the config.
 
 For Python versions <3.2, we also provide a

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -8,10 +8,11 @@ as well as http://www.structlog.org/en/stable/[`structlog`].
 ==== `logging`
 
 We provide a https://docs.python.org/3/library/logging.html#filter-objects[filter]
-which will add two new attributes to any filtered `LogRecord`:
+which will add three new attributes to any filtered `LogRecord`:
 
 * `elasticapm_transaction_id`
-* `elasticapm_transaction_trace_parent_id`
+* `elasticapm_trace_id`
+* `ealsticapm_span_id`
 
 Note that because https://docs.python.org/3/library/logging.html#filter-objects[filters
 are not propagated to descendent loggers], you should add the filter to each of
@@ -33,16 +34,17 @@ logging.getLogger("").addHandler(console)
 ==== `structlog`
 
 We provide a http://www.structlog.org/en/stable/processors.html[processor] for
-http://www.structlog.org/en/stable/[`structlog`] which will add two new keys
+http://www.structlog.org/en/stable/[`structlog`] which will add three new keys
 to the event_dict of any processed event:
 
-* `"elasticapm_transaction_id"`
-* `"elasticapm_transaction_trace_parent_id"`
+* `"transaction.id"`
+* `"trace.id"`
+* `"span.id"`
 
 [source,python]
 ----
 from structlog import PrintLogger, wrap_logger
-from elasticapm.handlers.logging import structlog_processor
+from elasticapm.handlers.structlog import structlog_processor
 
 wrapped_logger = PrintLogger()
 logger = wrap_logger(wrapped_logger, processors=[structlog_processor])

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -16,7 +16,7 @@ each LogRecord object:
 * `elasticapm_span_id`
 
 This factory also adds these fields to a dictionary attribute,
-`elasticapm_labels`, using the official ECS {ecs-ref}/ecs-tracing[tracing fields].
+`elasticapm_labels`, using the official ECS https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html[tracing fields].
 
 You can disable this automatic behavior by setting
 <<config-generic-disable-log-record-factory,`"DISABLE_LOG_RECORD_FACTORY": True`>>

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -64,3 +64,72 @@ log = logger.new()
 log.msg("some_event")
 ----
 
+
+[[log-correlation]]
+=== Log Correlation in Elasticsearch
+
+In order to correlate logs from your app with transactions captured by the
+Elastic APM Python Agent, your logs must contain one or more of the following
+identifiers:
+
+* transaction.id
+* trace.id
+* span.id
+
+If you're using structured logging, either https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging[with a custom solution]
+or with http://www.structlog.org/en/stable/[structlog (recommended)], then this
+is fairly easy. Throw the http://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer[JSONRenderer]
+in, and you can easily use https://www.elastic.co/blog/structured-logging-filebeat[Filebeat]
+to pull these logs into Elasticsearch.
+
+However, without structured logging the task gets a little trickier. Here we
+recommend first making sure your LogRecord objects have the elasticapm
+attributes (see <<logging>>), and then you'll want to combine some specific
+formatting with a Grok pattern, either in Elasticsearch using
+https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html[the grok processor],
+or in https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html[logstash with a plugin].
+
+Say you have a https://docs.python.org/3/library/logging.html#logging.Formatter[Formatter]
+that looks like this:
+
+[source,python]
+----
+import logging
+
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+----
+
+You can add the APM identifiers in an easy-to-parse manner:
+
+[source,python]
+----
+import logging
+
+format_string = (
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s "
+    "| elasticapm "
+    "transaction.id=%(elasticapm_transaction_id) "
+    "trace.id=%(elasticapm_trace_id) "
+    "span.id=%(elasticapm_span_id)"
+)
+formatter = logging.Formatter(format_string)
+----
+
+Then, you could use a grok pattern like this (for the
+https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html[Elasticsearch Grok Processor]):
+
+
+[source, json]
+----
+{
+  "description" : "...",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{GREEDYDATA:msg} | elasticapm transaction.id=%{DATA:transaction.id} trace.id=%{DATA:trace.id} span.id=%{DATA:span.id}"]
+      }
+    }
+  ]
+}
+----

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -1,5 +1,5 @@
 [[logging-integrations]]
-=== Logging Integrations
+=== Logging integrations
 
 The Elastic APM agent provides integrations with both the default Python logging library,
 as well as http://www.structlog.org/en/stable/[`structlog`].
@@ -22,10 +22,10 @@ You can disable this automatic behavior by setting `DISABLE_LOG_RECORD_FACTORY=T
 in the config.
 
 For Python versions <3.2, we also provide a
-https://docs.python.org/3/library/logging.html#filter-objects[filter]which will
+https://docs.python.org/3/library/logging.html#filter-objects[filter] which will
 add the same new attributes to any filtered `LogRecord`:
 
-Note that because https://docs.python.org/3/library/logging.html#filter-objects[filters
+Note: Because https://docs.python.org/3/library/logging.html#filter-objects[filters
 are not propagated to descendent loggers], you should add the filter to each of
 your log handlers, as handlers are propagated, along with their attached filters.
 

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -16,8 +16,7 @@ each LogRecord object:
 * `elasticapm_span_id`
 
 This factory also adds these fields to a dictionary attribute,
-`elasticapm_labels`, using the official tracing fields names as documented
-here: https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
+`elasticapm_labels`, using the official ECS {ecs-ref}/ecs-tracing[tracing fields].
 
 You can disable this automatic behavior by setting `DISABLE_LOG_RECORD_FACTORY=True`
 in the config.

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -7,12 +7,24 @@ as well as http://www.structlog.org/en/stable/[`structlog`].
 [[logging]]
 ==== `logging`
 
-We provide a https://docs.python.org/3/library/logging.html#filter-objects[filter]
-which will add three new attributes to any filtered `LogRecord`:
+For Python 3.2+, we use https://docs.python.org/3/library/logging.html#logging.setLogRecordFactory[`logging.setLogRecordFactory()`]
+to decorate the default LogRecordFactory to automatically add new attributes to
+each LogRecord object:
 
 * `elasticapm_transaction_id`
 * `elasticapm_trace_id`
-* `ealsticapm_span_id`
+* `elasticapm_span_id`
+
+This factory also adds these fields to a dictionary attribute,
+`elasticapm_labels`, using the official tracing fields names as documented
+here: https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html
+
+You can disable this automatic behavior by setting `DISABLE_LOG_RECORD_FACTORY=True`
+in the config.
+
+For Python versions <3.2, we also provide a
+https://docs.python.org/3/library/logging.html#filter-objects[filter]which will
+add the same new attributes to any filtered `LogRecord`:
 
 Note that because https://docs.python.org/3/library/logging.html#filter-objects[filters
 are not propagated to descendent loggers], you should add the filter to each of

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -49,9 +49,9 @@ We provide a http://www.structlog.org/en/stable/processors.html[processor] for
 http://www.structlog.org/en/stable/[`structlog`] which will add three new keys
 to the event_dict of any processed event:
 
-* `"transaction.id"`
-* `"trace.id"`
-* `"span.id"`
+* `transaction.id`
+* `trace.id`
+* `span.id`
 
 [source,python]
 ----
@@ -66,28 +66,28 @@ log.msg("some_event")
 
 
 [[log-correlation]]
-=== Log Correlation in Elasticsearch
+=== Log correlation in Elasticsearch
 
 In order to correlate logs from your app with transactions captured by the
 Elastic APM Python Agent, your logs must contain one or more of the following
 identifiers:
 
-* transaction.id
-* trace.id
-* span.id
+* `transaction.id`
+* `trace.id`
+* `span.id`
 
 If you're using structured logging, either https://docs.python.org/3/howto/logging-cookbook.html#implementing-structured-logging[with a custom solution]
-or with http://www.structlog.org/en/stable/[structlog (recommended)], then this
+or with http://www.structlog.org/en/stable/[structlog] (recommended), then this
 is fairly easy. Throw the http://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer[JSONRenderer]
-in, and you can easily use https://www.elastic.co/blog/structured-logging-filebeat[Filebeat]
+in, and use {blog-ref}/structured-logging-filebeat[Filebeat]
 to pull these logs into Elasticsearch.
 
-However, without structured logging the task gets a little trickier. Here we
+Without structured logging the task gets a little trickier. Here we
 recommend first making sure your LogRecord objects have the elasticapm
 attributes (see <<logging>>), and then you'll want to combine some specific
 formatting with a Grok pattern, either in Elasticsearch using
-https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html[the grok processor],
-or in https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html[logstash with a plugin].
+{ref}/grok-processor.html[the grok processor],
+or in {logstash-ref}/plugins-filters-grok.html[logstash with a plugin].
 
 Say you have a https://docs.python.org/3/library/logging.html#logging.Formatter[Formatter]
 that looks like this:
@@ -116,7 +116,7 @@ formatter = logging.Formatter(format_string)
 ----
 
 Then, you could use a grok pattern like this (for the
-https://www.elastic.co/guide/en/elasticsearch/reference/current/grok-processor.html[Elasticsearch Grok Processor]):
+{ref}/grok-processor.html[Elasticsearch Grok Processor]):
 
 
 [source, json]

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -1,7 +1,7 @@
 [[logging-integrations]]
 === Logging Integrations
 
-`elasticapm` provides integrations with both the default python logging library,
+The Elastic APM agent provides integrations with both the default Python logging library,
 as well as http://www.structlog.org/en/stable/[`structlog`].
 
 [[logging]]

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -42,4 +42,4 @@ from elasticapm.instrumentation.control import instrument, uninstrument  # noqa:
 from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
 from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id  # noqa: F401
+from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -42,4 +42,4 @@ from elasticapm.instrumentation.control import instrument, uninstrument  # noqa:
 from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
 from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_transaction_trace_parent_id  # noqa: F401
+from elasticapm.traces import get_transaction_id, get_trace_id  # noqa: F401

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -42,3 +42,4 @@ from elasticapm.instrumentation.control import instrument, uninstrument  # noqa:
 from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
 from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
+from elasticapm.traces import get_transaction_id, get_transaction_trace_parent_id  # noqa: F401

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -103,6 +103,15 @@ class Client(object):
             config.disable_send = True
         self.config = VersionedConfig(config, version=None)
 
+        # Insert the log_record_factory into the logging library
+        # The LogRecordFactory functionality is only available on python 3.2+
+        if sys.version_info >= (3, 2) and self.config.disable_log_record_factory is False:
+            record_factory = logging.getLogRecordFactory()
+            if not isinstance(record_factory, elasticapm.utils.wrapt.FunctionWrapper):
+                self.logger.debug("Inserting elasticapm log_record_factory into logging")
+                new_factory = elasticapm.handlers.logging.log_record_factory(record_factory)
+                logging.setLogRecordFactory(new_factory)
+
         headers = {
             "Content-Type": "application/x-ndjson",
             "Content-Encoding": "gzip",

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -111,7 +111,11 @@ class Client(object):
             throwaway_record = record_factory(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)
             if not hasattr(throwaway_record, "elasticapm_labels"):
                 self.logger.debug("Inserting elasticapm log_record_factory into logging")
-                new_factory = elasticapm.handlers.logging.log_record_factory(record_factory)
+
+                # Late import due to circular imports
+                import elasticapm.handlers.logging as elastic_logging
+
+                new_factory = elastic_logging.log_record_factory(record_factory)
                 logging.setLogRecordFactory(new_factory)
 
         headers = {

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -329,6 +329,7 @@ class Config(_ConfigBase):
     enable_distributed_tracing = _BoolConfigValue("ENABLE_DISTRIBUTED_TRACING", default=True)
     capture_headers = _BoolConfigValue("CAPTURE_HEADERS", default=True)
     django_transaction_name_from_route = _BoolConfigValue("DJANGO_TRANSACTION_NAME_FROM_ROUTE", default=False)
+    disable_log_record_factory = _BoolConfigValue("DISABLE_LOG_RECORD_FACTORY", default=False)
 
 
 class VersionedConfig(object):

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -37,10 +37,9 @@ import traceback
 
 from elasticapm.base import Client
 from elasticapm.traces import execution_context
-from elasticapm.utils import compat
+from elasticapm.utils import compat, wrapt
 from elasticapm.utils.encoding import to_unicode
 from elasticapm.utils.stacks import iter_stack_frames
-from elasticapm.utils import wrapt
 
 
 class LoggingHandler(logging.Handler):

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -161,7 +161,7 @@ class LoggingHandler(logging.Handler):
 class LoggingFilter(logging.Filter):
     """
     This filter doesn't actually do any "filtering" -- rather, it just adds
-    two new attributes to any "filtered" LogRecord objects:
+    three new attributes to any "filtered" LogRecord objects:
 
     * elasticapm_transaction_id
     * elasticapm_trace_id
@@ -183,28 +183,3 @@ class LoggingFilter(logging.Filter):
         span = execution_context.get_span()
         record.elasticapm_span_id = span.id if span else None
         return True
-
-
-def structlog_processor(logger, method_name, event_dict):
-    """
-    Add two new entries to the event_dict for any processed events:
-
-    * transaction.id
-    * trace.id
-    * span.id
-
-    :param logger:
-        Unused (logger instance in structlog)
-    :param method_name:
-        Unused (wrapped method_name)
-    :param event_dict:
-        Event dictionary for the event we're processing
-    :return:
-        `event_dict`, with two new entries.
-    """
-    transaction = execution_context.get_transaction()
-    event_dict["transaction.id"] = transaction.id if transaction else None
-    event_dict["trace.id"] = transaction.trace_parent.trace_id if transaction and transaction.trace_parent else None
-    span = execution_context.get_span()
-    event_dict["span.id"] = span.id if span else None
-    return event_dict

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -40,7 +40,7 @@ from elasticapm.traces import execution_context
 from elasticapm.utils import compat
 from elasticapm.utils.encoding import to_unicode
 from elasticapm.utils.stacks import iter_stack_frames
-from utils import wrapt
+from elasticapm.utils import wrapt
 
 
 class LoggingHandler(logging.Handler):

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -164,7 +164,7 @@ class LoggingFilter(logging.Filter):
     two new attributes to any "filtered" LogRecord objects:
 
     * elasticapm_transaction_id
-    * elasticapm_transaction_trace_parent_id
+    * elasticapm_trace_id
 
     These attributes can then be incorporated into your handlers and formatters,
     so that you can tie log messages to transactions in elasticsearch.
@@ -176,22 +176,20 @@ class LoggingFilter(logging.Filter):
         """
         transaction = execution_context.get_transaction()
         record.elasticapm_transaction_id = transaction.id
-        record.elasticapm_transaction_trace_parent_id = (
-            transaction.trace_parent.trace_id if transaction.trace_parent else None
-        )
+        record.elasticapm_trace_id = transaction.trace_parent.trace_id if transaction.trace_parent else None
         return True
 
 
-def structlog_processor(_, __, event_dict):
+def structlog_processor(logger, method_name, event_dict):
     """
     Add two new entries to the event_dict for any processed events:
 
-    * elasticapm_transaction_id
-    * elasticapm_transaction_trace_parent_id
+    * transaction.id
+    * trace.id
 
-    :param _:
+    :param logger:
         Unused (logger instance in structlog)
-    :param __:
+    :param method_name:
         Unused (wrapped method_name)
     :param event_dict:
         Event dictionary for the event we're processing
@@ -199,8 +197,6 @@ def structlog_processor(_, __, event_dict):
         `event_dict`, with two new entries.
     """
     transaction = execution_context.get_transaction()
-    event_dict["elasticapm_transaction_id"] = transaction.id
-    event_dict["elasticapm_transaction_trace_parent_id"] = (
-        transaction.trace_parent.trace_id if transaction.trace_parent else None
-    )
+    event_dict["transaction.id"] = transaction.id
+    event_dict["trace.id"] = transaction.trace_parent.trace_id if transaction.trace_parent else None
     return event_dict

--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -39,6 +39,8 @@ def structlog_processor(logger, method_name, event_dict):
     * trace.id
     * span.id
 
+    Only adds non-None IDs.
+
     :param logger:
         Unused (logger instance in structlog)
     :param method_name:
@@ -49,8 +51,11 @@ def structlog_processor(logger, method_name, event_dict):
         `event_dict`, with three new entries.
     """
     transaction = execution_context.get_transaction()
-    event_dict["transaction.id"] = transaction.id if transaction else None
-    event_dict["trace.id"] = transaction.trace_parent.trace_id if transaction and transaction.trace_parent else None
+    if transaction:
+        event_dict["transaction.id"] = transaction.id
+    if transaction and transaction.trace_parent:
+        event_dict["trace.id"] = transaction.trace_parent.trace_id
     span = execution_context.get_span()
-    event_dict["span.id"] = span.id if span else None
+    if span:
+        event_dict["span.id"] = span.id
     return event_dict

--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -1,0 +1,56 @@
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+
+
+from __future__ import absolute_import
+
+from traces import execution_context
+
+
+def structlog_processor(logger, method_name, event_dict):
+    """
+    Add three new entries to the event_dict for any processed events:
+
+    * transaction.id
+    * trace.id
+    * span.id
+
+    :param logger:
+        Unused (logger instance in structlog)
+    :param method_name:
+        Unused (wrapped method_name)
+    :param event_dict:
+        Event dictionary for the event we're processing
+    :return:
+        `event_dict`, with three new entries.
+    """
+    transaction = execution_context.get_transaction()
+    event_dict["transaction.id"] = transaction.id if transaction else None
+    event_dict["trace.id"] = transaction.trace_parent.trace_id if transaction and transaction.trace_parent else None
+    span = execution_context.get_span()
+    event_dict["span.id"] = span.id if span else None
+    return event_dict

--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -28,7 +28,7 @@
 
 from __future__ import absolute_import
 
-from traces import execution_context
+from elasticapm.traces import execution_context
 
 
 def structlog_processor(logger, method_name, event_dict):

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -652,9 +652,9 @@ def get_transaction_id():
     return transaction.id
 
 
-def get_transaction_trace_parent_id():
+def get_trace_id():
     """
-    Returns the current transaction ID
+    Returns the current trace ID
     """
     transaction = execution_context.get_transaction()
     if not transaction:

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -662,6 +662,16 @@ def get_trace_id():
     return transaction.trace_parent.trace_id if transaction.trace_parent else None
 
 
+def get_span_id():
+    """
+    Returns the current span ID
+    """
+    span = execution_context.get_span()
+    if not span:
+        return
+    return span.id
+
+
 def set_context(data, key="custom"):
     """
     Attach contextual data to the current transaction and errors that happen during the current transaction.

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -642,6 +642,26 @@ def set_transaction_result(result, override=True):
         transaction.result = result
 
 
+def get_transaction_id():
+    """
+    Returns the current transaction ID
+    """
+    transaction = execution_context.get_transaction()
+    if not transaction:
+        return
+    return transaction.id
+
+
+def get_transaction_trace_parent_id():
+    """
+    Returns the current transaction ID
+    """
+    transaction = execution_context.get_transaction()
+    if not transaction:
+        return
+    return transaction.trace_parent.trace_id if transaction.trace_parent else None
+
+
 def set_context(data, key="custom"):
     """
     Attach contextual data to the current transaction and errors that happen during the current transaction.

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -43,7 +43,9 @@ from elasticapm.utils import compat
 from elasticapm.utils.stacks import iter_stack_frames
 from tests.fixtures import TempStoreClient
 
-original_factory = logging.getLogRecordFactory()
+original_factory = None
+if compat.PY3:
+    original_factory = logging.getLogRecordFactory()
 
 
 @pytest.fixture()

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -271,7 +271,7 @@ def test_structlog_processor_no_span():
     new_dict = structlog_processor(None, None, event_dict)
     assert new_dict["transaction.id"] == transaction.id
     assert new_dict["trace.id"] == transaction.trace_parent.trace_id
-    assert new_dict["span.id"] is None
+    assert "span.id" not in new_dict
 
 
 def test_logging_filter_span():

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -256,7 +256,7 @@ def test_logging_filter():
     record = logging.LogRecord(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)
     f.filter(record)
     assert record.elasticapm_transaction_id
-    assert record.elasticapm_transaction_trace_parent_id
+    assert record.elasticapm_trace_id
 
 
 def test_structlog_processor():
@@ -264,5 +264,5 @@ def test_structlog_processor():
     requests_store.begin_transaction("test")
     event_dict = {}
     new_dict = structlog_processor(None, None, event_dict)
-    assert "elasticapm_transaction_id" in new_dict
-    assert "elasticapm_transaction_trace_parent_id" in new_dict
+    assert "transaction.id" in new_dict
+    assert "trace.id" in new_dict


### PR DESCRIPTION
* Added new entries to the public API as helpers to retrieve transaction, trace, and span IDs
* Added new ways to add APM tracing fields to logs:
  * `logging` filter
  * `structlog` processor
  * automatic log_record_factory for python 3.2+
* Added new "Logging Integrations" documentation
* Added documentation around ingest for log correlation
* Added tests for the filter, processor, and log_record_factory

Resolves elastic/apm-agent-python#520 
