### PR TITLE
ci(jenkins): send downstream build data to ES is not required anymore

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -274,11 +274,6 @@ pipeline {
           def processor = new ResultsProcessor()
           processor.processResults(mapResults)
           archiveArtifacts allowEmptyArchive: true, artifacts: 'results.json,results.html', defaultExcludes: false
-          catchError(buildResult: 'SUCCESS') {
-            def datafile = readFile(file: "results.json")
-            def json = getVaultSecret(secret: 'secret/apm-team/ci/apm-server-benchmark-cloud')
-            sendDataToElasticsearch(es: json.data.url, data: datafile, restCall: '/jenkins-builds-test-results/_doc/')
-          }
         }
       }
       notifyBuildResult()


### PR DESCRIPTION
## What does this pull request do?

Get rid of the sendData to ES for the downstream jobs.

## Why is it important?

We have changed our process to send data to ES, and the legacy approach is now deprecated.

## Related issues
closes #ISSUE