### PR TITLE
Remote config options for 7.7

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -10,7 +10,7 @@ You can either configure the agent by setting environment variables:
 ELASTIC_APM_SERVICE_NAME=foo python manage.py runserver
 ----
 
-or with inline configuration: 
+or with inline configuration:
 
 [source,python]
 ----
@@ -481,7 +481,7 @@ this setting has to be provided in *<<config-format-duration, duration format>>*
 
 |============
 | Environment                    | Django/Flask       | Default
-| `ELASTIC_APM_API_REQUEST_SIZE` | `API_REQUEST_SIZE` | `"724kb"`
+| `ELASTIC_APM_API_REQUEST_SIZE` | `API_REQUEST_SIZE` | `"768kb"`
 |============
 
 Maximum queue length of the request buffer before sending the request to the APM Server.
@@ -692,7 +692,7 @@ NOTE: this setting only disables the *sending* of the given metrics, not collect
 |============
 
 Enable/disable the tracking and collection of breakdown metrics.
-By setting this to `False`, tracking this metric is completely disabled, which can reduce the overhead of the agent. 
+By setting this to `False`, tracking this metric is completely disabled, which can reduce the overhead of the agent.
 
 NOTE: This feature requires APM Server and Kibana >= 7.3.
 
@@ -824,12 +824,12 @@ The unit is provided as suffix directly after the number, without and separation
 
 *Example*: `5ms`
 
-*Supported units* 
+*Supported units*
 
  * `ms` (milliseconds)
  * `s` (seconds)
  * `m` (minutes)
- 
+
 [float]
 [[config-format-size]]
 ==== Size format

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -137,8 +137,6 @@ class Client(object):
             "verify_server_cert": self.config.verify_server_cert,
             "server_cert": self.config.server_cert,
             "timeout": self.config.server_timeout,
-            "max_flush_time": self.config.api_request_time / 1000.0,
-            "max_buffer_size": self.config.api_request_size,
             "processors": self.load_processors(),
         }
         self._api_endpoint_url = compat.urlparse.urljoin(

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -301,7 +301,7 @@ class Config(_ConfigBase):
     breakdown_metrics = _BoolConfigValue("BREAKDOWN_METRICS", default=True)
     disable_metrics = _ListConfigValue("DISABLE_METRICS", type=starmatch_to_regex, default=[])
     central_config = _BoolConfigValue("CENTRAL_CONFIG", default=True)
-    api_request_size = _ConfigValue("API_REQUEST_SIZE", type=int, validators=[size_validator], default=750 * 1024)
+    api_request_size = _ConfigValue("API_REQUEST_SIZE", type=int, validators=[size_validator], default=768 * 1024)
     api_request_time = _ConfigValue("API_REQUEST_TIME", type=int, validators=[duration_validator], default=10 * 1000)
     transaction_sample_rate = _ConfigValue("TRANSACTION_SAMPLE_RATE", type=float, default=1.0)
     transaction_max_spans = _ConfigValue("TRANSACTION_MAX_SPANS", type=int, default=500)

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -505,11 +505,13 @@ class Tracer(object):
         self.frames_collector_func = frames_collector_func
         self._agent = agent
         self._ignore_patterns = [re.compile(p) for p in config.transactions_ignore_patterns or []]
-        if config.span_frames_min_duration in (-1, None):
-            # both None and -1 mean "no minimum"
-            self.span_frames_min_duration = None
+
+    @property
+    def span_frames_min_duration(self):
+        if self.config.span_frames_min_duration in (-1, None):
+            return None
         else:
-            self.span_frames_min_duration = config.span_frames_min_duration / 1000.0
+            return self.config.span_frames_min_duration / 1000.0
 
     def begin_transaction(self, transaction_type, trace_parent=None, start=None):
         """

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -478,6 +478,38 @@ def test_transaction_sampling(elasticapm_client, not_so_random):
         assert transaction["sampled"] or not "context" in transaction
 
 
+def test_transaction_sample_rate_dynamic(elasticapm_client, not_so_random):
+    elasticapm_client.config.update(version="1", transaction_sample_rate=0.4)
+    for i in range(10):
+        elasticapm_client.begin_transaction("test_type")
+        with elasticapm.capture_span("xyz"):
+            pass
+        elasticapm_client.end_transaction("test")
+
+    transactions = elasticapm_client.events[TRANSACTION]
+    spans_per_transaction = defaultdict(list)
+    for span in elasticapm_client.events[SPAN]:
+        spans_per_transaction[span["transaction_id"]].append(span)
+
+    # seed is fixed by not_so_random fixture
+    assert len([t for t in transactions if t["sampled"]]) == 3
+    for transaction in transactions:
+        assert transaction["sampled"] or not transaction["id"] in spans_per_transaction
+        assert transaction["sampled"] or not "context" in transaction
+
+    elasticapm_client.config.update(version="1", transaction_sample_rate=1.0)
+    for i in range(5):
+        elasticapm_client.begin_transaction("test_type")
+        with elasticapm.capture_span("xyz"):
+            pass
+        elasticapm_client.end_transaction("test")
+
+    transactions = elasticapm_client.events[TRANSACTION]
+
+    # seed is fixed by not_so_random fixture
+    assert len([t for t in transactions if t["sampled"]]) == 8
+
+
 @pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 5}], indirect=True)
 def test_transaction_max_spans(elasticapm_client):
     elasticapm_client.begin_transaction("test_type")

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -84,8 +84,9 @@ def test_transport_state_set_success():
 
 
 @mock.patch("elasticapm.transport.base.Transport.send")
-def test_empty_queue_flush_is_not_sent(mock_send):
-    transport = Transport(client=None, metadata={"x": "y"}, max_flush_time=5)
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_time": "5s"}], indirect=True)
+def test_empty_queue_flush_is_not_sent(mock_send, elasticapm_client):
+    transport = Transport(client=elasticapm_client, metadata={"x": "y"})
     try:
         transport.start_thread()
         transport.flush()
@@ -95,8 +96,9 @@ def test_empty_queue_flush_is_not_sent(mock_send):
 
 
 @mock.patch("elasticapm.transport.base.Transport.send")
-def test_metadata_prepended(mock_send):
-    transport = Transport(client=None, metadata={"x": "y"}, max_flush_time=5, compress_level=0)
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_time": "5s"}], indirect=True)
+def test_metadata_prepended(mock_send, elasticapm_client):
+    transport = Transport(client=elasticapm_client, metadata={"x": "y"}, compress_level=0)
     transport.start_thread()
     transport.queue("error", {}, flush=True)
     transport.close()
@@ -111,9 +113,33 @@ def test_metadata_prepended(mock_send):
 
 
 @mock.patch("elasticapm.transport.base.Transport.send")
-def test_flush_time(mock_send, caplog):
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_time": "100ms"}], indirect=True)
+def test_flush_time(mock_send, caplog, elasticapm_client):
     with caplog.at_level("DEBUG", "elasticapm.transport"):
-        transport = Transport(client=None, metadata={}, max_flush_time=0.1)
+        transport = Transport(client=elasticapm_client, metadata={})
+        transport.start_thread()
+        # let first run finish
+        time.sleep(0.2)
+        transport.close()
+    record = caplog.records[0]
+    assert "due to time since last flush" in record.message
+    assert mock_send.call_count == 0
+
+
+@mock.patch("elasticapm.transport.base.Transport.send")
+def test_api_request_time_dynamic(mock_send, caplog, elasticapm_client):
+    elasticapm_client.config.update(version="1", api_request_time="1s")
+    with caplog.at_level("DEBUG", "elasticapm.transport"):
+        transport = Transport(client=elasticapm_client, metadata={})
+        transport.start_thread()
+        # let first run finish
+        time.sleep(0.2)
+        transport.close()
+    assert not caplog.records
+    assert mock_send.call_count == 0
+    elasticapm_client.config.update(version="1", api_request_time="100ms")
+    with caplog.at_level("DEBUG", "elasticapm.transport"):
+        transport = Transport(client=elasticapm_client, metadata={})
         transport.start_thread()
         # let first run finish
         time.sleep(0.2)
@@ -124,8 +150,33 @@ def test_flush_time(mock_send, caplog):
 
 
 @mock.patch("elasticapm.transport.base.Transport._flush")
-def test_flush_time_size(mock_flush, caplog):
-    transport = Transport(client=None, metadata={}, max_buffer_size=100, queue_chill_count=1)
+def test_api_request_size_dynamic(mock_flush, caplog, elasticapm_client):
+    elasticapm_client.config.update(version="1", api_request_size="100b")
+    transport = Transport(client=elasticapm_client, metadata={}, queue_chill_count=1)
+    transport.start_thread()
+    try:
+        with caplog.at_level("DEBUG", "elasticapm.transport"):
+            # we need to add lots of uncompressible data to fill up the gzip-internal buffer
+            for i in range(12):
+                transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
+            transport._flushed.wait(timeout=0.1)
+        assert mock_flush.call_count == 1
+        elasticapm_client.config.update(version="1", api_request_size="1mb")
+        with caplog.at_level("DEBUG", "elasticapm.transport"):
+            # we need to add lots of uncompressible data to fill up the gzip-internal buffer
+            for i in range(12):
+                transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
+            transport._flushed.wait(timeout=0.1)
+        # Should be unchanged because our buffer limit is much higher.
+        assert mock_flush.call_count == 1
+    finally:
+        transport.close()
+
+
+@mock.patch("elasticapm.transport.base.Transport._flush")
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_size": "100b"}], indirect=True)
+def test_flush_time_size(mock_flush, caplog, elasticapm_client):
+    transport = Transport(client=elasticapm_client, metadata={}, queue_chill_count=1)
     transport.start_thread()
     try:
         with caplog.at_level("DEBUG", "elasticapm.transport"):
@@ -139,8 +190,9 @@ def test_flush_time_size(mock_flush, caplog):
 
 
 @mock.patch("elasticapm.transport.base.Transport.send")
-def test_forced_flush(mock_send, caplog):
-    transport = Transport(client=None, metadata={}, max_buffer_size=1000, compress_level=0)
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_size": "1000b"}], indirect=True)
+def test_forced_flush(mock_send, caplog, elasticapm_client):
+    transport = Transport(client=elasticapm_client, metadata={}, compress_level=0)
     transport.start_thread()
     try:
         with caplog.at_level("DEBUG", "elasticapm.transport"):


### PR DESCRIPTION
This PR tests support for the remote config options being added in Kibana for 7.7. (All config options technically support remote config, but we need to test that propagation works properly.)

List:

- [x] `capture_headers`
- [x] `capture_body`
- [x] `api_request_size`
- [x] `api_request_time`
- [x] `span_frames_min_duration`
- [x] `transaction_sample_rate`
- [x] `transaction_max_spans`

I'll be opening a separate PR for `enabled`/`recorded` once I get to those, since they're not as urgent (and will require more work).

## Related issues
Refs https://github.com/elastic/apm/issues/213