### PR TITLE
ci(jenkins): fix benchmark PATH variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,6 +174,7 @@ pipeline {
         AGENT_WORKDIR = "${env.WORKSPACE}/${env.BUILD_NUMBER}/${env.BASE_DIR}"
         LANG = 'C.UTF-8'
         LC_ALL = "${env.LANG}"
+        PATH = "${env.WORKSPACE}/.local/bin:${env.WORKSPACE}/bin:${env.PATH}"
       }
       when {
         beforeAgent true


### PR DESCRIPTION
## What does this pull request do?

Enable PATH for the benchmarking stage

## Why is it important?

Caused by https://github.com/elastic/apm-agent-python/commit/57f5dec04736e9a0bd7615253f82f54ce9005cf0#diff-58231b16fdee45a03a4ee3cf94a9f2c3L27

## Related issues
closes #ISSUE