### PR TITLE
temporarily disable building packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,8 @@ pipeline {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks.')
     booleanParam(name: 'tests_ci', defaultValue: true, description: 'Enable tests.')
-    booleanParam(name: 'package_ci', defaultValue: true, description: 'Enable building packages.')
+    // temporarily disable building packages until https://github.com/pypa/manylinux/issues/512 is fixed
+    booleanParam(name: 'package_ci', defaultValue: false, description: 'Enable building packages.')
   }
   stages {
     stage('Initializing'){


### PR DESCRIPTION
building packages currently fails due to https://github.com/pypa/manylinux/issues/512
