### PR TITLE
Update supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,8 +193,6 @@ setup_kwargs = dict(
         "Topic :: Software Development",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Technically we support 3.4 until one more minor version, but
I'm only doing this so that our badge on the README will read
correctly, so jumping the gun a little should be fine.