### PR TITLE
move django specific stuff in conftest to subdirectory

### DIFF
--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -1,6 +1,7 @@
 # this is a limited list of matrix builds to be used for PRs
 # see .jenkins_framework_full.yml for a full list
 FRAMEWORK:
+  - none
   - django-1.11
   - django-2.0
   - django-2.2

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -1,6 +1,7 @@
 # This is the full list of matrix builds, to be triggered with a daily build
 # or manually
 FRAMEWORK:
+  - none
   - django-1.8
   - django-1.11
   - django-2.0

--- a/conftest.py
+++ b/conftest.py
@@ -38,7 +38,6 @@ from os.path import abspath, dirname
 try:
     import eventlet
 
-    print("patching eventlet")
     eventlet.monkey_patch()
 except ImportError:
     pass
@@ -57,6 +56,7 @@ sys.path.insert(0, where_am_i)
 
 # don't run tests of dependencies that land in "build" and "src"
 collect_ignore = ["build", "src"]
+
 pytest_plugins = ["tests.fixtures"]
 
 for module, fixtures in {

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ markers =
     boto3: mark a test as test of the boto3 library instrumentation
     elasticsearch: mark a test as elasticsearch test
     gevent
+    eventlet
     celery
     opentracing
     zerorpc

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ markers =
     requests: mark a test as test of the requests library instrumentation
     boto3: mark a test as test of the boto3 library instrumentation
     elasticsearch: mark a test as elasticsearch test
+    django
+    flask
     gevent
     eventlet
     celery

--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -39,7 +39,7 @@ from elasticapm.conf.constants import ERROR, TRANSACTION
 from elasticapm.contrib.celery import register_exception_tracking, register_instrumentation
 from tests.contrib.django.testapp.tasks import failing_task, successful_task
 
-pytestmark = pytest.mark.celery
+pytestmark = [pytest.mark.celery, pytest.mark.django]
 
 
 def test_failing_celery_task(django_elasticapm_client):

--- a/tests/contrib/celery/flask_tests.py
+++ b/tests/contrib/celery/flask_tests.py
@@ -37,7 +37,7 @@ import mock
 
 from elasticapm.conf.constants import ERROR, TRANSACTION
 
-pytestmark = pytest.mark.celery
+pytestmark = [pytest.mark.celery, pytest.mark.flask]
 
 
 def test_task_failure(flask_celery):

--- a/tests/contrib/django/conftest.py
+++ b/tests/contrib/django/conftest.py
@@ -1,0 +1,108 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os.path
+
+from tests.utils.compat import middleware_setting
+
+where_am_i = os.path.dirname(os.path.abspath(__file__))
+
+BASE_TEMPLATE_DIR = os.path.join(where_am_i, "testapp", "templates")
+
+
+def pytest_configure(config):
+    try:
+        from django.conf import settings
+    except ImportError:
+        settings = None
+    if settings is not None and not settings.configured:
+        import django
+
+        settings_dict = dict(
+            SECRET_KEY="42",
+            DATABASES={
+                "default": {
+                    "ENGINE": "django.db.backends.sqlite3",
+                    "NAME": "elasticapm_tests.db",
+                    "TEST_NAME": "elasticapm_tests.db",
+                    "TEST": {"NAME": "elasticapm_tests.db"},
+                }
+            },
+            TEST_DATABASE_NAME="elasticapm_tests.db",
+            INSTALLED_APPS=[
+                "django.contrib.auth",
+                "django.contrib.admin",
+                "django.contrib.sessions",
+                "django.contrib.sites",
+                "django.contrib.redirects",
+                "django.contrib.contenttypes",
+                "elasticapm.contrib.django",
+                "tests.contrib.django.testapp",
+            ],
+            ROOT_URLCONF="tests.contrib.django.testapp.urls",
+            DEBUG=False,
+            SITE_ID=1,
+            BROKER_HOST="localhost",
+            BROKER_PORT=5672,
+            BROKER_USER="guest",
+            BROKER_PASSWORD="guest",
+            BROKER_VHOST="/",
+            CELERY_ALWAYS_EAGER=True,
+            TEMPLATE_DEBUG=False,
+            TEMPLATE_DIRS=[BASE_TEMPLATE_DIR],
+            ALLOWED_HOSTS=["*"],
+            TEMPLATES=[
+                {
+                    "BACKEND": "django.template.backends.django.DjangoTemplates",
+                    "DIRS": [BASE_TEMPLATE_DIR],
+                    "OPTIONS": {
+                        "context_processors": ["django.contrib.auth.context_processors.auth"],
+                        "loaders": ["django.template.loaders.filesystem.Loader"],
+                        "debug": False,
+                    },
+                }
+            ],
+            ELASTIC_APM={
+                "METRICS_INTERVAL": "0ms",
+                "TRANSPORT_CLASS": "tests.fixtures.DummyTransport",
+            },  # avoid autostarting the metrics collector thread
+        )
+        settings_dict.update(
+            **middleware_setting(
+                django.VERSION,
+                [
+                    "django.contrib.sessions.middleware.SessionMiddleware",
+                    "django.contrib.auth.middleware.AuthenticationMiddleware",
+                    "django.contrib.messages.middleware.MessageMiddleware",
+                ],
+            )
+        )
+        settings.configure(**settings_dict)
+        if hasattr(django, "setup"):
+            django.setup()

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -56,7 +56,6 @@ from django.test.utils import override_settings
 
 import mock
 
-from conftest import BASE_TEMPLATE_DIR
 from elasticapm.base import Client
 from elasticapm.conf import constants
 from elasticapm.conf.constants import ERROR, SPAN, TRANSACTION
@@ -66,6 +65,7 @@ from elasticapm.contrib.django.handlers import LoggingHandler
 from elasticapm.contrib.django.middleware.wsgi import ElasticAPM
 from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
+from tests.contrib.django.conftest import BASE_TEMPLATE_DIR
 from tests.contrib.django.testapp.views import IgnoredException, MyException
 from tests.utils.compat import middleware_setting
 

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -85,6 +85,8 @@ except ImportError:
 
     has_with_eager_tasks = False
 
+pytestmark = pytest.mark.django
+
 
 class MockClientHandler(_TestClientHandler):
     def __call__(self, environ, start_response=[]):

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -49,6 +49,8 @@ try:
 except ImportError:
     from urllib2 import urlopen
 
+pytestmark = pytest.mark.flask
+
 
 def test_error_handler(flask_apm_client):
     client = flask_apm_client.app.test_client()

--- a/tests/instrumentation/django_tests/conftest.py
+++ b/tests/instrumentation/django_tests/conftest.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #  BSD 3-Clause License
 #
 #  Copyright (c) 2019, Elasticsearch BV
@@ -30,42 +28,4 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-import importlib
-import sys
-from os.path import abspath, dirname
-
-try:
-    import eventlet
-
-    print("patching eventlet")
-    eventlet.monkey_patch()
-except ImportError:
-    pass
-
-try:
-    from psycopg2cffi import compat
-
-    compat.register()
-except ImportError:
-    pass
-
-where_am_i = dirname(abspath(__file__))
-
-
-sys.path.insert(0, where_am_i)
-
-# don't run tests of dependencies that land in "build" and "src"
-collect_ignore = ["build", "src"]
-pytest_plugins = ["tests.fixtures"]
-
-for module, fixtures in {
-    "django": "tests.contrib.django.fixtures",
-    "flask": "tests.contrib.flask.fixtures",
-    "aiohttp": "aiohttp.pytest_plugin",
-}.items():
-    try:
-        importlib.import_module(module)
-        pytest_plugins.append(fixtures)
-    except ImportError:
-        pass
+from tests.contrib.django.conftest import pytest_configure

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -37,11 +37,10 @@ from os.path import join
 import django
 from django.test.utils import override_settings
 
-import mock
 import pytest
 
-from conftest import BASE_TEMPLATE_DIR
 from elasticapm.conf.constants import TRANSACTION
+from tests.contrib.django.conftest import BASE_TEMPLATE_DIR
 from tests.utils.compat import middleware_setting
 
 try:

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -49,6 +49,7 @@ try:
 except ImportError:
     from django.core.urlresolvers import reverse
 
+pytestmark = pytest.mark.django
 
 # Testing Django 1.8+ backends
 TEMPLATES = (

--- a/tests/requirements/requirements-none.txt
+++ b/tests/requirements/requirements-none.txt
@@ -1,0 +1,1 @@
+-r requirements-base.txt

--- a/tests/scripts/envs/django.sh
+++ b/tests/scripts/envs/django.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m django"

--- a/tests/scripts/envs/flask.sh
+++ b/tests/scripts/envs/flask.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m flask"

--- a/tests/utils/compat_tests.py
+++ b/tests/utils/compat_tests.py
@@ -68,6 +68,7 @@ def test_default_library_paths(version_tuple, python_implementation, system):
         assert compat.get_default_library_patters() == expected
 
 
+@pytest.mark.django
 @pytest.mark.skipif(not has_multivaluedict, reason="Django not installed")
 def test_multivalue_dict():
     d = MultiValueDict()
@@ -77,6 +78,7 @@ def test_multivalue_dict():
     assert d == {"a": ["b", "c"], "b": "d", "e": "f"}
 
 
+@pytest.mark.flask
 @pytest.mark.skipif(not has_multidict, reason="Werkzeug not installed")
 def test_multi_dict():
     d = MultiDict()


### PR DESCRIPTION
also, use fixtures as pytest plugins instead of importing them


## What does this pull request do?

It uses pytest's ability to pick up folder-specific conftests.
This allows us to move django-specific setup to where it belongs.

## Why is it important?

Currently, when running the django/flask matrix builds,
all non-specific tests (as in, anything that doesn't have
any specific marks) also runs. This leads to a lot of repeated
tests.

Ideally, we'd introduce new marks for Django/Flask, and a new
matrix row that only runs non-marked tests.
Having the conftest separate is the first step for this.