### PR TITLE
Fix Exception.capture error handling

### DIFF
--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -87,8 +87,8 @@ class Exception(BaseEvent):
             new_exc_info = True
             exc_info = sys.exc_info()
 
-        if not exc_info:
-            raise ValueError("No exception found")
+        if exc_info == (None, None, None):
+            raise ValueError("No exception found: capture_exception requires an active exception.")
 
         try:
             exc_type, exc_value, exc_traceback = exc_info

--- a/tests/events/tests.py
+++ b/tests/events/tests.py
@@ -32,9 +32,10 @@
 
 from __future__ import absolute_import
 
+import pytest
 from mock import Mock
 
-from elasticapm.events import Message
+from elasticapm.events import Exception, Message
 
 
 def test_event_to_string():
@@ -46,3 +47,8 @@ def test_event_to_string():
     data = {"log": {"message": unformatted_message % (1, 2), "param_message": unformatted_message}}
 
     assert message.to_string(client, data) == formatted_message
+
+
+def test_capture_exception_no_exception(elasticapm_client):
+    with pytest.raises(ValueError):
+        Exception.capture(elasticapm_client)


### PR DESCRIPTION
Ref #599

`sys.exc_info()` returns `(None, None, None)` if there is no active
exception. Still fail hard and fast, but more clearly.