### PR TITLE
Fix missing link in docs

### DIFF
--- a/docs/advanced-topics.asciidoc
+++ b/docs/advanced-topics.asciidoc
@@ -3,6 +3,7 @@
 
 * <<instrumenting-custom-code>>
 * <<sanitizing-data>>
+* <<how-the-agent-works>>
 * <<run-tests-locally>>
 
 include::./custom-instrumentation.asciidoc[Custom Instrumentation]


### PR DESCRIPTION
Happened to notice this missing link. The include was there, but not the link!