### PR TITLE
ci(jenkins): downstream@master log rotation didn't keep too many builds in the history

### DIFF
--- a/.ci/downstreamTests.groovy
+++ b/.ci/downstreamTests.groovy
@@ -23,7 +23,7 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '100', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()


### PR DESCRIPTION
## What does this pull request do?

Enable th build rotation of up to 100 builds for the downstream jobs 

## Why is it important?

Hard to debug what's going on when a build error happens and the build rotation was applied

## Related issues
closes #ISSUE