### PR TITLE
avoid double instrumentation of callables

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,11 @@ This will be the last minor release to support the following versions:
  * Use Span ID as parent ID in errors if an error happens inside a span {pull}669[#669]
  * Added experimental support for API Key authentication {pull}679[#679]
 
+[float]
+===== Bug fixes
+
+ * introduced workaround to avoid instrumenting twice in rare cases (#708)
+
 
 [[release-notes-5.x]]
 === Python Agent version 5.x

--- a/setup.py
+++ b/setup.py
@@ -195,8 +195,6 @@ setup_kwargs = dict(
         "Topic :: Software Development",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## What does this pull request do?

To achieve this, we use our own FunctionWrapper subclass,
and check if the callable is already of that type.

This only works if we are the only module that wraps the
original function. If other providers are also wrapping
the callable, we might miss it.


## Why is it important?

It might be possible in certain cases that a module
is instrumented twice. 

## Related issues
Fixes #695