### PR TITLE
skip flaky metrics comparison test

### DIFF
--- a/tests/metrics/cpu_psutil_tests.py
+++ b/tests/metrics/cpu_psutil_tests.py
@@ -61,6 +61,7 @@ def test_cpu_mem_from_psutil():
 cpu_linux = pytest.importorskip("elasticapm.metrics.sets.cpu_linux")
 
 
+@pytest.mark.skip("test is flaky on CI")
 def test_compare_psutil_linux_metricsets():
     psutil_metricset = cpu_psutil.CPUMetricSet(MetricsRegistry(0, lambda x: None))
     linux_metricset = cpu_linux.CPUMetricSet(MetricsRegistry(0, lambda x: None))


### PR DESCRIPTION
skip flaky metrics comparison test

## Why is it important?

Unfortunately, this test fails quite often on CI due to unpredictable
load.