### PR TITLE
[docs] Add ECS versioning

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,7 @@
 :branch: current
 :server-branch: 6.5
+:ecs_version: current
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
This PR unblocks https://github.com/elastic/docs/pull/1170. Because Agents are verisioned separately from the stack, this attribute needs to be defined locally in each Agent.

Backport to `5.x`.