### PR TITLE
[docs] add direct_html flag

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -28,4 +28,4 @@ params="--chunk=1"
 if [ "$PREVIEW" = "1" ]; then
   params="--chunk=1 --open"
 fi
-$docs_dir/build_docs $params --doc "$index" --out "$dest_dir"
+$docs_dir/build_docs --direct_html $params --doc "$index" --out "$dest_dir"


### PR DESCRIPTION
Adds `--direct_html` flag to the doc build script. See https://github.com/elastic/docs/pull/1636 for more info.