### PR TITLE
updated trove classifiers to include Python 3.7 and 3.8, and license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,8 +197,11 @@ setup_kwargs = dict(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
+        "License :: OSI Approved :: BSD License",
     ],
 )
 


### PR DESCRIPTION
## What does this pull request do?
Adds some new entries in our trove classifiers

## Why is it important?

These entries are used by e.g. pypi.org to show meta data about the
package.