### PR TITLE
Add psutil to pypy-2 exclusions

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -258,3 +258,6 @@ exclude:
     FRAMEWORK: aiopg-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aiopg-newest
+  # psutil
+  - PYTHON_VERSION: pypy-2  #currently fails on pypy2 (https://github.com/giampaolo/psutil/issues/1659)
+    FRAMEWORK: psutil-newest


### PR DESCRIPTION
This was causing test failures due to psutil 5.7.0 being released.

See https://github.com/giampaolo/psutil/issues/1659

We can remove this exclusion once the next version of pypy2 is released.