### PR TITLE
during the threading refactor, this call went forgotten

### DIFF
--- a/elasticapm/contrib/celery/__init__.py
+++ b/elasticapm/contrib/celery/__init__.py
@@ -76,14 +76,10 @@ def register_instrumentation(client):
 
 
 def _register_worker_signals(client):
-    def worker_startup(*args, **kwargs):
-        client._transport._start_event_processor()
-
     def worker_shutdown(*args, **kwargs):
         client.close()
 
     def connect_worker_process_init(*args, **kwargs):
-        signals.worker_process_init.connect(worker_startup, dispatch_uid="elasticapm-start-worker", weak=False)
         signals.worker_process_shutdown.connect(worker_shutdown, dispatch_uid="elasticapm-shutdown-worker", weak=False)
 
     signals.worker_init.connect(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -233,7 +233,10 @@ class DummyTransport(HTTPTransportBase):
         self.events[event_type].append(data)
         self._flushed.set()
 
-    def _start_event_processor(self):
+    def start_thread(self):
+        pass
+
+    def stop_thread(self):
         pass
 
     def get_config(self, current_version=None, keys=None):


### PR DESCRIPTION
## What does this pull request do?

Removes a now invalid method call

## Why is it important?

Because we shouldn't break celery :)

## Related issues

closes #723