### PR TITLE
Disable codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,42 +2,42 @@
 # Docs can be found here: https://docs.codecov.io/v4.3.0/docs/commit-status
 coverage:
   status:
-    project:
-      tests:
-        target: 97%
-        paths: "tests/"
-        base: auto
-        branches: null
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: error
-        only_pulls: false
-        flags: null
-      agent:
-        target: auto
-        # Overall coverage should never drop more then 0.5%
-        threshold: 0.5
-        paths: "elasticapm/"
-        base: auto
-        branches: null
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: error
-        only_pulls: false
-        flags: null
-    patch:
-      default:
-        target: auto
-        # Allows PRs without tests, overall stats count
-        threshold: 100
-        base: auto
-        branches: null
-        if_no_uploads: error
-        if_not_found: success
-        if_ci_failed: error
-        only_pulls: false
-        flags: null
-        paths: null
+    project: off
+      # tests:
+      #   target: 97%
+      #   paths: "tests/"
+      #   base: auto
+      #   branches: null
+      #   if_no_uploads: error
+      #   if_not_found: success
+      #   if_ci_failed: error
+      #   only_pulls: false
+      #   flags: null
+      # agent:
+      #   target: auto
+      #   # Overall coverage should never drop more then 0.5%
+      #   threshold: 0.5
+      #   paths: "elasticapm/"
+      #   base: auto
+      #   branches: null
+      #   if_no_uploads: error
+      #   if_not_found: success
+      #   if_ci_failed: error
+      #   only_pulls: false
+      #   flags: null
+    patch: off
+      # default:
+      #   target: auto
+      #   # Allows PRs without tests, overall stats count
+      #   threshold: 100
+      #   base: auto
+      #   branches: null
+      #   if_no_uploads: error
+      #   if_not_found: success
+      #   if_ci_failed: error
+      #   only_pulls: false
+      #   flags: null
+      #   paths: null
 
 # Disable comments on Pull Requests
 comment: false


### PR DESCRIPTION
## What does this pull request do?

The CodeCov stats have been broken, throwing false negatives, for
months. Let's disable them until we can figure out how to make them
accurate/useful.