### PR TITLE
[docs] Add EOL table to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-Release notes are now available in our documentation at ([elastic.co](https://www.elastic.co/guide/en/apm/agent/python/current/release-notes.html))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,7 @@ If you have commit access, the process is as follows:
 
 1. Update the version in `elasticapm/version.py` according to the scale of the change. (major, minor or patch)
 1. Update `CHANGELOG.asciidoc`. Rename the `Unreleased` section to the correct version (`vX.X.X`), and nest under the appropriate sub-heading, e.g., `Python Agent version 5.x`.
+1. For Majors: Add a new row to the EOL table in `docs/upgrading.asciidoc`. The EOL date is the release date plus 18 months.
 1. Commit changes with message `update CHANGELOG and bump version to X.Y.Z` where `X.Y.Z` is the version in `elasticapm/version.py`
 1. Tag the commit with `git tag -a vX.Y.Z`, for example `git tag -a v1.2.3`.
    Copy the changelog for the release to the tag message, removing any leading `#`.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -7,6 +7,26 @@ Upgrades that involve a major version bump often come with some backwards incomp
 We highly recommend to always pin the version of `elastic-apm` in your `requirements.txt` or `Pipfile`.
 This avoids automatic upgrades to potentially incompatible versions.
 
+[float]
+[[end-of-life-dates]]
+=== End of life dates
+
+We love all our products, but sometimes we must say goodbye to a release so that we can continue moving
+forward on future development and innovation.
+Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
+as well as how long a release is considered still in active development or maintenance.
+The table below is a simplified description of this policy.
+
+[options="header"]
+|====
+|Agent version |EOL Date |Maintained until
+|1.x |2019-06-11 |2.0
+|2.x |2019-08-06 |3.0
+|3.x |2020-01-20 |4.0
+|4.x |2020-05-14 |5.0
+|5.x |2021-02-05 |6.0
+|====
+
 [[upgrading-5.x]]
 === Upgrading to version 5 of the agent
 


### PR DESCRIPTION
## What does this pull request do?

This PR defines end of life and end of maintenance dates for the Python Agent.

## Why is it important?

We love all our products, but sometimes we must say goodbye to a release so that we can continue moving forward on future development and innovation.

## Related issues
For https://github.com/elastic/apm/issues/173.

## Screenshots
<img width="689" alt="Screen Shot 2020-02-13 at 12 59 13 PM" src="https://user-images.githubusercontent.com/5618806/74477998-4f73ba00-4e61-11ea-94b3-56c902707f21.png">

