### PR TITLE
Attribute checking on span to prevent AttributeError: 'DroppedSpan' object has no attribute 'id'

### DIFF
--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -217,7 +217,7 @@ def _add_attributes_to_log_record(record):
     record.elasticapm_trace_id = trace_id
 
     span = execution_context.get_span()
-    span_id = span.id if span else None
+    span_id = span.id if span and hasattr(span, "id") else None
     record.elasticapm_span_id = span_id
 
     record.elasticapm_labels = {"transaction.id": transaction_id, "trace.id": trace_id, "span.id": span_id}


### PR DESCRIPTION
This issue has been tough to debug properly, but briefly explained, I'm running into an error in my project where `span` is missing the attribute `id`. 

This seemingly happens during the handling of a `401` response, in a series of iterated requests. In about 20 requests, the first 6 run smoothly returning `200`s, before the 7th throws the error shown below - this pattern holds up when changing the order of requests and suggests to me that this error might be a symptom of another issue.

The suggested fix solved my problem. Oddly, once fixed, there are no longer any `401`s returned.

<b>Stack trace</b>:
```python
File "/app/src/shared/helpers/kerberos.py", line 27, in get
--
  | response = requests.get(url, headers=headers, auth=HTTPKerberosAuth())
  | File "/usr/local/lib/python3.7/site-packages/requests/api.py", line 75, in get
  | return request('get', url, params=params, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests/api.py", line 60, in request
  | return session.request(method=method, url=url, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
  | resp = self.send(prep, **send_kwargs)
  | File "/usr/local/lib/python3.7/site-packages/elasticapm/instrumentation/packages/base.py", line 141, in call_if_sampling
  | return self.call(module, method, wrapped, instance, args, kwargs)
  | File "/usr/local/lib/python3.7/site-packages/elasticapm/instrumentation/packages/requests.py", line 65, in call
  | return wrapped(*args, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests/sessions.py", line 653, in send
  | r = dispatch_hook('response', hooks, r, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests/hooks.py", line 31, in dispatch_hook
  | _hook_data = hook(hook_data, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests_kerberos/kerberos_.py", line 400, in handle_response
  | _r = self.handle_401(response, **kwargs)
  | File "/usr/local/lib/python3.7/site-packages/requests_kerberos/kerberos_.py", line 284, in handle_401
  | log.debug("handle_401(): Handling: 401")
  | File "/usr/local/lib/python3.7/logging/__init__.py", line 1366, in debug
  | self._log(DEBUG, msg, args, **kwargs)
  | File "/usr/local/lib/python3.7/logging/__init__.py", line 1513, in _log
  | exc_info, func, extra, sinfo)
  | File "/usr/local/lib/python3.7/logging/__init__.py", line 1483, in makeRecord
  | sinfo)
  | File "/usr/local/lib/python3.7/site-packages/elasticapm/handlers/logging.py", line 201, in log_record_factory
  | return _add_attributes_to_log_record(record)
  | File "/usr/local/lib/python3.7/site-packages/elasticapm/handlers/logging.py", line 220, in _add_attributes_to_log_record
  | span_id = span.id if span else None
  | AttributeError: 'DroppedSpan' object has no attribute 'id'
``` 