### PR TITLE
implemented async_capture_span and instrumentation for the aiohttp client

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ build: off
 test_script:
   - bash .\\tests\\scripts\\download_json_schema.sh
   - if "%ASYNCIO%" == "true" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest -m "not integrationtest"
-  - if "%ASYNCIO%" == "false" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest --ignore=tests/asyncio -m "not integrationtest"
+  - if "%ASYNCIO%" == "false" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest --ignore-glob="*/asyncio/*" -m "not integrationtest"
 
 after_test:
   - ".\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -178,3 +178,16 @@ exclude:
   # gevent
   - PYTHON_VERSION: pypy-2  # see https://github.com/gevent/gevent/issues/1380, fix will be in gevent 1.5
     FRAMEWORK: gevent-newest
+  # aiohttp client, only supported in Python 3.7+
+  - PYTHON_VERSION: python-2.7
+    FRAMEWORK: aiohttp_client-newest
+  - PYTHON_VERSION: pypy-2
+    FRAMEWORK: aiohttp_client-newest
+  - PYTHON_VERSION: pypy-3
+    FRAMEWORK: aiohttp_client-newest
+  - PYTHON_VERSION: python-3.4
+    FRAMEWORK: aiohttp_client-newest
+  - PYTHON_VERSION: python-3.5
+    FRAMEWORK: aiohttp_client-newest
+  - PYTHON_VERSION: python-3.6
+    FRAMEWORK: aiohttp_client-newest

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -32,3 +32,4 @@ FRAMEWORK:
   - zerorpc-0.4
   - mysql_connector-newest
   - pymysql-newest
+  - aiohttp_client-newest

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ flake8:
 test:
 	if [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6|3.7|3.8|nightly|pypy3)$$ ]] ; then \
 	py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT); \
-	else py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore=tests/asyncio --ignore-glob='*/py3_*.py'; fi
+	else py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/py3_*.py' --ignore-glob='*/asyncio/*'; fi
 
 coverage: PYTEST_ARGS=--cov --cov-report xml:coverage.xml
 coverage: test

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -27,7 +27,7 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-
+import sys
 
 __all__ = ("VERSION", "Client")
 
@@ -43,3 +43,7 @@ from elasticapm.traces import capture_span, set_context, set_custom_context  # n
 from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
 from elasticapm.traces import set_transaction_result  # noqa: F401
 from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
+
+
+if sys.version_info >= (3, 5):
+    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401

--- a/elasticapm/contrib/asyncio/__init__.py
+++ b/elasticapm/contrib/asyncio/__init__.py
@@ -27,28 +27,3 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
-from elasticapm.traces import capture_span
-from elasticapm.utils import get_host_from_url, sanitize_url
-
-
-class RequestsInstrumentation(AbstractInstrumentedModule):
-    name = "requests"
-
-    instrument_list = [("requests.sessions", "Session.send")]
-
-    def call(self, module, method, wrapped, instance, args, kwargs):
-        if "request" in kwargs:
-            request = kwargs["request"]
-        else:
-            request = args[0]
-
-        signature = request.method.upper()
-        signature += " " + get_host_from_url(request.url)
-        url = sanitize_url(request.url)
-
-        with capture_span(
-            signature, span_type="external", span_subtype="http", extra={"http": {"url": url}}, leaf=True
-        ):
-            return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/asyncio/__init__.py
+++ b/elasticapm/instrumentation/packages/asyncio/__init__.py
@@ -27,28 +27,3 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
-from elasticapm.traces import capture_span
-from elasticapm.utils import get_host_from_url, sanitize_url
-
-
-class RequestsInstrumentation(AbstractInstrumentedModule):
-    name = "requests"
-
-    instrument_list = [("requests.sessions", "Session.send")]
-
-    def call(self, module, method, wrapped, instance, args, kwargs):
-        if "request" in kwargs:
-            request = kwargs["request"]
-        else:
-            request = args[0]
-
-        signature = request.method.upper()
-        signature += " " + get_host_from_url(request.url)
-        url = sanitize_url(request.url)
-
-        with capture_span(
-            signature, span_type="external", span_subtype="http", extra={"http": {"url": url}}, leaf=True
-        ):
-            return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/asyncio/base.py
+++ b/elasticapm/instrumentation/packages/asyncio/base.py
@@ -29,26 +29,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
-from elasticapm.traces import capture_span
-from elasticapm.utils import get_host_from_url, sanitize_url
 
 
-class RequestsInstrumentation(AbstractInstrumentedModule):
-    name = "requests"
-
-    instrument_list = [("requests.sessions", "Session.send")]
-
-    def call(self, module, method, wrapped, instance, args, kwargs):
-        if "request" in kwargs:
-            request = kwargs["request"]
-        else:
-            request = args[0]
-
-        signature = request.method.upper()
-        signature += " " + get_host_from_url(request.url)
-        url = sanitize_url(request.url)
-
-        with capture_span(
-            signature, span_type="external", span_subtype="http", extra={"http": {"url": url}}, leaf=True
-        ):
-            return wrapped(*args, **kwargs)
+class AsyncAbstractInstrumentedModule(AbstractInstrumentedModule):
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        raise NotImplementedError()

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -28,6 +28,7 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
 
 from elasticapm.utils.module_import import import_string
 
@@ -58,6 +59,9 @@ _cls_register = {
     "elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation",
     "elasticapm.instrumentation.packages.urllib.UrllibInstrumentation",
 }
+
+if sys.version_info >= (3, 5):
+    _cls_register.update(["elasticapm.instrumentation.packages.asyncio.aiohttp_client.AioHttpClientInstrumentation"])
 
 
 def register(cls):

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -344,7 +344,8 @@ class Span(BaseSpan):
         "parent_span_id",
         "frames",
         "labels",
-        "sync" "_child_durations",
+        "sync",
+        "_child_durations",
     )
 
     def __init__(

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -205,6 +205,7 @@ class Transaction(BaseSpan):
         parent_span_id=None,
         span_subtype=None,
         span_action=None,
+        sync=True,
         start=None,
     ):
         parent_span = execution_context.get_span()
@@ -227,6 +228,7 @@ class Transaction(BaseSpan):
                 parent_span_id=parent_span_id,
                 span_subtype=span_subtype,
                 span_action=span_action,
+                sync=sync,
                 start=start,
             )
             span.frames = tracer.frames_collector_func()
@@ -235,7 +237,16 @@ class Transaction(BaseSpan):
         return span
 
     def begin_span(
-        self, name, span_type, context=None, leaf=False, labels=None, span_subtype=None, span_action=None, start=None
+        self,
+        name,
+        span_type,
+        context=None,
+        leaf=False,
+        labels=None,
+        span_subtype=None,
+        span_action=None,
+        sync=True,
+        start=None,
     ):
         """
         Begin a new span
@@ -258,6 +269,7 @@ class Transaction(BaseSpan):
             parent_span_id=None,
             span_subtype=span_subtype,
             span_action=span_action,
+            sync=sync,
             start=start,
         )
 
@@ -332,7 +344,7 @@ class Span(BaseSpan):
         "parent_span_id",
         "frames",
         "labels",
-        "_child_durations",
+        "sync" "_child_durations",
     )
 
     def __init__(
@@ -347,6 +359,7 @@ class Span(BaseSpan):
         parent_span_id=None,
         span_subtype=None,
         span_action=None,
+        sync=True,
         start=None,
     ):
         """
@@ -361,6 +374,7 @@ class Span(BaseSpan):
         :param parent_span_id: override of the span ID
         :param span_subtype: sub type of the span, e.g. mysql
         :param span_action: sub type of the span, e.g. query
+        :param sync: indicate if the span was executed synchronously or asynchronously
         :param start: timestamp, mostly useful for testing
         """
         self.start_time = start or _time_func()
@@ -378,6 +392,7 @@ class Span(BaseSpan):
         self.parent = parent
         self.parent_span_id = parent_span_id
         self.frames = None
+        self.sync = sync
         if span_subtype is None and "." in span_type:
             # old style dottet type, let's split it up
             type_bits = span_type.split(".")
@@ -404,6 +419,7 @@ class Span(BaseSpan):
             "type": encoding.keyword_field(self.type),
             "subtype": encoding.keyword_field(self.subtype),
             "action": encoding.keyword_field(self.action),
+            "sync": self.sync,
             "timestamp": int(self.timestamp * 1000000),  # microseconds
             "duration": self.duration * 1000,  # milliseconds
         }

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -127,6 +127,16 @@ def sanitize_url(url):
     return url.replace("%s:%s" % (parts.username, parts.password), "%s:%s" % (parts.username, constants.MASK))
 
 
+def get_host_from_url(url):
+    parsed_url = compat.urlparse.urlparse(url)
+    host = parsed_url.hostname or " "
+
+    if parsed_url.port and default_ports.get(parsed_url.scheme) != parsed_url.port:
+        host += ":" + str(parsed_url.port)
+
+    return host
+
+
 def read_pem_file(file_obj):
     cert = b""
     for line in file_obj:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ markers =
     mysql_connector
     pymysql
     mysqldb
+    aiohttp_client
 
 [isort]
 line_length=120

--- a/tests/instrumentation/asyncio/__init__.py
+++ b/tests/instrumentation/asyncio/__init__.py
@@ -27,28 +27,3 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
-from elasticapm.traces import capture_span
-from elasticapm.utils import get_host_from_url, sanitize_url
-
-
-class RequestsInstrumentation(AbstractInstrumentedModule):
-    name = "requests"
-
-    instrument_list = [("requests.sessions", "Session.send")]
-
-    def call(self, module, method, wrapped, instance, args, kwargs):
-        if "request" in kwargs:
-            request = kwargs["request"]
-        else:
-            request = args[0]
-
-        signature = request.method.upper()
-        signature += " " + get_host_from_url(request.url)
-        url = sanitize_url(request.url)
-
-        with capture_span(
-            signature, span_type="external", span_subtype="http", extra={"http": {"url": url}}, leaf=True
-        ):
-            return wrapped(*args, **kwargs)

--- a/tests/requirements/requirements-aiohttp_client-newest.txt
+++ b/tests/requirements/requirements-aiohttp_client-newest.txt
@@ -1,0 +1,2 @@
+aiohttp
+-r requirements-base.txt

--- a/tests/scripts/envs/aiohttp_client.sh
+++ b/tests/scripts/envs/aiohttp_client.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m aiohttp_client"


### PR DESCRIPTION
## What does this pull request do?

It adds an async version of `capture_span`, surprisingly named
`async_capture_span`, as well as instrumentation for the
aiohttp HTTP client.

## Why is it important?

Having an asyncio aware version of `capture_span` allows us
to implement instrumentation of asyncio libraries