### PR TITLE
ci(jenkins): disable stages for only docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,8 +64,8 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
               dir("${BASE_DIR}"){
-                // Skip all the stages except docs for PR's with asciidoc changes only
-                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+                // Skip all the stages except docs for PR's with asciidoc and md changes only
+                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
               }
             }
           }


### PR DESCRIPTION
### What

- Any builds for any branch or PR that only contains changes related to the asciidoc then it will skip all the stages but the `checkout`

### Why

Docs validation happens with the `elasticsearch-ci/docs` therefore there is no need to validate anything in our end.