### PR TITLE
ci: grab Docker containers logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,6 +346,10 @@ class PythonParallelTaskGenerator extends DefaultParallelTaskGenerator {
               basedir: "${steps.env.BASE_DIR}",
               flags: "-e PYTHON_VERSION,WEBFRAMEWORK",
               secret: "${steps.env.CODECOV_SECRET}")
+            steps.archiveArtifacts(
+              allowEmptyArchive: true,
+              artifacts: '**/docker-info/**',
+              defaultExcludes: false)
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,17 +339,22 @@ class PythonParallelTaskGenerator extends DefaultParallelTaskGenerator {
           } finally {
             steps.junit(allowEmptyResults: true,
               keepLongStdio: true,
-              testResults: "**/python-agent-junit.xml,**/target/**/TEST-*.xml")
+              testResults: "**/python-agent-junit.xml,**/target/**/TEST-*.xml"
+            )
             steps.env.PYTHON_VERSION = "${x}"
             steps.env.WEBFRAMEWORK = "${y}"
             steps.codecov(repo: "${steps.env.REPO}",
               basedir: "${steps.env.BASE_DIR}",
               flags: "-e PYTHON_VERSION,WEBFRAMEWORK",
-              secret: "${steps.env.CODECOV_SECRET}")
-            steps.archiveArtifacts(
-              allowEmptyArchive: true,
-              artifacts: '**/docker-info/**',
-              defaultExcludes: false)
+              secret: "${steps.env.CODECOV_SECRET}"
+            )
+            dir("${steps.env.BASE_DIR}/tests"){
+              steps.archiveArtifacts(
+                allowEmptyArchive: true,
+                artifacts: '**/docker-info/**',
+                defaultExcludes: false
+              )
+            }
           }
         }
       }

--- a/tests/scripts/docker/docker-get-logs.sh
+++ b/tests/scripts/docker/docker-get-logs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STEP=${1:-""}
+
+DOCKER_INFO_DIR="docker-info/${STEP}"
+mkdir -p ${DOCKER_INFO_DIR}
+cp docker-compose.yml ${DOCKER_INFO_DIR}
+cd ${DOCKER_INFO_DIR}
+
+docker ps -a &> docker-containers.txt
+
+DOCKER_IDS=$(docker ps -aq)
+
+for id in ${DOCKER_IDS}
+do
+  docker ps -af id=${id} --no-trunc &> ${id}-cmd.txt
+  docker logs ${id} &> ${id}.log || echo "It is not possible to grab the logs of ${id}"
+  docker inspect ${id} &> ${id}-inspect.json || echo "It is not possible to grab the inspect of ${id}"
+done

--- a/tests/scripts/docker/docker-summary.sh
+++ b/tests/scripts/docker/docker-summary.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER_IDS=$(docker ps -aq)
+
+for id in ${DOCKER_IDS}
+do
+  echo "***********************************************************"
+  echo "***************Docker Container ${id}***************"
+  echo "***********************************************************"
+  docker ps -af id=${id} --no-trunc
+  echo "----"
+  docker logs ${id} | tail -n 10 || echo "It is not possible to grab the logs of ${id}"
+done
+
+echo "*******************************************************"
+echo "***************Docker Containers Summary***************"
+echo "*******************************************************"
+docker ps -a

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -4,7 +4,7 @@ set -ex
 function cleanup {
     if [ -n "${BUILD_NUMBER}" ]; then # only on CI
         ./scripts/docker/docker-summary.sh
-        STEP="${1}-${2}" ./scripts/docker/docker-get-logs.sh
+        ./scripts/docker/docker-get-logs.sh "${1}-${2}"
     fi
     PYTHON_VERSION=${1} docker-compose down -v
 

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -2,6 +2,10 @@
 set -ex
 
 function cleanup {
+    if [ -n "${BUILD_NUMBER}" ]; then # only on CI
+        ./scripts/docker/docker-summary.sh
+        STEP="${1}-${2}" ./scripts/docker/docker-get-logs.sh
+    fi
     PYTHON_VERSION=${1} docker-compose down -v
 
     if [[ $CODECOV_TOKEN ]]; then


### PR DESCRIPTION
## What does this pull request do?

It grabs the Docker containers logs before to destroy the containers.

## Why is it important?

In order to diagnose some issues sometimes, we need the Docker container logs.

## Related issues
related to https://github.com/elastic/apm-agent-python/issues/718
