### PR TITLE
pypy2/psutil also breaks for older versions of psutil, let's exclude them too

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -258,6 +258,10 @@ exclude:
     FRAMEWORK: aiopg-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aiopg-newest
-  # psutil
-  - PYTHON_VERSION: pypy-2  #currently fails on pypy2 (https://github.com/giampaolo/psutil/issues/1659)
+  # psutil currently fails on pypy2 (https://github.com/giampaolo/psutil/issues/1659)
+  - PYTHON_VERSION: pypy-2
     FRAMEWORK: psutil-newest
+  - PYTHON_VERSION: pypy-2
+    FRAMEWORK: psutil-4.0
+  - PYTHON_VERSION: pypy-2
+    FRAMEWORK: psutil-5.0


### PR DESCRIPTION
## What does this pull request do?

Excludes older psutil versions on pypy2

## Why is it important?

Because it breaks the full matrix test run