### PR TITLE
remove testing for psycopg2 2.5 (released in 2013) and 2.6 (2016)

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -107,19 +107,6 @@ exclude:
     FRAMEWORK: pymongo-3.4
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: pymongo-3.0
-  # psycopg2
-  - PYTHON_VERSION: python-3.7
-    FRAMEWORK: psycopg2-2.5
-  - PYTHON_VERSION: python-3.7
-    FRAMEWORK: psycopg2-2.6
-  - PYTHON_VERSION: python-3.8
-    FRAMEWORK: psycopg2-2.5
-  - PYTHON_VERSION: python-3.8
-    FRAMEWORK: psycopg2-2.6
-  - PYTHON_VERSION: pypy-3
-    FRAMEWORK: psycopg2-2.5
-  - PYTHON_VERSION: pypy-3
-    FRAMEWORK: psycopg2-2.6
   # python-memcached
   - PYTHON_VERSION: python-3.4
     FRAMEWORK: memcached-1.51

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -41,8 +41,7 @@ FRAMEWORK:
   - redis-2.8
   - redis-2.9
   - redis-newest
-  - psycopg2-2.5
-  - psycopg2-2.6
+  - psycopg2-2.7
   - psycopg2-newest
   - pymssql-newest
   - memcached-1.51

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -151,7 +151,7 @@ Collected trace data:
 [[automatic-instrumentation-db-postgres]]
 ==== PostgreSQL
 
-Library: `psycopg2`, `psycopg2-binary` (`>=2.5,<2.8`)
+Library: `psycopg2`, `psycopg2-binary` (`>=2.7`)
 
 Instrumented methods:
 

--- a/tests/requirements/requirements-psycopg2-2.5.txt
+++ b/tests/requirements/requirements-psycopg2-2.5.txt
@@ -1,3 +1,0 @@
-psycopg2>=2.5,<2.6 ; platform_python_implementation == 'CPython'
-psycopg2cffi>=2.5,<2.6 ; platform_python_implementation == 'PyPy'
--r requirements-base.txt

--- a/tests/requirements/requirements-psycopg2-2.6.txt
+++ b/tests/requirements/requirements-psycopg2-2.6.txt
@@ -1,3 +1,0 @@
-psycopg2>=2.6,<2.7 ; platform_python_implementation == 'CPython'
-psycopg2cffi>=2.6,<2.7 ; platform_python_implementation == 'PyPy'
--r requirements-base.txt

--- a/tests/requirements/requirements-psycopg2-2.7.txt
+++ b/tests/requirements/requirements-psycopg2-2.7.txt
@@ -1,0 +1,3 @@
+psycopg2>=2.7,<2.8 ; platform_python_implementation == 'CPython'
+psycopg2cffi>=2.7,<2.8 ; platform_python_implementation == 'PyPy'
+-r requirements-base.txt

--- a/tests/requirements/requirements-psycopg2-newest.txt
+++ b/tests/requirements/requirements-psycopg2-newest.txt
@@ -1,3 +1,3 @@
-psycopg2>=2.7 ; platform_python_implementation == 'CPython'
-psycopg2cffi>=2.7 ; platform_python_implementation == 'PyPy'
+psycopg2 ; platform_python_implementation == 'CPython'
+psycopg2cffi ; platform_python_implementation == 'PyPy'
 -r requirements-base.txt


### PR DESCRIPTION
## What does this pull request do?

Removes old psycopg2 versions from full matrix test builds, and
ensures that both 2.7 and 2.8 are tested.

## Why is it important?

Testing of these versions broke some time between June and now, due
to our Python containers being upgraded to a version that doesn't use
such old postgres client libraries anymore. Continuing to test these
would be exceedingly difficult, and not worth the hassle.