### PR TITLE
Fix logging integrations for DroppedSpan spans

### DIFF
--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -217,7 +217,7 @@ def _add_attributes_to_log_record(record):
     record.elasticapm_trace_id = trace_id
 
     span = execution_context.get_span()
-    span_id = span.id if span else None
+    span_id = span.id if span and hasattr(span, "id") else None
     record.elasticapm_span_id = span_id
 
     record.elasticapm_labels = {"transaction.id": transaction_id, "trace.id": trace_id, "span.id": span_id}

--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -56,6 +56,6 @@ def structlog_processor(logger, method_name, event_dict):
     if transaction and transaction.trace_parent:
         event_dict["trace.id"] = transaction.trace_parent.trace_id
     span = execution_context.get_span()
-    if span:
+    if span and hasattr(span, "id"):
         event_dict["span.id"] = span.id
     return event_dict

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -252,9 +252,8 @@ def test_arbitrary_object(logger):
     assert event["log"]["param_message"] == "['a', 'list', 'of', 'strings']"
 
 
-def test_logging_filter_no_span():
-    requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, Config(), None)
-    transaction = requests_store.begin_transaction("test")
+def test_logging_filter_no_span(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
     f = LoggingFilter()
     record = logging.LogRecord(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)
     f.filter(record)
@@ -264,9 +263,8 @@ def test_logging_filter_no_span():
     assert record.elasticapm_labels
 
 
-def test_structlog_processor_no_span():
-    requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, Config(), None)
-    transaction = requests_store.begin_transaction("test")
+def test_structlog_processor_no_span(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
     event_dict = {}
     new_dict = structlog_processor(None, None, event_dict)
     assert new_dict["transaction.id"] == transaction.id
@@ -274,9 +272,9 @@ def test_structlog_processor_no_span():
     assert "span.id" not in new_dict
 
 
-def test_logging_filter_span():
-    requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, Config(), None)
-    transaction = requests_store.begin_transaction("test")
+@pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 5}], indirect=True)
+def test_logging_filter_span(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
     with capture_span("test") as span:
         f = LoggingFilter()
         record = logging.LogRecord(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)
@@ -286,16 +284,43 @@ def test_logging_filter_span():
         assert record.elasticapm_span_id == span.id
         assert record.elasticapm_labels
 
+    # Capture too many spans so we start dropping
+    for i in range(10):
+        with capture_span("drop"):
+            pass
 
-def test_structlog_processor_span():
-    requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, Config(), None)
-    transaction = requests_store.begin_transaction("test")
+    # Test logging with DroppedSpan
+    with capture_span("drop") as span:
+        record = logging.LogRecord(__name__, logging.DEBUG, __file__, 252, "dummy_msg2", [], None)
+        f.filter(record)
+        assert record.elasticapm_transaction_id == transaction.id
+        assert record.elasticapm_trace_id == transaction.trace_parent.trace_id
+        assert record.elasticapm_span_id is None
+        assert record.elasticapm_labels
+
+
+@pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 5}], indirect=True)
+def test_structlog_processor_span(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
     with capture_span("test") as span:
         event_dict = {}
         new_dict = structlog_processor(None, None, event_dict)
         assert new_dict["transaction.id"] == transaction.id
         assert new_dict["trace.id"] == transaction.trace_parent.trace_id
         assert new_dict["span.id"] == span.id
+
+    # Capture too many spans so we start dropping
+    for i in range(10):
+        with capture_span("drop"):
+            pass
+
+    # Test logging with DroppedSpan
+    with capture_span("drop") as span:
+        event_dict = {}
+        new_dict = structlog_processor(None, None, event_dict)
+        assert new_dict["transaction.id"] == transaction.id
+        assert new_dict["trace.id"] == transaction.trace_parent.trace_id
+        assert "span.id" not in new_dict
 
 
 @pytest.mark.skipif(not compat.PY3, reason="Log record factories are only 3.2+")
@@ -304,8 +329,7 @@ def test_automatic_log_record_factory_install(elasticapm_client):
     Use the elasticapm_client fixture to load the client, which in turn installs
     the log_record_factory. Check to make sure it happened.
     """
-    requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, Config(), None)
-    transaction = requests_store.begin_transaction("test")
+    transaction = elasticapm_client.begin_transaction("test")
     with capture_span("test") as span:
         record_factory = logging.getLogRecordFactory()
         record = record_factory(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)


### PR DESCRIPTION
The logging integrations assumed (erroneously) that all spans would have an ID. This fixes that assumption, so that `DroppedSpan`s don't cause exceptions.

I also fixed up some tests to use the `elasticapm_client` fixture instead of manually creating a Tracer object.