### PR TITLE
added async_capture_span for decorating coroutines and `async with`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -42,7 +42,7 @@ build: off
 test_script:
   - bash .\\tests\\scripts\\download_json_schema.sh
   - if "%ASYNCIO%" == "true" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest -m "not integrationtest"
-  - if "%ASYNCIO%" == "false" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest --ignore=tests/asyncio -m "not integrationtest"
+  - if "%ASYNCIO%" == "false" call appveyor-retry .\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe -m pytest --ignore-glob="*/asyncio/*" -m "not integrationtest"
 
 after_test:
   - ".\\tests\\appveyor\\build.cmd %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ flake8:
 test:
 	if [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6|3.7|3.8|nightly|pypy3)$$ ]] ; then \
 	py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT); \
-	else py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore=tests/asyncio --ignore-glob='*/py3_*.py'; fi
+	else py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/py3_*.py' --ignore-glob='*/asyncio/*'; fi
 
 coverage: PYTEST_ARGS=--cov --cov-report xml:coverage.xml
 coverage: test

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -324,6 +324,43 @@ def coffee_maker(strength):
  * `span_action`: action of the span, e.g. `query`. Defaults to `None`
 
 [float]
+[[api-async-capture-span]]
+==== `elasticapm.async_capture_span`
+
+Capture a custom async-aware span.
+This can be used either as a function decorator or as a context manager (in an `async with` statement).
+When used as a decorator, the name of the span will be set to the name of the function.
+When used as a context manager, a name has to be provided.
+
+[source,python]
+----
+import elasticapm
+
+@elasticapm.async_capture_span()
+async def coffee_maker(strength):
+    await fetch_water()
+
+    async with elasticapm.async_capture_span('near-to-machine', labels={"type": "arabica"}):
+        await insert_filter()
+        async for i in range(strength):
+            await pour_coffee()
+
+        start_drip()
+
+    fresh_pots()
+----
+
+ * `name`: The name of the span
+ * `span_type`: The type of the span, usually in a dot-separated hierarchy of `type`, `subtype`, and `action`, e.g. `db.mysql.query`. Alternatively, type, subtype and action can be provided as three separate arguments, see `span_subtype` and `span_action`.
+ * `skip_frames`: The number of stack frames to skip when collecting stack traces. Defaults to `0`.
+ * `leaf`: if `True`, all spans nested bellow this span will be ignored. Defaults to `False`.
+ * `labels`: a dictionary of labels. Keys must be strings, values can be strings, booleans, or numerical (`int`, `float`, `decimal.Decimal`). Defaults to `None`.
+ * `span_subtype`: subtype of the span, e.g. name of the database. Defaults to `None`.
+ * `span_action`: action of the span, e.g. `query`. Defaults to `None`
+
+NOTE: `asyncio` is only supported for Python 3.7+.
+
+[float]
 [[api-label]]
 ==== `elasticapm.label()`
 

--- a/docs/custom-instrumentation.asciidoc
+++ b/docs/custom-instrumentation.asciidoc
@@ -18,12 +18,34 @@ def coffee_maker(strength):
 
     with elasticapm.capture_span('near-to-machine'):
         insert_filter()
-        for i in range(strengh):
+        for i in range(strength):
             pour_coffee()
 
         start_drip()
 
     fresh_pots()
 ----
+
+Similarly, you can use `elasticapm.async_capture_span` for instrumenting `async` workloads:
+
+[source,python]
+----
+import elasticapm
+
+@elasticapm.async_capture_span()
+async def coffee_maker(strength):
+    await fetch_water()
+
+    async with elasticapm.async_capture_span('near-to-machine'):
+        await insert_filter()
+        async for i in range(strength):
+            await pour_coffee()
+
+        start_drip()
+
+    fresh_pots()
+----
+
+NOTE: `asyncio` support is only available in Python 3.7+.
 
 See <<api-capture-span, the API docs>> for more information on `capture_span`. 

--- a/elasticapm/contrib/asyncio/__init__.py
+++ b/elasticapm/contrib/asyncio/__init__.py
@@ -1,6 +1,5 @@
 #  BSD 3-Clause License
 #
-#  Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
 #  Copyright (c) 2019, Elasticsearch BV
 #  All rights reserved.
 #
@@ -27,23 +26,4 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-import sys
-
-__all__ = ("VERSION", "Client")
-
-try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
-except Exception:
-    VERSION = "unknown"
-
-from elasticapm.base import Client
-from elasticapm.conf import setup_logging  # noqa: F401
-from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
-from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
-from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
-
-
-if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/elasticapm/instrumentation/packages/asyncio/__init__.py
+++ b/elasticapm/instrumentation/packages/asyncio/__init__.py
@@ -1,0 +1,29 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/elasticapm/instrumentation/packages/asyncio/base.py
+++ b/elasticapm/instrumentation/packages/asyncio/base.py
@@ -1,6 +1,5 @@
 #  BSD 3-Clause License
 #
-#  Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
 #  Copyright (c) 2019, Elasticsearch BV
 #  All rights reserved.
 #
@@ -27,23 +26,11 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-import sys
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ("VERSION", "Client")
-
-try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
-except Exception:
-    VERSION = "unknown"
-
-from elasticapm.base import Client
-from elasticapm.conf import setup_logging  # noqa: F401
-from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
-from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
-from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 
 
-if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401
+class AsyncAbstractInstrumentedModule(AbstractInstrumentedModule):
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        raise NotImplementedError()

--- a/elasticapm/instrumentation/packages/asyncio/sleep.py
+++ b/elasticapm/instrumentation/packages/asyncio/sleep.py
@@ -1,6 +1,5 @@
 #  BSD 3-Clause License
 #
-#  Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
 #  Copyright (c) 2019, Elasticsearch BV
 #  All rights reserved.
 #
@@ -27,23 +26,21 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-import sys
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ("VERSION", "Client")
-
-try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
-except Exception:
-    VERSION = "unknown"
-
-from elasticapm.base import Client
-from elasticapm.conf import setup_logging  # noqa: F401
-from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
-from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
-from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
+from elasticapm.contrib.asyncio.traces import async_capture_span
+from elasticapm.instrumentation.packages.asyncio.base import AsyncAbstractInstrumentedModule
 
 
-if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401
+class AsyncIOSleepInstrumentation(AsyncAbstractInstrumentedModule):
+    name = "asyncio_sleep"
+
+    instrument_list = [("asyncio.tasks", "sleep")]
+
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        delay = args[0] if args else kwargs["delay"]
+
+        signature = "asyncio.sleep %.3f" % delay
+
+        async with async_capture_span(signature, leaf=True, span_type="task", span_subtype="sleep"):
+            return await wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/asyncio/sleep.py
+++ b/elasticapm/instrumentation/packages/asyncio/sleep.py
@@ -38,9 +38,5 @@ class AsyncIOSleepInstrumentation(AsyncAbstractInstrumentedModule):
     instrument_list = [("asyncio.tasks", "sleep")]
 
     async def call(self, module, method, wrapped, instance, args, kwargs):
-        delay = args[0] if args else kwargs["delay"]
-
-        signature = "asyncio.sleep %.3f" % delay
-
-        async with async_capture_span(signature, leaf=True, span_type="task", span_subtype="sleep"):
+        async with async_capture_span("asyncio.sleep", leaf=True, span_type="task", span_subtype="sleep"):
             return await wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -28,6 +28,7 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import sys
 
 from elasticapm.utils.module_import import import_string
 
@@ -58,6 +59,9 @@ _cls_register = {
     "elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation",
     "elasticapm.instrumentation.packages.urllib.UrllibInstrumentation",
 }
+
+if sys.version_info >= (3, 5):
+    _cls_register.update(["elasticapm.instrumentation.packages.asyncio.sleep.AsyncIOSleepInstrumentation"])
 
 
 def register(cls):

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -205,6 +205,7 @@ class Transaction(BaseSpan):
         parent_span_id=None,
         span_subtype=None,
         span_action=None,
+        sync=True,
         start=None,
     ):
         parent_span = execution_context.get_span()
@@ -227,6 +228,7 @@ class Transaction(BaseSpan):
                 parent_span_id=parent_span_id,
                 span_subtype=span_subtype,
                 span_action=span_action,
+                sync=sync,
                 start=start,
             )
             span.frames = tracer.frames_collector_func()
@@ -235,7 +237,16 @@ class Transaction(BaseSpan):
         return span
 
     def begin_span(
-        self, name, span_type, context=None, leaf=False, labels=None, span_subtype=None, span_action=None, start=None
+        self,
+        name,
+        span_type,
+        context=None,
+        leaf=False,
+        labels=None,
+        span_subtype=None,
+        span_action=None,
+        sync=True,
+        start=None,
     ):
         """
         Begin a new span
@@ -258,6 +269,7 @@ class Transaction(BaseSpan):
             parent_span_id=None,
             span_subtype=span_subtype,
             span_action=span_action,
+            sync=sync,
             start=start,
         )
 
@@ -332,6 +344,7 @@ class Span(BaseSpan):
         "parent_span_id",
         "frames",
         "labels",
+        "sync",
         "_child_durations",
     )
 
@@ -347,6 +360,7 @@ class Span(BaseSpan):
         parent_span_id=None,
         span_subtype=None,
         span_action=None,
+        sync=True,
         start=None,
     ):
         """
@@ -361,6 +375,7 @@ class Span(BaseSpan):
         :param parent_span_id: override of the span ID
         :param span_subtype: sub type of the span, e.g. mysql
         :param span_action: sub type of the span, e.g. query
+        :param sync: indicate if the span was executed synchronously or asynchronously
         :param start: timestamp, mostly useful for testing
         """
         self.start_time = start or _time_func()
@@ -378,6 +393,7 @@ class Span(BaseSpan):
         self.parent = parent
         self.parent_span_id = parent_span_id
         self.frames = None
+        self.sync = sync
         if span_subtype is None and "." in span_type:
             # old style dottet type, let's split it up
             type_bits = span_type.split(".")
@@ -404,6 +420,7 @@ class Span(BaseSpan):
             "type": encoding.keyword_field(self.type),
             "subtype": encoding.keyword_field(self.subtype),
             "action": encoding.keyword_field(self.action),
+            "sync": self.sync,
             "timestamp": int(self.timestamp * 1000000),  # microseconds
             "duration": self.duration * 1000,  # milliseconds
         }

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ markers =
     mysql_connector
     pymysql
     mysqldb
+    aiohttp_client
 
 [isort]
 line_length=120

--- a/tests/instrumentation/asyncio/__init__.py
+++ b/tests/instrumentation/asyncio/__init__.py
@@ -1,6 +1,5 @@
 #  BSD 3-Clause License
 #
-#  Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
 #  Copyright (c) 2019, Elasticsearch BV
 #  All rights reserved.
 #
@@ -27,23 +26,4 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-import sys
-
-__all__ = ("VERSION", "Client")
-
-try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
-except Exception:
-    VERSION = "unknown"
-
-from elasticapm.base import Client
-from elasticapm.conf import setup_logging  # noqa: F401
-from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
-from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
-from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
-
-
-if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/tests/instrumentation/asyncio/base_tests.py
+++ b/tests/instrumentation/asyncio/base_tests.py
@@ -1,6 +1,5 @@
 #  BSD 3-Clause License
 #
-#  Copyright (c) 2012, the Sentry Team, see AUTHORS for more details
 #  Copyright (c) 2019, Elasticsearch BV
 #  All rights reserved.
 #
@@ -27,23 +26,41 @@
 #  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-import sys
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__all__ = ("VERSION", "Client")
+from asyncio import tasks
 
-try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
-except Exception:
-    VERSION = "unknown"
+import pytest
 
-from elasticapm.base import Client
-from elasticapm.conf import setup_logging  # noqa: F401
-from elasticapm.instrumentation.control import instrument, uninstrument  # noqa: F401
-from elasticapm.traces import capture_span, set_context, set_custom_context  # noqa: F401
-from elasticapm.traces import set_transaction_name, set_user_context, tag, label  # noqa: F401
-from elasticapm.traces import set_transaction_result  # noqa: F401
-from elasticapm.traces import get_transaction_id, get_trace_id, get_span_id  # noqa: F401
+import elasticapm
+from elasticapm.conf import constants
+
+pytestmark = [pytest.mark.asyncio]
 
 
-if sys.version_info >= (3, 5):
-    from elasticapm.contrib.asyncio.traces import async_capture_span  # noqa: F401
+async def test_async_capture_span(elasticapm_client):
+    @elasticapm.async_capture_span()
+    async def do_some_work():
+        async with elasticapm.async_capture_span("more-work"):
+            await tasks.sleep(0.1)
+
+    elasticapm_client.begin_transaction("test")
+    await do_some_work()
+    elasticapm_client.end_transaction("test", "OK")
+    transaction = elasticapm_client.events[constants.TRANSACTION][0]
+    spans = elasticapm_client.spans_for_transaction(transaction)
+    assert len(spans) == 3
+    sleep, c, d = spans
+    assert sleep["subtype"] == "sleep"
+    assert not sleep["sync"]
+    assert sleep["transaction_id"] == transaction["id"]
+
+    assert c["type"] == "code"
+    assert c["subtype"] == "custom"
+    assert not c["sync"]
+    assert c["transaction_id"] == transaction["id"]
+
+    assert d["type"] == "code"
+    assert d["subtype"] == "custom"
+    assert not d["sync"]
+    assert d["transaction_id"] == transaction["id"]

--- a/tests/instrumentation/asyncio/base_tests.py
+++ b/tests/instrumentation/asyncio/base_tests.py
@@ -38,7 +38,7 @@ from elasticapm.conf import constants
 pytestmark = [pytest.mark.asyncio]
 
 
-async def test_async_capture_span(elasticapm_client):
+async def test_async_capture_span(instrument, elasticapm_client):
     @elasticapm.async_capture_span()
     async def do_some_work():
         async with elasticapm.async_capture_span("more-work"):


### PR DESCRIPTION
## What does this pull request do?

It adds a new API, `async_capture_span`, which can be used to decorate
coroutines and asynchronous context managers (`async with`).

Additionally, it adds instrumentation for `asyncio.tasks.sleep`.

## Why is it important?

Providing these APIs allows ourselves and our users to instrument
asynchronous applications.

## Related issues

refs #598