### PR TITLE
ci(jenkins): tidy up env variables

### DIFF
--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -3,6 +3,9 @@
 
 pipeline {
   agent { label 'linux && immutable' }
+  environment {
+    HOME = "${env.WORKSPACE}"
+  }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
@@ -20,7 +23,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+          docker.image('python:3.7-stretch').inside(){
             // registry: '' will help to disable the docker login
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -20,11 +20,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          echo 'For debugging purposes in the host'
-          sh 'env | sort'
           docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
-            echo 'For debugging purposes within the docker container.'
-            sh 'env | sort'
             // registry: '' will help to disable the docker login
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -20,7 +20,11 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
+          echo 'For debugging purposes in the host'
+          sh 'env | sort'
           docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+            echo 'For debugging purposes within the docker container.'
+            sh 'env | sort'
             // registry: '' will help to disable the docker login
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -17,14 +17,10 @@ pipeline {
   }
   stages {
     stage('Sanity checks') {
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-      }
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+          docker.image('python:3.7-stretch').inside(){
             // registry: '' will help to disable the docker login
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -20,7 +20,7 @@ pipeline {
       steps {
         script {
           def sha = getGitCommitSha()
-          docker.image('python:3.7-stretch').inside(){
+          docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
             // registry: '' will help to disable the docker login
             preCommit(commit: "${sha}", junit: true, registry: '')
           }

--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -18,6 +18,9 @@ pipeline {
     PIPELINE_LOG_LEVEL='INFO'
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
+    HOME = "${env.WORKSPACE}"
+    PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+    PIP_CACHE = "${env.WORKSPACE}/.cache"
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -35,10 +38,6 @@ pipeline {
   stages {
     stage('Initializing'){
       options { skipDefaultCheckout() }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-      }
       stages {
         stage('Checkout') {
           steps {
@@ -160,9 +159,6 @@ def runScript(Map params = [:]){
   def python = params.python
   def framework = params.framework
   log(level: 'INFO', text: "${label}")
-  env.HOME = "${env.WORKSPACE}"
-  env.PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-  env.PIP_CACHE = "${env.WORKSPACE}/.cache"
   deleteDir()
   sh "mkdir ${env.PIP_CACHE}"
   unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+                docker.image('python:3.7-stretch').inside(){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
                     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,9 @@ pipeline {
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
     OPBEANS_REPO = 'opbeans-python'
+    HOME = "${env.WORKSPACE}"
+    PATH = "${env.WORKSPACE}/.local/bin:${env.WORKSPACE}/bin:${env.PATH}"
+    PIP_CACHE = "${env.WORKSPACE}/.cache"
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -121,10 +124,6 @@ pipeline {
         beforeAgent true
         expression { return params.package_ci }
       }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
-      }
       steps {
         withGithubNotify(context: 'Building packages') {
           deleteDir()
@@ -162,9 +161,6 @@ pipeline {
       agent { label 'metal' }
       options { skipDefaultCheckout() }
       environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.WORKSPACE}/.local/bin:${env.PATH}"
-        PIP_CACHE = "${env.WORKSPACE}/.cache"
         AGENT_WORKDIR = "${env.WORKSPACE}/${env.BUILD_NUMBER}/${env.BASE_DIR}"
         LANG = 'C.UTF-8'
         LC_ALL = "${env.LANG}"
@@ -207,10 +203,6 @@ pipeline {
       options {
         skipDefaultCheckout()
         timeout(time: 12, unit: 'HOURS')
-      }
-      environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/.local/bin"
       }
       when {
         beforeInput true
@@ -366,9 +358,6 @@ def runScript(Map params = [:]){
   def python = params.python
   def framework = params.framework
   log(level: 'INFO', text: "${label}")
-  env.HOME = "${env.WORKSPACE}"
-  env.PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-  env.PIP_CACHE = "${env.WORKSPACE}/.cache"
   deleteDir()
   sh "mkdir ${env.PIP_CACHE}"
   unstash 'source'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside(){
+                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
                     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,9 +46,6 @@ pipeline {
   stages {
     stage('Initializing'){
       options { skipDefaultCheckout() }
-      environment {
-        ELASTIC_DOCS = "${env.WORKSPACE}/elastic/docs"
-      }
       stages {
         /**
         Checkout the code and stash it, to use it on other stages.
@@ -145,11 +142,9 @@ pipeline {
       agent none
       when {
         beforeAgent true
-        allOf {
-          anyOf {
-            environment name: 'GIT_BUILD_CAUSE', value: 'pr'
-            expression { return !params.Run_As_Master_Branch }
-          }
+        anyOf {
+          changeRequest()
+          expression { return !params.Run_As_Master_Branch }
         }
       }
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,6 @@ pipeline {
     stage('Initializing'){
       options { skipDefaultCheckout() }
       environment {
-        HOME = "${env.WORKSPACE}"
-        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         ELASTIC_DOCS = "${env.WORKSPACE}/elastic/docs"
       }
       stages {
@@ -76,7 +74,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               script {
-                docker.image('python:3.7-stretch').inside("-e PATH=${PATH}:${env.WORKSPACE}/bin"){
+                docker.image('python:3.7-stretch').inside(){
                   dir("${BASE_DIR}"){
                     // registry: '' will help to disable the docker login
                     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')


### PR DESCRIPTION
## What does this pull request do?

Tidy up the existing env variables, which are now defined in the preCommit step context or could be defined once and used in several places

## Why is it important?

Simplify the pipeline

## Related issues

https://github.com/elastic/apm-pipeline-library/pull/325