### PR TITLE
[docs][5.x] fix ECS versioning (#593)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,7 @@
 :branch: current
 :server-branch: 6.5
+:ecs_version: current
+
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
Backports the following commits:

* docs: fix ECS versioning (#593)