### PR TITLE
add tag "mode" to indicate that a benchmark has been triggered by CI

### DIFF
--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -24,4 +24,5 @@ python run_bench_commits.py \
     --es-user "${ES_USER}" \
     --es-password "${ES_PASS}" \
     --as-is \
-    --tag "branch=${BRANCH_NAME}"
+    --tag "branch=${BRANCH_NAME}" \
+    --tag mode=CI


### PR DESCRIPTION
## What does this pull request do?

tags benchmark runs triggered by CI with mode=CI

## Why is it important?

We backfilled benchmarks for all commits since v4.0, and tagged
them with mode=backfill. Using this, we can tell if a benchmark
has been triggered by CI or not.