### PR TITLE
ignore errors from flake8-black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 exclude=elasticapm/utils/wrapt,build,src,tests,dist,conftest.py,setup.py
 max-line-length=120
-ignore=E731,W503,E203
+ignore=E731,W503,E203,BLK100


### PR DESCRIPTION
## What does this pull request do?

Adds BLK100 to ignorable errors from flake8. We already run black 
in its own pre-commit hook and on CI, so no need to also have 
flake8/hound run black.