### PR TITLE
use the configured hostname in get_system_info

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -36,7 +36,6 @@ import itertools
 import logging
 import os
 import platform
-import socket
 import sys
 import time
 import warnings
@@ -317,7 +316,7 @@ class Client(object):
 
     def get_system_info(self):
         system_data = {
-            "hostname": keyword_field(socket.gethostname()),
+            "hostname": keyword_field(self.config.hostname),
             "architecture": platform.machine(),
             "platform": platform.system().lower(),
         }

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 
 import os
 import platform
+import socket
 import sys
 import time
 from collections import defaultdict
@@ -79,6 +80,7 @@ def test_system_info(elasticapm_client):
         mocked.return_value = {}
         system_info = elasticapm_client.get_system_info()
     assert {"hostname", "architecture", "platform"} == set(system_info.keys())
+    assert system_info["hostname"] == socket.gethostname()
 
 
 @pytest.mark.parametrize("elasticapm_client", [{"hostname": "my_custom_hostname"}], indirect=True)
@@ -96,14 +98,11 @@ def test_global_labels(elasticapm_client):
 
 def test_docker_kubernetes_system_info(elasticapm_client):
     # mock docker/kubernetes data here to get consistent behavior if test is run in docker
-    with mock.patch("elasticapm.utils.cgroup.get_cgroup_container_metadata") as mock_metadata, mock.patch(
-        "socket.gethostname"
-    ) as mock_gethostname:
+    with mock.patch("elasticapm.utils.cgroup.get_cgroup_container_metadata") as mock_metadata:
         mock_metadata.return_value = {"container": {"id": "123"}, "kubernetes": {"pod": {"uid": "456"}}}
-        mock_gethostname.return_value = "foo"
         system_info = elasticapm_client.get_system_info()
     assert system_info["container"] == {"id": "123"}
-    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": "foo"}}
+    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": socket.gethostname()}}
 
 
 @mock.patch.dict(
@@ -171,7 +170,7 @@ def test_docker_kubernetes_system_info_except_hostname_from_environ():
         mock_gethostname.return_value = "foo"
         system_info = elasticapm_client.get_system_info()
     assert "kubernetes" in system_info
-    assert system_info["kubernetes"] == {"pod": {"name": "foo"}, "namespace": "namespace"}
+    assert system_info["kubernetes"] == {"pod": {"name": socket.gethostname()}, "namespace": "namespace"}
 
 
 def test_config_by_environment():

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -81,6 +81,13 @@ def test_system_info(elasticapm_client):
     assert {"hostname", "architecture", "platform"} == set(system_info.keys())
 
 
+@pytest.mark.parametrize("elasticapm_client", [{"hostname": "my_custom_hostname"}], indirect=True)
+def test_system_info_hostname_configurable(elasticapm_client):
+    # mock docker/kubernetes data here to get consistent behavior if test is run in docker
+    system_info = elasticapm_client.get_system_info()
+    assert system_info["hostname"] == "my_custom_hostname"
+
+
 @pytest.mark.parametrize("elasticapm_client", [{"global_labels": "az=us-east-1,az.rack=8"}], indirect=True)
 def test_global_labels(elasticapm_client):
     data = elasticapm_client._build_metadata()


### PR DESCRIPTION
## What does this pull request do?

We currently ignore the hostname configuration in the
system info collection. That's no good.

Thanks to @esseti for finding the bug and suggesting a fix!

## Related issues

fixes #688