### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,7 +268,8 @@ pipeline {
             dir("${OPBEANS_REPO}"){
               git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                   url: "git@github.com:elastic/${OPBEANS_REPO}.git"
-              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // It's required to transform the tag value to the artifact version
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
               // The opbeans pipeline will trigger a release for the master branch
               gitPush()
               // The opbeans pipeline will trigger a release for the release tag

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
+    OPBEANS_REPO = 'opbeans-python'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -254,6 +255,23 @@ pipeline {
               dir("${BASE_DIR}"){
                 releasePackages()
               }
+            }
+          }
+        }
+        stage('Opbeans') {
+          environment {
+            REPO_NAME = "${OPBEANS_REPO}"
+          }
+          steps {
+            deleteDir()
+            dir("${OPBEANS_REPO}"){
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${OPBEANS_REPO}.git"
+              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME}", label: 'Bump version'
+              // The opbeans pipeline will trigger a release for the master branch
+              gitPush()
+              // The opbeans pipeline will trigger a release for the release tag
+              gitCreateTag(tag: "${env.BRANCH_NAME}")
             }
           }
         }


### PR DESCRIPTION
## What does this pull request do?

Add a final stage in the release process to bump the opbeans agent dependency.

## Why is it important?

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Bump dependency versions in the opbeans-python
- [x] Push changes. (Implementation within the opbeans-python but the call it's done within this pipeline)
- [x] Create a tag to trigger the release pipeline in the opbeans-python. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the `master` branch for the opbeans-python and tag it with the name of the tag version too. Therefore, the opbeans-python pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-python.
