### PR TITLE
use duration argument instead of time.sleep in tests

### DIFF
--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -555,10 +555,10 @@ def test_transaction_max_spans_dynamic(elasticapm_client):
 @pytest.mark.parametrize("elasticapm_client", [{"span_frames_min_duration": 20}], indirect=True)
 def test_transaction_span_frames_min_duration(elasticapm_client):
     elasticapm_client.begin_transaction("test_type")
-    with elasticapm.capture_span("noframes"):
-        time.sleep(0.001)
-    with elasticapm.capture_span("frames"):
-        time.sleep(0.040)
+    with elasticapm.capture_span("noframes", duration=0.001):
+        pass
+    with elasticapm.capture_span("frames", duration=0.04):
+        pass
     elasticapm_client.end_transaction("test")
 
     spans = elasticapm_client.events[SPAN]
@@ -576,8 +576,8 @@ def test_transaction_span_frames_min_duration_no_limit(elasticapm_client):
     elasticapm_client.begin_transaction("test_type")
     with elasticapm.capture_span("frames"):
         pass
-    with elasticapm.capture_span("frames"):
-        time.sleep(0.040)
+    with elasticapm.capture_span("frames", duration=0.04):
+        pass
     elasticapm_client.end_transaction("test")
 
     spans = elasticapm_client.events[SPAN]

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -187,11 +187,11 @@ def test_leaf_tracing(tracer):
         with capture_span("child1-leaf", "custom", leaf=True):
 
             # These two spans should not show up
-            with capture_span("ignored-child1", "custom", leaf=True):
-                time.sleep(0.01)
+            with capture_span("ignored-child1", "custom", leaf=True, duration=0.01):
+                pass
 
-            with capture_span("ignored-child2", "custom", leaf=False):
-                time.sleep(0.01)
+            with capture_span("ignored-child2", "custom", leaf=False, duration=0.01):
+                pass
 
     tracer.end_transaction(None, "transaction")
 


### PR DESCRIPTION
this avoids flakiness in tests due to high CPU usage on the test instance