### PR TITLE
Fix elasticsearch tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,13 +34,18 @@ This will be the last minor release to support the following versions:
  * Django 1.8, 1.9 and 1.10
  * Flask < 1.0
 
+ In addition, as of this release we no longer support positional args for
+ elasticsearch-py. This is in keeping with the
+ https://elasticsearch-py.readthedocs.io/en/master/api.html#api-documentation[upstream policy]
+ of positional args being unsupported. {pull}697[#697]
+
 [float]
 ===== New Features
 
  * Added support for aiohttp client and server {pull}659[#659]
  * Added support for W3C `traceparent` and `tracestate` headers {pull}660[#660]
  * Added Django 3.0 and Flask 1.1 to the support matrix {pull}667[#667]
- * Added support for aiopg {pull}668[#668] 
+ * Added support for aiopg {pull}668[#668]
  * Use Span ID as parent ID in errors if an error happens inside a span {pull}669[#669]
 
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -6,7 +6,7 @@ The Elastic APM Python Agent comes with support for the following frameworks:
 
  * <<django-support,Django>>
  * <<flask-support,Flask>>
- 
+
 For other frameworks and custom Python code, the agent exposes a set of <<api,APIs>> for integration.
 
 NOTE: The Elastic APM Python agent does currently not support asynchronous frameworks like Twisted or Tornado.
@@ -22,7 +22,7 @@ The following Python versions are supported:
  * 3.5
  * 3.6
  * 3.7
- 
+
 WARNING: Python 2.7 will reach End of Life on January 1, 2020.
 The Elastic APM agent will stop supporting Python 2.7 in the first major version after that date.
 
@@ -37,7 +37,7 @@ We support these Django versions:
  * 2.1
  * 2.2
  * 3.0
- 
+
 For upcoming Django versions, we generally aim to ensure compatibility starting with the first Release Candidate.
 
 NOTE: we currently don't support Django running in ASGI mode.
@@ -80,7 +80,7 @@ Instrumented methods:
 
  * `elasticsearch.connection.http_urllib3.Urllib3HttpConnection.perform_request`
  * `elasticsearch.connection.http_requests.RequestsHttpConnection.perform_request`
- 
+
 Additionally, the instrumentation wraps the following methods of the `Elasticsearch` client class:
 
  * `elasticsearch.client.Elasticsearch.delete_by_query`
@@ -93,6 +93,11 @@ Collected trace data:
  * the query string (if available)
  * the `query` element from the request body (if available)
 
+We recommend using keyword args only with elasticsearch-py, as recommended by
+https://elasticsearch-py.readthedocs.io/en/master/api.html#api-documentation[the elasticsearch-py docs].
+If you are using positional arguments, we will be unable to gather the `query`
+element from the request body.
+
 [float]
 [[automatic-instrumentation-db-sqlite]]
 ==== SQLite
@@ -102,7 +107,7 @@ Instrumented methods:
  * `sqlite3.connect`
  * `sqlite3.dbapi2.connect`
  * `pysqlite2.dbapi2.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -119,7 +124,7 @@ Library: `MySQLdb`
 Instrumented methods:
 
  * `MySQLdb.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -135,7 +140,7 @@ Library: `mysql-connector-python`
 Instrumented methods:
 
  * `mysql.connector.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -151,7 +156,7 @@ Library: `pymysql`
 Instrumented methods:
 
  * `pymysql.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -167,7 +172,7 @@ Library: `psycopg2`, `psycopg2-binary` (`>=2.7`)
 Instrumented methods:
 
  * `psycopg2.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -184,7 +189,7 @@ Instrumented methods:
 
  * `aiopg.cursor.Cursor.execute`
  * `aiopg.cursor.Cursor.callproc`
- 
+
 Collected trace data:
 
  * parametrized SQL query
@@ -198,7 +203,7 @@ Library: `pyodbc`, (`>=4.0`)
 Instrumented methods:
 
  * `pyodbc.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -214,7 +219,7 @@ Library: `pymssql`, (`>=2.1.0`)
 Instrumented methods:
 
  * `pymssql.connect`
- 
+
 The instrumented `connect` method returns a wrapped connection/cursor which instruments the actual `Cursor.execute` calls.
 
 Collected trace data:
@@ -281,7 +286,7 @@ Instrumented methods:
 Collected trace data:
 
     * Redis command name
-    
+
 
 [float]
 [[automatic-instrumentation-db-cassandra]]
@@ -310,7 +315,7 @@ Library: `urllib2` (Python 2) / `urllib.request` (Python 3)
 
 Instrumented methods:
 
- * `urllib2.AbstractHTTPHandler.do_open` / `urllib.request.AbstractHTTPHandler.do_open` 
+ * `urllib2.AbstractHTTPHandler.do_open` / `urllib.request.AbstractHTTPHandler.do_open`
 
 Collected trace data:
 
@@ -331,8 +336,8 @@ Additionally, we instrumented vendored instances of urllib3 in the following lib
 
  * `requests`
  * `botocore`
- 
-Both libraries have "unvendored" urllib3 in more recent versions, we recommend to use the newest versions. 
+
+Both libraries have "unvendored" urllib3 in more recent versions, we recommend to use the newest versions.
 
 Collected trace data:
 
@@ -346,7 +351,7 @@ Collected trace data:
 Instrumented methods:
 
  * `requests.sessions.Session.send`
- 
+
 Collected trace data:
 
  * HTTP method
@@ -366,13 +371,13 @@ Library: `boto3` (`>=1.0`)
 Instrumented methods:
 
  * `botocore.client.BaseClient._make_api_call`
- 
+
 Collected trace data:
 
  * AWS region (e.g. `eu-central-1`)
  * AWS service name (e.g. `s3`)
  * operation name (e.g. `ListBuckets`)
- 
+
 
 
 [float]
@@ -392,7 +397,7 @@ Instrumented methods:
 Collected trace data:
 
  * template name
- 
+
 [float]
 [[automatic-instrumentation-jinja2]]
 ==== Jinja2

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -76,7 +76,8 @@ class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
                 query.append("q=" + params["q"].decode("utf-8", errors="replace"))
             if isinstance(body, dict) and "query" in body:
                 query.append(json.dumps(body["query"], default=compat.text_type))
-            context["db"]["statement"] = "\n\n".join(query)
+            if query:
+                context["db"]["statement"] = "\n\n".join(query)
         elif api_method == "Elasticsearch.update":
             if isinstance(body, dict) and "script" in body:
                 # only get the `script` field from the body

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -97,73 +97,6 @@ class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
 class ElasticsearchInstrumentation(AbstractInstrumentedModule):
     name = "elasticsearch"
 
-    body_positions = {
-        2: {
-            "count_percolate": 3,
-            "create": 2,
-            "field_stats": 1,
-            "mpercolate": 0,
-            "percolate": 3,
-            "put_script": 2,
-            "search_exists": 2,
-            "suggest": 0,
-            "index": 2,
-            "search": 2,
-            "scroll": 1,
-            "search_template": 2,
-            "update_by_query": 2,
-        },
-        5: {
-            "count_percolate": 3,
-            "create": 3,
-            "field_stats": 1,
-            "mpercolate": 0,
-            "percolate": 3,
-            "put_script": 2,
-            "suggest": 0,
-            "index": 2,
-            "search": 2,
-            "scroll": 1,
-            "search_template": 2,
-            "update_by_query": 2,
-        },
-        6: {
-            "create": 3,
-            "put_script": 1,
-            "index": 2,
-            "search": 2,
-            "scroll": 1,
-            "search_template": 2,
-            "update_by_query": 2,
-        },
-        7: {
-            "create": 2,
-            "put_script": 1,
-            "index": 1,
-            "search": 1,
-            "scroll": 0,
-            "search_template": 1,
-            "update_by_query": 1,
-        },
-        "all": {
-            "bulk": 0,
-            "clear_scroll": 1,
-            "count": 2,
-            "delete_by_query": 1,
-            "explain": 3,
-            "field_caps": 1,
-            "mget": 0,
-            "msearch": 0,
-            "msearch_template": 0,
-            "mtermvectors": 2,
-            "put_template": 1,
-            "reindex": 0,
-            "render_search_template": 1,
-            "termvectors": 3,
-            "update": 3,
-        },
-    }
-
     instrument_list = [
         ("elasticsearch.client", "Elasticsearch.delete_by_query"),
         ("elasticsearch.client", "Elasticsearch.search"),
@@ -193,12 +126,9 @@ class ElasticsearchInstrumentation(AbstractInstrumentedModule):
         params = params.copy() if params is not None else {}
 
         cls_name, method_name = method.split(".", 1)
-        body_pos = (
-            self.body_positions["all"].get(method_name) or self.body_positions[self.version].get(method_name) or None
-        )
 
         # store a reference to the non-serialized body so we can use it in the connection layer
-        body = args[body_pos] if (body_pos is not None and len(args) > body_pos) else kwargs.get("body")
+        body = kwargs.get("body")
         params[BODY_REF_NAME] = body
         params[API_METHOD_KEY_NAME] = method
 

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -94,10 +94,8 @@ def test_info(instrument, elasticapm_client, elasticsearch):
 @pytest.mark.integrationtest
 def test_create(instrument, elasticapm_client, elasticsearch):
     elasticapm_client.begin_transaction("test")
-    if ES_VERSION[0] < 5:
-        r1 = elasticsearch.create("tweets", document_type, {"user": "kimchy", "text": "hola"}, 1)
-    elif ES_VERSION[0] < 7:
-        r1 = elasticsearch.create("tweets", document_type, 1, body={"user": "kimchy", "text": "hola"})
+    if ES_VERSION[0] < 7:
+        r1 = elasticsearch.create(index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"})
     else:
         r1 = elasticsearch.create(index="tweets", id=1, body={"user": "kimchy", "text": "hola"})
     r2 = elasticsearch.create(
@@ -128,7 +126,7 @@ def test_index(instrument, elasticapm_client, elasticsearch):
     if ES_VERSION[0] < 7:
         r1 = elasticsearch.index("tweets", document_type, {"user": "kimchy", "text": "hola"})
     else:
-        r1 = elasticsearch.index("tweets", {"user": "kimchy", "text": "hola"})
+        r1 = elasticsearch.index(index="tweets", body={"user": "kimchy", "text": "hola"})
     r2 = elasticsearch.index(
         index="tweets", doc_type=document_type, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
@@ -265,12 +263,9 @@ def test_update_script(instrument, elasticapm_client, elasticsearch):
         index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    if ES_VERSION[0] < 7:
-        r1 = elasticsearch.update("tweets", document_type, 1, {"script": "ctx._source.text = 'adios'"}, refresh=True)
-    else:
-        r1 = elasticsearch.update(
-            index="tweets", id=1, doc_type=document_type, body={"script": "ctx._source.text = 'adios'"}, refresh=True
-        )
+    r1 = elasticsearch.update(
+        index="tweets", id=1, doc_type=document_type, body={"script": "ctx._source.text = 'adios'"}, refresh=True
+    )
     elasticapm_client.end_transaction("test", "OK")
 
     transaction = elasticapm_client.events[TRANSACTION][0]
@@ -295,12 +290,9 @@ def test_update_document(instrument, elasticapm_client, elasticsearch):
         index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    if ES_VERSION[0] < 7:
-        r1 = elasticsearch.update("tweets", document_type, 1, {"doc": {"text": "adios"}}, refresh=True)
-    else:
-        r1 = elasticsearch.update(
-            index="tweets", id=1, doc_type=document_type, body={"doc": {"text": "adios"}}, refresh=True
-        )
+    r1 = elasticsearch.update(
+        index="tweets", id=1, doc_type=document_type, body={"doc": {"text": "adios"}}, refresh=True
+    )
     elasticapm_client.end_transaction("test", "OK")
 
     transaction = elasticapm_client.events[TRANSACTION][0]

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -99,7 +99,7 @@ def test_create(instrument, elasticapm_client, elasticsearch):
     elif ES_VERSION[0] < 7:
         r1 = elasticsearch.create("tweets", document_type, 1, body={"user": "kimchy", "text": "hola"})
     else:
-        r1 = elasticsearch.create("tweets", 1, body={"user": "kimchy", "text": "hola"})
+        r1 = elasticsearch.create(index="tweets", id=1, body={"user": "kimchy", "text": "hola"})
     r2 = elasticsearch.create(
         index="tweets", doc_type=document_type, id=2, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
@@ -179,7 +179,7 @@ def test_exists_source(instrument, elasticapm_client, elasticsearch):
     if ES_VERSION[0] < 7:
         assert elasticsearch.exists_source("tweets", document_type, 1) is True
     else:
-        assert elasticsearch.exists_source("tweets", 1, document_type) is True
+        assert elasticsearch.exists_source(index="tweets", id=1, doc_type=document_type) is True
     assert elasticsearch.exists_source(index="tweets", doc_type=document_type, id=1) is True
     elasticapm_client.end_transaction("test", "OK")
 
@@ -208,7 +208,7 @@ def test_get(instrument, elasticapm_client, elasticsearch):
     if ES_VERSION[0] == 6:
         r1 = elasticsearch.get("tweets", document_type, 1)
     else:
-        r1 = elasticsearch.get("tweets", 1, document_type)
+        r1 = elasticsearch.get(index="tweets", id=1, doc_type=document_type)
     r2 = elasticsearch.get(index="tweets", doc_type=document_type, id=1)
     elasticapm_client.end_transaction("test", "OK")
 
@@ -237,7 +237,7 @@ def test_get_source(instrument, elasticapm_client, elasticsearch):
     if ES_VERSION[0] < 7:
         r1 = elasticsearch.get_source("tweets", document_type, 1)
     else:
-        r1 = elasticsearch.get_source("tweets", 1, document_type)
+        r1 = elasticsearch.get_source(index="tweets", id=1, doc_type=document_type)
     r2 = elasticsearch.get_source(index="tweets", doc_type=document_type, id=1)
     elasticapm_client.end_transaction("test", "OK")
 
@@ -433,7 +433,9 @@ def test_count_querystring(instrument, elasticapm_client, elasticsearch):
     spans = elasticapm_client.spans_for_transaction(transaction)
     assert len(spans) == 1
     span = spans[0]
-    assert span["name"] == "ES GET /tweets/_count"
+    # Starting in 7.5.1, these turned into POST instead of GET. That detail is
+    # unimportant for these tests.
+    assert span["name"] in ("ES GET /tweets/_count", "ES POST /tweets/_count")
     assert span["type"] == "db"
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"


### PR DESCRIPTION
## What does this pull request do?

Fixes elasticsearch tests (failing as of the release of 7.5.1), and removes some brittleness around argument ordering, since that API is dynamically generated and order is not guaranteed.

Also removed our extensive matrix tracking the position of the `body` argument. `elasticsearch-py` [actually doesn't support non-kwarg use of the API](https://elasticsearch-py.readthedocs.io/en/master/api.html#api-documentation), they are only args because there's no way in py2 to have a required kwarg. Made a note in the docs and updated the tests to match.
