### PR TITLE
fix pod ID for kubernetes when using the systemd cgroup driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
  * ensure that metrics with value 0 are not collected if they have the `reset_on_collect` flag set (#615)
  * unwrap postgres cursor for newly introduced psycopg2 extensions (#621)
+ * fix pod ID for kubernetes when using the systemd cgroup driver (#631)
 
 ## v5.2.2
 [Check the diff](https://github.com/elastic/apm-agent-python/compare/v5.2.1...v5.2.2)

--- a/elasticapm/utils/cgroup.py
+++ b/elasticapm/utils/cgroup.py
@@ -100,6 +100,8 @@ def parse_cgroups(filehandle):
             pod_id = kubepods_match.group(1)
             if not pod_id:
                 pod_id = kubepods_match.group(2)
+                if pod_id:
+                    pod_id = pod_id.replace("_", "-")
             return {"container": {"id": container_id}, "kubernetes": {"pod": {"uid": pod_id}}}
         elif container_id_regexp.match(container_id):
             return {"container": {"id": container_id}}

--- a/tests/utils/cgroup_tests.py
+++ b/tests/utils/cgroup_tests.py
@@ -56,7 +56,7 @@ from elasticapm.utils import cgroup, compat
             "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope",
             {
                 "container": {"id": "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63"},
-                "kubernetes": {"pod": {"uid": "90d81341_92de_11e7_8cf2_507b9d4141fa"}},
+                "kubernetes": {"pod": {"uid": "90d81341-92de-11e7-8cf2-507b9d4141fa"}},
             },
         ),
         (


### PR DESCRIPTION
When the systemd cgroup driver is used, cgroup paths will have hyphens (e.g. in pod UIDs) escaped to underscores. When we're parsing cgroups, we must therefore unescape them.

refs elastic/apm#165