### PR TITLE
Fix test suite when aiohttp is not installed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -59,11 +59,7 @@ collect_ignore = ["build", "src"]
 
 pytest_plugins = ["tests.fixtures"]
 
-for module, fixtures in {
-    "django": "tests.contrib.django.fixtures",
-    "flask": "tests.contrib.flask.fixtures",
-    "aiohttp": "aiohttp.pytest_plugin",
-}.items():
+for module, fixtures in {"django": "tests.contrib.django.fixtures", "flask": "tests.contrib.flask.fixtures"}.items():
     try:
         importlib.import_module(module)
         pytest_plugins.append(fixtures)

--- a/tests/requirements/requirements-aiohttp-3.0.txt
+++ b/tests/requirements/requirements-aiohttp-3.0.txt
@@ -1,2 +1,3 @@
 aiohttp==3.0.6
+pytest-aiohttp
 -r requirements-base.txt

--- a/tests/requirements/requirements-aiohttp-4.0.txt
+++ b/tests/requirements/requirements-aiohttp-4.0.txt
@@ -1,2 +1,3 @@
 aiohttp>=4.0.0a1,<5.0
+pytest-aiohttp
 -r requirements-base.txt

--- a/tests/requirements/requirements-aiohttp-newest.txt
+++ b/tests/requirements/requirements-aiohttp-newest.txt
@@ -1,2 +1,3 @@
 aiohttp
+pytest-aiohttp
 -r requirements-base.txt


### PR DESCRIPTION
## What does this pull request do?

Due to the reference in conftest.py, the test suite would fail if aiohttp were not installed, even if those tests were not targeted. This fixes that issue by instead requiring `pytest-aiohttp`.