### PR TITLE
Fix aiohttp client

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
@@ -44,6 +44,7 @@ class AioHttpClientInstrumentation(AsyncAbstractInstrumentedModule):
     async def call(self, module, method, wrapped, instance, args, kwargs):
         method = kwargs["method"] if "method" in kwargs else args[0]
         url = kwargs["url"] if "url" in kwargs else args[1]
+        url = str(url)
 
         signature = " ".join([method.upper(), get_host_from_url(url)])
         url = sanitize_url(url)

--- a/tests/instrumentation/asyncio/aiohttp_client_tests.py
+++ b/tests/instrumentation/asyncio/aiohttp_client_tests.py
@@ -31,6 +31,7 @@
 import pytest  # isort:skip
 
 aiohttp = pytest.importorskip("aiohttp")  # isort:skip
+yarl = pytest.importorskip("yarl")  # isort:skip
 
 from elasticapm.conf import constants
 from elasticapm.utils.disttracing import TraceParent
@@ -38,9 +39,13 @@ from elasticapm.utils.disttracing import TraceParent
 pytestmark = [pytest.mark.asyncio, pytest.mark.aiohttp]
 
 
-async def test_http_get(instrument, event_loop, elasticapm_client, waiting_httpserver):
+@pytest.mark.parametrize("use_yarl", [True, False])
+async def test_http_get(instrument, event_loop, elasticapm_client, waiting_httpserver, use_yarl):
     assert event_loop.is_running()
     elasticapm_client.begin_transaction("test")
+
+    url = waiting_httpserver.url
+    url = yarl.URL(url) if use_yarl else url
 
     async with aiohttp.ClientSession() as session:
         async with session.get(waiting_httpserver.url) as resp:


### PR DESCRIPTION
Fix for broken `aiohttp.client` tracker.

`url` may be not a string:
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py#L1083
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/typedefs.py#L45