### PR TITLE
fix psutil requirements files to have upper limits

### DIFF
--- a/tests/requirements/requirements-psutil-4.0.txt
+++ b/tests/requirements/requirements-psutil-4.0.txt
@@ -1,2 +1,2 @@
-psutil >= 4.0.0
+psutil>=4.0.0,<5.0
 -r requirements-base.txt

--- a/tests/requirements/requirements-psutil-5.0.txt
+++ b/tests/requirements/requirements-psutil-5.0.txt
@@ -1,2 +1,2 @@
-psutil >= 5.0.0
+psutil>=5.0.0,<6.0
 -r requirements-base.txt


### PR DESCRIPTION
## What does this pull request do?

Previously, due to no upper constraint, all 3 psutil matrix builds
ran using the newest version, which kinda defeats the purpose of
matrix tests.