### PR TITLE
exclude psycopg2-2.7/python-3.8 due to build issues

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -131,6 +131,9 @@ exclude:
     FRAMEWORK: pymssql-newest
   - PYTHON_VERSION: python-3.8 # currently fails with error on python 3.8 due to cython issues
     FRAMEWORK: pymssql-newest
+  # psycopg2
+  - PYTHON_VERSION: python-3.8 # see https://github.com/psycopg/psycopg2/issues/858
+    FRAMEWORK: psycopg2-2.7
   # pyodbc
   - PYTHON_VERSION: pypy-2
     FRAMEWORK: pyodbc-newest


### PR DESCRIPTION
## What does this pull request do?

Excludes psycopg2-2.7/python-3.8 combination

## Why is it important?

psycopg2 has an incompatibility with Python 3.8. It has been
fixed for psycopg2 2.8, but not for 2.7 and earlier.

See https://github.com/psycopg/psycopg2/issues/858