### PR TITLE
ci(jenkins): enable benchmark run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .DS_Store
 .idea
 .vscode
+.benchmarks
 pip-log.txt
 /*.egg-info
 /build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,11 @@ repos:
         exclude: "(elasticapm/utils/wrapt/.*|tests/utils/stacks/linenos.py)"
         language: script
         types: [python]
+
+-   repo: git@github.com:elastic/apm-pipeline-library
+    rev: current
+    hooks:
+    -   id: check-bash-syntax
+    -   id: check-jenkins-pipelines
+        files: ^(.ci/(.*\.groovy|Jenkinsfile)|Jenkinsfile)$
+    -   id: check-jjbb

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,3 @@ repos:
         exclude: "(elasticapm/utils/wrapt/.*|tests/utils/stacks/linenos.py)"
         language: script
         types: [python]
-
--   repo: git@github.com:elastic/apm-pipeline-library
-    rev: current
-    hooks:
-    -   id: check-bash-syntax
-    -   id: check-jenkins-pipelines
-        files: ^(.ci/(.*\.groovy|Jenkinsfile)|Jenkinsfile)$
-    -   id: check-jjbb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,6 +171,8 @@ pipeline {
         PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
         PIP_CACHE = "${env.WORKSPACE}/.cache"
         AGENT_WORKDIR = "${env.WORKSPACE}/${env.BUILD_NUMBER}/${env.BASE_DIR}"
+        LANG = 'C.UTF-8'
+        LC_ALL = "${env.LANG}"
       }
       when {
         beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
               dir(BASE_DIR){
                 sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
                                              user_var: 'ES_USER', pass_var: 'ES_PASS') {
-                  sh 'scripts/run-benchmarks.sh "${AGENT_WORKDIR}" "${GIT_BASE_COMMIT}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
+                  sh 'scripts/run-benchmarks.sh "${AGENT_WORKDIR}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,6 +170,7 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
         PIP_CACHE = "${env.WORKSPACE}/.cache"
+        AGENT_WORKDIR = "${env.WORKSPACE}/${env.BUILD_NUMBER}/${env.BASE_DIR}"
       }
       when {
         beforeAgent true
@@ -190,7 +191,7 @@ pipeline {
               dir(BASE_DIR){
                 sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
                                              user_var: 'ES_USER', pass_var: 'ES_PASS') {
-                  sh 'scripts/run-benchmarks.sh "${GIT_BASE_COMMIT}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
+                  sh 'scripts/run-benchmarks.sh "${AGENT_WORKDIR}" "${GIT_BASE_COMMIT}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
+        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
         PIP_CACHE = "${env.WORKSPACE}/.cache"
       }
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,10 +181,12 @@ pipeline {
           dir(env.BUILD_NUMBER) {
             deleteDir()
             unstash 'source'
-            dir(BASE_DIR){
-              sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
-                                           user_var: 'ES_USER', pass_var: 'ES_PASS') {
-                sh 'scripts/run-benchmarks.sh "${GIT_BASE_COMMIT}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
+            script {
+              dir(BASE_DIR){
+                sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
+                                             user_var: 'ES_USER', pass_var: 'ES_PASS') {
+                  sh 'scripts/run-benchmarks.sh "${GIT_BASE_COMMIT}" "${ES_URL}" "${ES_USER}" "${ES_PASS}"'
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,11 @@ pipeline {
     stage('Benchmarks') {
       agent { label 'metal' }
       options { skipDefaultCheckout() }
+      environment {
+        HOME = "${env.WORKSPACE}"
+        PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
+        PIP_CACHE = "${env.WORKSPACE}/.cache"
+      }
       when {
         beforeAgent true
         allOf {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,8 @@ pipeline {
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks.')
+    booleanParam(name: 'tests_ci', defaultValue: true, description: 'Enable tests.')
+    booleanParam(name: 'package_ci', defaultValue: true, description: 'Enable building packages.')
   }
   stages {
     stage('Initializing'){
@@ -89,6 +91,10 @@ pipeline {
     */
     stage('Test') {
       options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        expression { return params.tests_ci }
+      }
       steps {
         withGithubNotify(context: 'Test', tab: 'tests') {
           deleteDir()
@@ -114,6 +120,10 @@ pipeline {
     }
     stage('Building packages') {
       options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        expression { return params.package_ci }
+      }
       environment {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -2,10 +2,16 @@
 set -ex
 
 AGENT_WORKDIR=${1:?Please specify the python agent workspace}
-COMMIT_SHA=${2:?Please specify the git SHA commit}
-ES_URL=${3:?Please specify the elasticstack URL}
-ES_USER=${4:?Please specify the user to connect with}
-ES_PASS=${5:?Please specify the password to connect with}
+ES_URL=${2:?Please specify the elasticstack URL}
+ES_USER=${3:?Please specify the user to connect with}
+ES_PASS=${4:?Please specify the password to connect with}
+
+## If BRANCH_NAME is set then use the tag filter.
+## This particular env variable is inferred from the Jenkins CI.
+EXTRA_ARGS=''
+if [ -n "${BRANCH_NAME}" ] ; then
+    EXTRA_ARGS="--tag \"branch=${BRANCH_NAME}\""
+fi
 
 if [ -d .benchmarks ] ; then
     rm -rf .benchmarks
@@ -24,4 +30,5 @@ python run_bench_commits.py \
     --es-url "${ES_URL}" \
     --es-user "${ES_USER}" \
     --es-password "${ES_PASS}" \
-    --as-is
+    --as-is \
+    "${EXTRA_ARGS}"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -6,6 +6,9 @@ ES_URL=${2:?Please specify the elasticstack URL}
 ES_USER=${3:?Please specify the user to connect with}
 ES_PASS=${4:?Please specify the password to connect with}
 
+if [ -d .benchmarks ] ; then
+    rm -rf .benchmarks
+fi
 git clone https://github.com/elastic/apm-agent-python-benchmarks.git .benchmarks
 
 cd .benchmarks
@@ -13,7 +16,7 @@ cd .benchmarks
 ## Prepare virtualenv
 virtualenv -p python3 "${HOME}/.local"
 
-pip install --user -r requirements.txt
+pip install -r requirements.txt
 
 python run_bench_commits.py \
     --worktree agent \

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -6,13 +6,6 @@ ES_URL=${2:?Please specify the elasticstack URL}
 ES_USER=${3:?Please specify the user to connect with}
 ES_PASS=${4:?Please specify the password to connect with}
 
-## If BRANCH_NAME is set then use the tag filter.
-## This particular env variable is inferred from the Jenkins CI.
-EXTRA_ARGS=''
-if [ -n "${BRANCH_NAME}" ] ; then
-    EXTRA_ARGS="--tag \"branch=${BRANCH_NAME}\""
-fi
-
 if [ -d .benchmarks ] ; then
     rm -rf .benchmarks
 fi
@@ -31,4 +24,4 @@ python run_bench_commits.py \
     --es-user "${ES_USER}" \
     --es-password "${ES_PASS}" \
     --as-is \
-    "${EXTRA_ARGS}"
+    --tag "branch=${BRANCH_NAME}"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -10,6 +10,9 @@ git clone https://github.com/elastic/apm-agent-python-benchmarks.git .benchmarks
 
 cd .benchmarks
 
+## Prepare virtualenv
+virtualenv -p python3 "${HOME}/.local"
+
 pip install --user -r requirements.txt
 
 python run_bench_commits.py \

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-COMMIT_SHA=${1:?Please specify the git SHA commit}
-ES_URL=${2:?Please specify the elasticstack URL}
-ES_USER=${3:?Please specify the user to connect with}
-ES_PASS=${4:?Please specify the password to connect with}
+AGENT_WORKDIR=${1:?Please specify the python agent workspace}
+COMMIT_SHA=${2:?Please specify the git SHA commit}
+ES_URL=${3:?Please specify the elasticstack URL}
+ES_USER=${4:?Please specify the user to connect with}
+ES_PASS=${5:?Please specify the password to connect with}
 
 if [ -d .benchmarks ] ; then
     rm -rf .benchmarks
@@ -19,7 +20,7 @@ virtualenv -p python3 "${HOME}/.local"
 pip install -r requirements.txt
 
 python run_bench_commits.py \
-    --worktree agent \
+    --worktree "${AGENT_WORKDIR}" \
     --es-url "${ES_URL}" \
     --es-user "${ES_USER}" \
     --es-password "${ES_PASS}" \

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -ex
+set -e
 
 AGENT_WORKDIR=${1:?Please specify the python agent workspace}
 ES_URL=${2:?Please specify the elasticstack URL}

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -ex
+
+COMMIT_SHA=${1:?Please specify the git SHA commit}
+ES_URL=${2:?Please specify the elasticstack URL}
+ES_USER=${3:?Please specify the user to connect with}
+ES_PASS=${4:?Please specify the password to connect with}
+
+git clone https://github.com/elastic/apm-agent-python-benchmarks.git .benchmarks
+
+cd .benchmarks
+
+pip install --user -r requirements.txt
+
+python run_bench_commits.py \
+    --worktree agent \
+    --es-url "${ES_URL}" \
+    --es-user "${ES_USER}" \
+    --es-password "${ES_PASS}" \
+    --start-commit "${COMMIT_SHA}"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -24,4 +24,4 @@ python run_bench_commits.py \
     --es-url "${ES_URL}" \
     --es-user "${ES_USER}" \
     --es-password "${ES_PASS}" \
-    --start-commit "${COMMIT_SHA}"
+    --as-is


### PR DESCRIPTION
## What does this pull request do?

* Run benchmark by default for each commit into the master branch. It does enable us to run the benchmark on a PR basis but only if using the Jenkins UI. 

* Besides, it does enable us to customize what CI stages should be launch using the UI. 

## Why is it important?

APM agents do run benchmark by default.

## e2e tests

- See [build without tag flag and as-is](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-651/15/pipeline)

- See [build with latest changes](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-651/20/)

## UI view

![image](https://user-images.githubusercontent.com/2871786/69548780-e41bf980-0f8f-11ea-9260-8a60db1cf27e.png)
