### PR TITLE
chore: rename parent stage Release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,7 +210,7 @@ pipeline {
         }
       }
     }
-    stage('Release') {
+    stage('Prepare Release') {
       options {
         skipDefaultCheckout()
         timeout(time: 12, unit: 'HOURS')


### PR DESCRIPTION
## What does this pull request do?

It changes the name of the parent stage Release to Prepare Release.

## Why is it important?

It is a cosmetic change to avoid confusion.
