### PR TITLE
ci(jenkins): install python3 for the given VERSION

### DIFF
--- a/scripts/install-python.ps1
+++ b/scripts/install-python.ps1
@@ -1,0 +1,9 @@
+# Abort with non zero exit code on errors
+$ErrorActionPreference = "Stop"
+
+Write-Host("Getting latest Python3 version for {0} ..." -f $env:VERSION)
+& choco list python3 --exact --by-id-only --all | Select-String -Pattern "python3 $env:VERSION"
+$Version = $(choco list python3 --exact --by-id-only --all) | Select-String -Pattern "python3 $env:VERSION" | %{$_.ToString().split(" ")[1]} | sort | Select-Object -Last 1
+
+Write-Host("Installing Python3 {0} ..." -f $Version)
+& choco install python3 --no-progress -y --version "$Version"


### PR DESCRIPTION
## What does this pull request do?

Install python with the version that's the same that the given VERSION or the closest one. Therefore the VERSION format could be:
- fully
- major
- major.minor
- semver...

## Why is it important?

It will help to install python3 in windows just given the major.minor version rather than the major.minor.patch version

## Related issues

Caused by https://github.com/elastic/apm-agent-python/pull/726

## Tests

```powershell
$Env:VERSION = "3.8"
.\install-python.ps1
```

![image](https://user-images.githubusercontent.com/2871786/74919151-163bcc80-53c2-11ea-9b52-835a09777d35.png)
