### PR TITLE
fix issues with older versions of aiohttp

### DIFF
--- a/tests/requirements/requirements-aiohttp-3.0.txt
+++ b/tests/requirements/requirements-aiohttp-3.0.txt
@@ -1,2 +1,2 @@
-aiohttp==3.0.0
+aiohttp==3.0.6
 -r requirements-base.txt


### PR DESCRIPTION
## What does this pull request do?

Older 3.x versions than 3.0.6 had some attributes missing in TCPSite.__slots__,
so that's the minimum we can test with.

Resource.canonical has been added in 3.3, so we need to fall back to private
attributes for older versions.