### PR TITLE
Add git reference repos to CI configuration

### DIFF
--- a/.ci/jobs/apm-agent-python-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-python-linting-mbp.yml
@@ -37,6 +37,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-python.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-python-mbp.yml
+++ b/.ci/jobs/apm-agent-python-mbp.yml
@@ -40,6 +40,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-python.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'

--- a/.ci/jobs/apm-agent-python-nightly-mbp.yml
+++ b/.ci/jobs/apm-agent-python-nightly-mbp.yml
@@ -36,6 +36,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-agent-python.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'


### PR DESCRIPTION
## What does this pull request do?

Adds reference repos.

These correspond to repos and download locations which can be seen in [the Jenkins job which mirrors them](https://apm-ci.elastic.co/job/jenkins-git-fetch-reference/).

## Why is it important?

Makes for more efficient git checkouts.

