### PR TITLE
send the correct content-type and no content-encoding for remote config

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -126,6 +126,8 @@ class Transport(HTTPTransportBase):
         url = self._config_url
         data = json_encoder.dumps(keys).encode("utf-8")
         headers = self._headers.copy()
+        headers[b"Content-Type"] = "application/json"
+        headers.pop(b"Content-Encoding", None)  # remove gzip content-encoding header
         headers.update(self.auth_headers)
         max_age = 300
         if current_version:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -150,6 +150,7 @@ def elasticapm_client(request):
     client_config = getattr(request, "param", {})
     client_config.setdefault("service_name", "myapp")
     client_config.setdefault("secret_token", "test_key")
+    client_config.setdefault("central_config", "false")
     client_config.setdefault("include_paths", ("*/tests/*",))
     client_config.setdefault("span_frames_min_duration", -1)
     client_config.setdefault("metrics_interval", "0ms")

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -266,11 +266,18 @@ def test_get_config(waiting_httpserver, elasticapm_client):
         code=200, content=b'{"x": "y"}', headers={"Cache-Control": "max-age=5", "Etag": "2"}
     )
     url = waiting_httpserver.url
-    transport = Transport(url + "/" + constants.EVENTS_API_PATH, client=elasticapm_client)
+    transport = Transport(
+        url + "/" + constants.EVENTS_API_PATH,
+        client=elasticapm_client,
+        headers={"Content-Type": "application/x-ndjson", "Content-Encoding": "gzip"},
+    )
     version, data, max_age = transport.get_config("1", {})
     assert version == "2"
     assert data == {"x": "y"}
     assert max_age == 5
+
+    assert "Content-Encoding" not in waiting_httpserver.requests[0].headers
+    assert waiting_httpserver.requests[0].headers["Content-Type"] == "application/json"
 
 
 @mock.patch("urllib3.poolmanager.PoolManager.urlopen")


### PR DESCRIPTION
## What does this pull request do?

Due to an oversight, we were sending the wrong headers for remote config requests. It doesn't seem to bother apm-server so far, but let's better be on the safe side.
