### PR TITLE
ci(jenkins): reuse agents (4 less agents to be used)

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,6 +44,13 @@ pipeline {
           }
         }
         stage('Sanity checks') {
+          when {
+            beforeAgent true
+            anyOf {
+              not { changeRequest() }
+              expression { return params.Run_As_Master_Branch }
+            }
+          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
@@ -117,6 +124,27 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
       }
+      input {
+        message 'Should we release a new version?'
+        ok 'Yes, we should.'
+        parameters {
+          choice(
+            choices: [
+              'https://upload.pypi.org/legacy/',
+              'https://test.pypi.org/legacy/'
+             ],
+             description: 'PyPI repository URL',
+             name: 'REPO_URL')
+        }
+      }
+      when {
+        beforeAgent true
+        beforeInput true
+        anyOf {
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+          expression { return params.Run_As_Master_Branch }
+        }
+      }
       steps {
         withGithubNotify(context: 'Release') {
           deleteDir()
@@ -162,6 +190,10 @@ def releasePackages(){
     sh(label: "Release packages", script: """
     set +x
     python -m pip install --user twine
+    python setup.py sdist
+    echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
+    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
+    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} wheelhouse/*.whl
     """)
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,13 +44,6 @@ pipeline {
           }
         }
         stage('Sanity checks') {
-          when {
-            beforeAgent true
-            anyOf {
-              not { changeRequest() }
-              expression { return params.Run_As_Master_Branch }
-            }
-          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
@@ -124,27 +117,6 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
       }
-      input {
-        message 'Should we release a new version?'
-        ok 'Yes, we should.'
-        parameters {
-          choice(
-            choices: [
-              'https://upload.pypi.org/legacy/',
-              'https://test.pypi.org/legacy/'
-             ],
-             description: 'PyPI repository URL',
-             name: 'REPO_URL')
-        }
-      }
-      when {
-        beforeAgent true
-        beforeInput true
-        anyOf {
-          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
-          expression { return params.Run_As_Master_Branch }
-        }
-      }
       steps {
         withGithubNotify(context: 'Release') {
           deleteDir()
@@ -190,10 +162,6 @@ def releasePackages(){
     sh(label: "Release packages", script: """
     set +x
     python -m pip install --user twine
-    python setup.py sdist
-    echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
-    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
-    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} wheelhouse/*.whl
     """)
   }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -4,7 +4,7 @@
 import co.elastic.matrix.*
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR="src/github.com/elastic/apm-agent-python"
     PIPELINE_LOG_LEVEL='INFO'
@@ -26,7 +26,6 @@ pipeline {
   }
   stages {
     stage('Initializing'){
-      agent { label 'docker && linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -73,7 +72,6 @@ pipeline {
     Execute unit tests.
     */
     stage('Test') {
-      agent { label 'linux && immutable' }
       options {
         timeout(time: 1, unit: 'HOURS')
         skipDefaultCheckout()
@@ -96,7 +94,6 @@ pipeline {
       }
     }
     stage('Building packages') {
-      agent { label 'docker && linux && immutable' }
       options {
         timeout(time: 1, unit: 'HOURS')
         skipDefaultCheckout()
@@ -119,7 +116,6 @@ pipeline {
       }
     }
     stage('Release') {
-      agent { label 'linux && immutable' }
       options {
         skipDefaultCheckout()
         timeout(time: 12, unit: 'HOURS')

--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def pythonTasksGen
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO="git@github.com:elastic/apm-agent-python.git"
     BASE_DIR="src/github.com/elastic/apm-agent-python"
@@ -41,7 +41,6 @@ pipeline {
     Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'docker && linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         script {
@@ -64,7 +63,6 @@ pipeline {
     Execute unit tests.
     */
     stage('Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         deleteDir()

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
@@ -17,7 +17,6 @@ pipeline {
   }
   stages {
     stage('Sanity checks') {
-      agent { label 'docker && linux && immutable' }
       environment {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,13 @@ pipeline {
           }
         }
         stage('Sanity checks') {
+          when {
+            beforeAgent true
+            anyOf {
+              not { changeRequest() }
+              expression { return params.Run_As_Master_Branch }
+            }
+          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
@@ -149,6 +156,27 @@ pipeline {
       environment {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
+      }
+      input {
+        message 'Should we release a new version?'
+        ok 'Yes, we should.'
+        parameters {
+          choice(
+            choices: [
+              'https://upload.pypi.org/legacy/',
+              'https://test.pypi.org/legacy/'
+             ],
+             description: 'PyPI repository URL',
+             name: 'REPO_URL')
+        }
+      }
+      when {
+        beforeAgent true
+        beforeInput true
+        anyOf {
+          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
+          expression { return params.Run_As_Master_Branch }
+        }
       }
       steps {
         withGithubNotify(context: 'Release') {
@@ -276,6 +304,10 @@ def releasePackages(){
     sh(label: "Release packages", script: """
     set +x
     python -m pip install --user twine
+    python setup.py sdist
+    echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
+    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
+    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} wheelhouse/*.whl
     """)
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ it is need as field to store the results of the tests.
 @Field def pythonTasksGen
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-python'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -40,7 +40,6 @@ pipeline {
   }
   stages {
     stage('Initializing'){
-      agent { label 'docker && linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -87,7 +86,6 @@ pipeline {
     Execute unit tests.
     */
     stage('Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       steps {
         withGithubNotify(context: 'Test', tab: 'tests') {
@@ -113,7 +111,6 @@ pipeline {
       }
     }
     stage('Building packages') {
-      agent { label 'docker && linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -155,7 +152,6 @@ pipeline {
       }
     }
     stage('Release') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,13 +58,6 @@ pipeline {
           }
         }
         stage('Sanity checks') {
-          when {
-            beforeAgent true
-            anyOf {
-              not { changeRequest() }
-              expression { return params.Run_As_Master_Branch }
-            }
-          }
           steps {
             withGithubNotify(context: 'Sanity checks', tab: 'tests') {
               deleteDir()
@@ -156,27 +149,6 @@ pipeline {
       environment {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
-      }
-      input {
-        message 'Should we release a new version?'
-        ok 'Yes, we should.'
-        parameters {
-          choice(
-            choices: [
-              'https://upload.pypi.org/legacy/',
-              'https://test.pypi.org/legacy/'
-             ],
-             description: 'PyPI repository URL',
-             name: 'REPO_URL')
-        }
-      }
-      when {
-        beforeAgent true
-        beforeInput true
-        anyOf {
-          tag pattern: 'v\\d+.*', comparator: 'REGEXP'
-          expression { return params.Run_As_Master_Branch }
-        }
       }
       steps {
         withGithubNotify(context: 'Release') {
@@ -304,10 +276,6 @@ def releasePackages(){
     sh(label: "Release packages", script: """
     set +x
     python -m pip install --user twine
-    python setup.py sdist
-    echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
-    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
-    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} wheelhouse/*.whl
     """)
   }
 }


### PR DESCRIPTION
### Highlights
- Let's reuse the top-level agent to reduce the number of fo requested agents and speed up just a bit the builds.
- Reset labels to be `linux && immutable` to help with what kind of OS is required to be used.
- Overall time improvements from 4.30m to 3m until the test stage. 

### Test cases
- Release
- Validate the `pre-commit` docker doesn't leave any leftovers