### PR TITLE
update changelog for #649

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,11 @@ https://github.com/elastic/apm-agent-python/compare/v5.3.1\...master[Check the d
 // Unreleased changes go here
 // When the next release happens, nest these changes under the "Python Agent version 5.x" heading
 
+[float]
+===== Bug fixes
+
+ * Added support for IPv6 address format when parsing urls {pull}649[#649]
+
 [[release-notes-5.x]]
 === Python Agent version 5.x
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -52,61 +52,79 @@ def test_deprecation():
     deprecated_function()
 
 
-def test_get_url_dict():
-    data = {
-        "http://example.com": {
-            "protocol": "http:",
-            "hostname": "example.com",
-            "pathname": "",
-            "full": "http://example.com",
-        },
-        "http://example.com:443": {
-            "protocol": "http:",
-            "hostname": "example.com",
-            "port": "443",
-            "pathname": "",
-            "full": "http://example.com:443",
-        },
-        "http://example.com:443/a/b/c": {
-            "protocol": "http:",
-            "hostname": "example.com",
-            "port": "443",
-            "pathname": "/a/b/c",
-            "full": "http://example.com:443/a/b/c",
-        },
-        "https://example.com:443/": {
-            "protocol": "https:",
-            "hostname": "example.com",
-            "port": "443",
-            "pathname": "/",
-            "full": "https://example.com:443/",
-        },
-        "https://example.com:443/a/b/c?de": {
-            "protocol": "https:",
-            "hostname": "example.com",
-            "port": "443",
-            "pathname": "/a/b/c",
-            "search": "?de",
-            "full": "https://example.com:443/a/b/c?de",
-        },
-        "https://[::ffff:a9fe:a9fe]/a/b/c?de": {
-            "protocol": "https:",
-            "hostname": "::ffff:a9fe:a9fe",
-            "pathname": "/a/b/c",
-            "search": "?de",
-            "full": "https://[::ffff:a9fe:a9fe]/a/b/c?de",
-        },
-        "http://[::ffff:a9fe:a9fe]:80/a/b/c?de": {
-            "protocol": "http:",
-            "hostname": "::ffff:a9fe:a9fe",
-            "port": "80",
-            "pathname": "/a/b/c",
-            "search": "?de",
-            "full": "http://[::ffff:a9fe:a9fe]:80/a/b/c?de",
-        },
-    }
-    for url, expected in data.items():
-        assert get_url_dict(url) == expected
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
+            "http://example.com",
+            {"protocol": "http:", "hostname": "example.com", "pathname": "", "full": "http://example.com"},
+        ),
+        (
+            "http://example.com:443",
+            {
+                "protocol": "http:",
+                "hostname": "example.com",
+                "port": "443",
+                "pathname": "",
+                "full": "http://example.com:443",
+            },
+        ),
+        (
+            "http://example.com:443/a/b/c",
+            {
+                "protocol": "http:",
+                "hostname": "example.com",
+                "port": "443",
+                "pathname": "/a/b/c",
+                "full": "http://example.com:443/a/b/c",
+            },
+        ),
+        (
+            "https://example.com:443/",
+            {
+                "protocol": "https:",
+                "hostname": "example.com",
+                "port": "443",
+                "pathname": "/",
+                "full": "https://example.com:443/",
+            },
+        ),
+        (
+            "https://example.com:443/a/b/c?de",
+            {
+                "protocol": "https:",
+                "hostname": "example.com",
+                "port": "443",
+                "pathname": "/a/b/c",
+                "search": "?de",
+                "full": "https://example.com:443/a/b/c?de",
+            },
+        ),
+        (
+            "https://[::ffff:a9fe:a9fe]/a/b/c?de",
+            {
+                "protocol": "https:",
+                "hostname": "::ffff:a9fe:a9fe",
+                "pathname": "/a/b/c",
+                "search": "?de",
+                "full": "https://[::ffff:a9fe:a9fe]/a/b/c?de",
+            },
+        ),
+        (
+            "http://[::ffff:a9fe:a9fe]:80/a/b/c?de",
+            {
+                "protocol": "http:",
+                "hostname": "::ffff:a9fe:a9fe",
+                "port": "80",
+                "pathname": "/a/b/c",
+                "search": "?de",
+                "full": "http://[::ffff:a9fe:a9fe]:80/a/b/c?de",
+            },
+        ),
+    ],
+)
+def test_get_url_dict(url, expected):
+    assert get_url_dict(url) == expected
 
 
 def test_get_name_from_func():


### PR DESCRIPTION
also, use proper parametrization for test_get_url_dict test cases


## What does this pull request do?

Adds changelog entry for #649, and uses parametrization for the related
test.

## Why is it important?

With parametrization, all test cases are run independently. That means
that if one of the cases fails, the other cases will still be run.