### PR TITLE
use %r instead of %d to log PID change

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -207,7 +207,7 @@ class Client(object):
         with self._thread_starter_lock:
             current_pid = os.getpid()
             if self._pid != current_pid:
-                self.logger.debug("Detected PID change from %d to %d, starting threads", self._pid, current_pid)
+                self.logger.debug("Detected PID change from %r to %r, starting threads", self._pid, current_pid)
                 for manager_type, manager in self._thread_managers.items():
                     self.logger.debug("Starting %s thread", manager_type)
                     manager.start_thread()


### PR DESCRIPTION
turns out PID is set to None in the beginning,
leading to a crash when logging this message.