### PR TITLE
ci(jenkins): use the cloud benchmark cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -276,7 +276,7 @@ pipeline {
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
           catchError(buildResult: 'SUCCESS') {
             def datafile = readFile(file: "results.json")
-            def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
+            def json = getVaultSecret(secret: env.BENCHMARK_SECRET)
             sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
           }
         }


### PR DESCRIPTION
## What does this pull request do?

Replace credentials


## Why is it important?

No more credentials to the old cluster

## Related issues
closes #ISSUE