### PR TITLE
Enable docker image cache in the CI workers

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source /usr/local/bin/bash_standard_lib.sh
+
+grep "-" .ci/.jenkins_python.yml | cut -d'-' -f2- | \
+while read -r version;
+do
+    (retry 2 ./tests/scripts/docker/docker_build.sh "${version}") || echo "Error building ${version} Docker image, we continue"
+done

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,5 +5,8 @@ source /usr/local/bin/bash_standard_lib.sh
 grep "-" .ci/.jenkins_python.yml | cut -d'-' -f2- | \
 while read -r version;
 do
-    (retry 2 ./tests/scripts/docker/docker_build.sh "${version}") || echo "Error building ${version} Docker image, we continue"
+    imageName="apm-agent-python:${version}"
+    registryImageName="docker.elastic.co/observability-ci/${imageName}"
+    (retry 2 docker pull "${registryImageName}")
+    docker tag "${registryImageName}" "${imageName}"
 done

--- a/tests/scripts/docker/docker_build.sh
+++ b/tests/scripts/docker/docker_build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -ex
-
-cd tests
-docker build --pull --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image

--- a/tests/scripts/docker/docker_build.sh
+++ b/tests/scripts/docker/docker_build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -ex
+
+cd tests
+docker build --pull --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -44,7 +44,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-docker build --pull --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+docker build --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e LOCAL_USER_ID=$UID \
   -e PYTHONDONTWRITEBYTECODE=1 -e WEBFRAMEWORK=$2 -e PIP_CACHE=${docker_pip_cache} \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -44,7 +44,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-docker build --force-rm --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+docker build --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e LOCAL_USER_ID=$UID \
   -e PYTHONDONTWRITEBYTECODE=1 -e WEBFRAMEWORK=$2 -e PIP_CACHE=${docker_pip_cache} \


### PR DESCRIPTION
## What does this pull request do?

Use the just built docker images from [pipeline](https://apm-ci.elastic.co/job/apm-shared/job/apm-docker-images-pipeline/) that are already available in the internal docker registry and retag them to use them in the CI pipeline.

## Why is it important?

Speed up the CI overall execution time

## How to test this

```bash
hub checkout pr 701
sh -x .ci/packer_cache.sh
```
_NOTE_: `/usr/local/bin/bash_standard_lib.sh` is required to exist. That particular requirement is already in place for the CI workers.


## Issues

superseed #700