### PR TITLE
ci(jenkins): run full test matrix on a PR basis if comment

### DIFF
--- a/.ci/jobs/apm-agent-python-nightly-mbp.yml
+++ b/.ci/jobs/apm-agent-python-nightly-mbp.yml
@@ -24,6 +24,9 @@
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:
         - regular-branches: true
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
         clean:
           after: true
           before: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:full\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -103,11 +103,16 @@ pipeline {
           unstash "source"
           dir("${BASE_DIR}"){
             script {
+              // To enable the full test matrix upon GitHub PR comments
+              def frameworkFile = '.ci/.jenkins_framework.yml'
+              if (env.GITHUB_COMMENT?.contains('full test')) {
+                frameworkFile = '.ci/.jenkins_framework_full.yml'
+              }
               pythonTasksGen = new PythonParallelTaskGenerator(
                 xKey: 'PYTHON_VERSION',
                 yKey: 'FRAMEWORK',
                 xFile: ".ci/.jenkins_python.yml",
-                yFile: ".ci/.jenkins_framework.yml",
+                yFile: frameworkFile,
                 exclusionFile: ".ci/.jenkins_exclude.yml",
                 tag: "Python",
                 name: "Python",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,8 @@ pipeline {
             script {
               // To enable the full test matrix upon GitHub PR comments
               def frameworkFile = '.ci/.jenkins_framework.yml'
-              if (env.GITHUB_COMMENT?.contains('full test')) {
+              if (env.GITHUB_COMMENT?.contains('full tests')) {
+                log(level: 'INFO', text: 'Full test matrix has been enabled.')
                 frameworkFile = '.ci/.jenkins_framework_full.yml'
               }
               pythonTasksGen = new PythonParallelTaskGenerator(


### PR DESCRIPTION
## What does this pull request do?

- Run nightly builds on a nightly basis.
- Enable full test matrix if comment `jenkins run the full tests`

## Related issues
closes #ISSUE

## Tests

https://github.com/elastic/apm-agent-python/pull/767#issuecomment-601808655 caused [build #3](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-767/3/pipeline)

![image](https://user-images.githubusercontent.com/2871786/77187733-d7865880-6acc-11ea-8e55-be926b79b88e.png)

