### PR TITLE
Capture headers body dynamic all frameworks

### DIFF
--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -322,7 +322,11 @@ class Config(_ConfigBase):
     local_var_max_length = _ConfigValue("LOCAL_VAR_MAX_LENGTH", type=int, default=200)
     local_var_list_max_length = _ConfigValue("LOCAL_VAR_LIST_MAX_LENGTH", type=int, default=10)
     local_var_dict_max_length = _ConfigValue("LOCAL_VAR_DICT_MAX_LENGTH", type=int, default=10)
-    capture_body = _ConfigValue("CAPTURE_BODY", default="off")
+    capture_body = _ConfigValue(
+        "CAPTURE_BODY",
+        default="off",
+        validators=[lambda val, _: {"errors": "error", "transactions": "transaction"}.get(val, val)],
+    )
     async_mode = _BoolConfigValue("ASYNC_MODE", default=True)
     instrument_django_middleware = _BoolConfigValue("INSTRUMENT_DJANGO_MIDDLEWARE", default=True)
     autoinsert_django_middleware = _BoolConfigValue("AUTOINSERT_DJANGO_MIDDLEWARE", default=True)

--- a/elasticapm/contrib/aiohttp/middleware.py
+++ b/elasticapm/contrib/aiohttp/middleware.py
@@ -29,9 +29,10 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import aiohttp
-from aiohttp.web import middleware
+from aiohttp.web import Response, middleware
 
 import elasticapm
+from elasticapm.conf import constants
 from elasticapm.contrib.aiohttp.utils import get_data_from_request, get_data_from_response
 from elasticapm.utils.disttracing import TraceParent
 
@@ -65,33 +66,29 @@ def tracing_middleware(app):
                 name += " unknown route"
             elasticapm.set_transaction_name(name, override=False)
             elasticapm.set_context(
-                lambda: get_data_from_request(
-                    request,
-                    capture_body=elasticapm_client.config.capture_body in ("transactions", "all"),
-                    capture_headers=elasticapm_client.config.capture_headers,
-                ),
-                "request",
+                lambda: get_data_from_request(request, elasticapm_client.config, constants.TRANSACTION), "request"
             )
 
         try:
             response = await handler(request)
             elasticapm.set_transaction_result("HTTP {}xx".format(response.status // 100), override=False)
             elasticapm.set_context(
-                lambda: get_data_from_response(response, capture_headers=elasticapm_client.config.capture_headers),
-                "response",
+                lambda: get_data_from_response(response, elasticapm_client.config, constants.TRANSACTION), "response"
             )
             return response
-        except Exception:
+        except Exception as exc:
             if elasticapm_client:
                 elasticapm_client.capture_exception(
-                    context={
-                        "request": get_data_from_request(
-                            request, capture_body=elasticapm_client.config.capture_body in ("all", "errors")
-                        )
-                    }
+                    context={"request": get_data_from_request(request, elasticapm_client.config, constants.ERROR)}
                 )
                 elasticapm.set_transaction_result("HTTP 5xx", override=False)
-                elasticapm.set_context({"status_code": 500}, "response")
+                if isinstance(exc, Response):
+                    elasticapm.set_context(
+                        lambda: get_data_from_response(exc, elasticapm_client.config, constants.ERROR),  # noqa: F821
+                        "response",
+                    )
+                else:
+                    elasticapm.set_context({"status_code": 500}, "response")
             raise
         finally:
             elasticapm_client.end_transaction()

--- a/elasticapm/contrib/aiohttp/utils.py
+++ b/elasticapm/contrib/aiohttp/utils.py
@@ -28,16 +28,19 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from aiohttp.web import Request, Response
+
+from elasticapm.conf import Config
 from elasticapm.utils import compat, get_url_dict
 
 
-def get_data_from_request(request, capture_body=False, capture_headers=True):
+def get_data_from_request(request: Request, config: Config, event_type: str):
     result = {
         "method": request.method,
         "socket": {"remote_address": request.remote, "encrypted": request.secure},
         "cookies": dict(request.cookies),
     }
-    if capture_headers:
+    if config.capture_headers:
         result["headers"] = dict(request.headers)
 
     # TODO: capture body
@@ -46,13 +49,12 @@ def get_data_from_request(request, capture_body=False, capture_headers=True):
     return result
 
 
-def get_data_from_response(response, capture_headers=True):
+def get_data_from_response(response: Response, config: Config, event_type: str):
     result = {}
 
     if isinstance(getattr(response, "status", None), compat.integer_types):
         result["status_code"] = response.status
-
-    if capture_headers and getattr(response, "headers", None):
+    if config.capture_headers and getattr(response, "headers", None):
         headers = response.headers
         result["headers"] = {key: ";".join(headers.getall(key)) for key in compat.iterkeys(headers)}
     return result

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -38,6 +38,7 @@ from django.apps import apps
 from django.conf import settings as django_settings
 
 import elasticapm
+from elasticapm.conf import constants
 from elasticapm.contrib.django.client import client, get_client
 from elasticapm.utils import build_name_with_http_method_prefix, get_name_from_func, wrapt
 
@@ -176,12 +177,11 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
                     elasticapm.set_transaction_name(transaction_name, override=False)
 
                 elasticapm.set_context(
-                    lambda: self.client.get_data_from_request(
-                        request, capture_body=self.client.config.capture_body in ("all", "transactions")
-                    ),
-                    "request",
+                    lambda: self.client.get_data_from_request(request, constants.TRANSACTION), "request"
                 )
-                elasticapm.set_context(lambda: self.client.get_data_from_response(response), "response")
+                elasticapm.set_context(
+                    lambda: self.client.get_data_from_response(response, constants.TRANSACTION), "response"
+                )
                 elasticapm.set_context(lambda: self.client.get_user_info(request), "user")
                 elasticapm.set_transaction_result("HTTP {}xx".format(response.status_code // 100), override=False)
         except Exception:

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -37,7 +37,7 @@ from flask import request, signals
 import elasticapm
 import elasticapm.instrumentation.control
 from elasticapm.base import Client
-from elasticapm.conf import setup_logging
+from elasticapm.conf import constants, setup_logging
 from elasticapm.contrib.flask.utils import get_data_from_request, get_data_from_response
 from elasticapm.handlers.logging import LoggingHandler
 from elasticapm.traces import execution_context
@@ -110,13 +110,7 @@ class ElasticAPM(object):
 
         self.client.capture_exception(
             exc_info=kwargs.get("exc_info"),
-            context={
-                "request": get_data_from_request(
-                    request,
-                    capture_body=self.client.config.capture_body in ("errors", "all"),
-                    capture_headers=self.client.config.capture_headers,
-                )
-            },
+            context={"request": get_data_from_request(request, self.client.config, constants.ERROR)},
             custom={"app": self.app},
             handled=False,
         )
@@ -186,12 +180,7 @@ class ElasticAPM(object):
             trace_parent = TraceParent.from_headers(request.headers)
             self.client.begin_transaction("request", trace_parent=trace_parent)
             elasticapm.set_context(
-                lambda: get_data_from_request(
-                    request,
-                    capture_body=self.client.config.capture_body in ("transactions", "all"),
-                    capture_headers=self.client.config.capture_headers,
-                ),
-                "request",
+                lambda: get_data_from_request(request, self.client.config, constants.TRANSACTION), "request"
             )
             rule = request.url_rule.rule if request.url_rule is not None else ""
             rule = build_name_with_http_method_prefix(rule, request)
@@ -200,7 +189,7 @@ class ElasticAPM(object):
     def request_finished(self, app, response):
         if not self.app.debug or self.client.config.debug:
             elasticapm.set_context(
-                lambda: get_data_from_response(response, capture_headers=self.client.config.capture_headers), "response"
+                lambda: get_data_from_response(response, self.client.config, constants.TRANSACTION), "response"
             )
             if response.status_code:
                 result = "HTTP {}xx".format(response.status_code // 100)

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -40,6 +40,7 @@ from starlette.types import ASGIApp
 import elasticapm
 import elasticapm.instrumentation.control
 from elasticapm.base import Client
+from elasticapm.conf import constants
 from elasticapm.contrib.asyncio.traces import set_context
 from elasticapm.contrib.starlette.utils import get_data_from_request, get_data_from_response
 from elasticapm.utils.disttracing import TraceParent
@@ -130,7 +131,9 @@ class ElasticAPM(BaseHTTPMiddleware):
         try:
             response = await call_next(request)
         except Exception:
-            await self.capture_exception()
+            await self.capture_exception(
+                context={"request": await get_data_from_request(request, self.client.config, constants.ERROR)}
+            )
             elasticapm.set_transaction_result("HTTP 5xx", override=False)
             elasticapm.set_context({"status_code": 500}, "response")
 
@@ -169,14 +172,7 @@ class ElasticAPM(BaseHTTPMiddleware):
         trace_parent = TraceParent.from_headers(dict(request.headers))
         self.client.begin_transaction("request", trace_parent=trace_parent)
 
-        await set_context(
-            lambda: get_data_from_request(
-                request,
-                capture_body=self.client.config.capture_body in ("transactions", "all"),
-                capture_headers=self.client.config.capture_headers,
-            ),
-            "request",
-        )
+        await set_context(lambda: get_data_from_request(request, self.client.config, constants.TRANSACTION), "request")
         elasticapm.set_transaction_name("{} {}".format(request.method, request.url.path), override=False)
 
     async def _request_finished(self, response: Response):
@@ -186,7 +182,7 @@ class ElasticAPM(BaseHTTPMiddleware):
             response (Response)
         """
         await set_context(
-            lambda: get_data_from_response(response, capture_headers=self.client.config.capture_headers), "response"
+            lambda: get_data_from_response(response, self.client.config, constants.TRANSACTION), "response"
         )
 
         result = "HTTP {}xx".format(response.status_code // 100)

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -48,6 +48,7 @@ from elasticapm.conf import (
     _ConfigValue,
     _DictConfigValue,
     _ListConfigValue,
+    constants,
     duration_validator,
     setup_logging,
     size_validator,
@@ -282,3 +283,12 @@ def test_validate_catches_type_errors():
 
     c = MyConfig({"anint": "x"})
     assert "invalid literal" in c.errors["anint"]
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [("transactions", constants.TRANSACTION), ("errors", constants.ERROR), ("all", "all"), ("off", "off")],
+)
+def test_capture_body_mapping(val, expected):
+    c = Config(inline_dict={"capture_body": val})
+    assert c.capture_body == expected

--- a/tests/contrib/asyncio/aiohttp_web_tests.py
+++ b/tests/contrib/asyncio/aiohttp_web_tests.py
@@ -52,7 +52,7 @@ def aioeapm(elasticapm_client):
         return aiohttp.web.Response(body=b"Hello, world")
 
     async def boom(request):
-        raise ValueError()
+        raise aiohttp.web.HTTPInternalServerError(headers={"boom": "boom"})
 
     app = aiohttp.web.Application()
     app.router.add_route("GET", "/", hello)
@@ -108,8 +108,29 @@ async def test_exception(aiohttp_client, aioeapm):
     assert len(elasticapm_client.events[constants.ERROR]) == 1
     error = elasticapm_client.events[constants.ERROR][0]
     assert error["transaction_id"] == transaction["id"]
-    assert error["exception"]["type"] == "ValueError"
+    assert error["exception"]["type"] == "HTTPInternalServerError"
     assert error["context"]["request"] == transaction["context"]["request"]
+
+
+async def test_capture_headers_is_dynamic(aiohttp_client, aioeapm):
+    app = aioeapm.app
+    client = await aiohttp_client(app)
+    elasticapm_client = aioeapm.client
+
+    elasticapm_client.config.update("1", capture_headers=True)
+    await client.get("/boom")
+
+    elasticapm_client.config.update("2", capture_headers=False)
+    await client.get("/boom")
+    assert elasticapm_client.config.capture_headers is False
+
+    assert "headers" in elasticapm_client.events[constants.TRANSACTION][0]["context"]["request"]
+    assert "headers" in elasticapm_client.events[constants.TRANSACTION][0]["context"]["response"]
+    assert "headers" in elasticapm_client.events[constants.ERROR][0]["context"]["request"]
+
+    assert "headers" not in elasticapm_client.events[constants.TRANSACTION][1]["context"]["request"]
+    assert "headers" not in elasticapm_client.events[constants.TRANSACTION][1]["context"]["response"]
+    assert "headers" not in elasticapm_client.events[constants.ERROR][1]["context"]["request"]
 
 
 async def test_traceparent_handling(aiohttp_client, aioeapm):

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -122,7 +122,7 @@ def test_post(app, elasticapm_client):
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
-    assert request["method"] == "GET"
+    assert request["method"] == "POST"
     assert request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
     assert request["body"]["foo"] == "bar"
 

--- a/tests/contrib/asyncio/tornado/tornado_tests.py
+++ b/tests/contrib/asyncio/tornado/tornado_tests.py
@@ -52,6 +52,8 @@ def app(elasticapm_client):
                 pass
             return self.write("Hello, world")
 
+        post = get
+
     class RenderHandler(tornado.web.RequestHandler):
         def get(self):
             with async_capture_span("test"):
@@ -62,6 +64,8 @@ def app(elasticapm_client):
     class BoomHandler(tornado.web.RequestHandler):
         def get(self):
             raise tornado.web.HTTPError()
+
+        post = get
 
     app = tornado.web.Application(
         [(r"/", HelloHandler), (r"/boom", BoomHandler), (r"/render", RenderHandler)],
@@ -88,8 +92,8 @@ async def test_get(app, base_url, http_client):
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
-    request["method"] == "GET"
-    request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
+    assert request["method"] == "GET"
+    assert request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
 
     assert span["name"] == "test"
 
@@ -156,8 +160,8 @@ async def test_render(app, base_url, http_client):
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 2
     request = transaction["context"]["request"]
-    request["method"] == "GET"
-    request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
+    assert request["method"] == "GET"
+    assert request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
 
     span = spans[0]
     assert span["name"] == "test"
@@ -165,3 +169,30 @@ async def test_render(app, base_url, http_client):
     assert span["name"] == "test.html"
     assert span["action"] == "render"
     assert span["type"] == "template"
+
+
+@pytest.mark.gen_test
+async def test_capture_headers_body_is_dynamic(app, base_url, http_client):
+    elasticapm_client = app.elasticapm_client
+    for i, val in enumerate((True, False)):
+        elasticapm_client.config.update(str(i), capture_body="transaction" if val else "none", capture_headers=val)
+        await http_client.fetch(base_url, method="POST", body=b"xyz")
+
+        elasticapm_client.config.update(str(i) + str(i), capture_body="error" if val else "none", capture_headers=val)
+        with pytest.raises(tornado.httpclient.HTTPClientError):
+            await http_client.fetch(base_url + "/boom", method="POST", body=b"xyz")
+
+    transactions = elasticapm_client.events[constants.TRANSACTION]
+    errors = elasticapm_client.events[constants.ERROR]
+
+    assert "headers" in transactions[0]["context"]["request"]
+    assert transactions[0]["context"]["request"]["body"] == b"xyz"
+    assert "headers" in transactions[0]["context"]["response"]
+    assert "headers" in errors[0]["context"]["request"]
+    assert errors[0]["context"]["request"]["body"] == b"xyz"
+
+    assert "headers" not in transactions[2]["context"]["request"]
+    assert "headers" not in transactions[2]["context"]["response"]
+    assert transactions[2]["context"]["request"]["body"] == "[REDACTED]"
+    assert "headers" not in errors[1]["context"]["request"]
+    assert errors[1]["context"]["request"]["body"] == "[REDACTED]"

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -575,7 +575,7 @@ def test_post_data(django_elasticapm_client):
     assert "request" in event["context"]
     request = event["context"]["request"]
     assert request["method"] == "POST"
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert request["body"] == {"x": "1", "y": ["2", "3"]}
     else:
         assert request["body"] == "[REDACTED]"
@@ -607,7 +607,7 @@ def test_post_raw_data(django_elasticapm_client):
     assert "request" in event["context"]
     request = event["context"]["request"]
     assert request["method"] == "POST"
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert request["body"] == compat.b("foobar")
     else:
         assert request["body"] == "[REDACTED]"
@@ -621,7 +621,7 @@ def test_post_read_error_logging(django_elasticapm_client, caplog, rf):
 
     request.read = read
     with caplog.at_level(logging.DEBUG):
-        django_elasticapm_client.get_data_from_request(request, capture_body=True)
+        django_elasticapm_client.get_data_from_request(request, constants.ERROR)
     record = caplog.records[0]
     assert record.message == "Can't capture request body: foobar"
 
@@ -692,7 +692,7 @@ def test_request_capture(django_elasticapm_client):
     assert "request" in event["context"]
     request = event["context"]["request"]
     assert request["method"] == "POST"
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert request["body"] == "<unavailable>"
     else:
         assert request["body"] == "[REDACTED]"
@@ -1309,7 +1309,7 @@ def test_capture_post_errors_dict(client, django_elasticapm_client):
     with pytest.raises(MyException):
         client.post(reverse("elasticapm-raise-exc"), {"username": "john", "password": "smith"})
     error = django_elasticapm_client.events[ERROR][0]
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert error["context"]["request"]["body"] == {"username": "john", "password": "smith"}
     else:
         assert error["context"]["request"]["body"] == "[REDACTED]"
@@ -1392,7 +1392,7 @@ def test_capture_post_errors_multivalue_dict(client, django_elasticapm_client):
             content_type="application/x-www-form-urlencoded",
         )
     error = django_elasticapm_client.events[ERROR][0]
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert error["context"]["request"]["body"] == {"key": ["value1", "value2", "value3"], "test": "test"}
     else:
         assert error["context"]["request"]["body"] == "[REDACTED]"
@@ -1411,7 +1411,7 @@ def test_capture_post_errors_raw(client, django_sending_elasticapm_client):
         )
     django_sending_elasticapm_client.close()
     error = django_sending_elasticapm_client.httpserver.payloads[0][1]["error"]
-    if django_sending_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_sending_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert error["context"]["request"]["body"] == '{"a": "b"}'
     else:
         assert error["context"]["request"]["body"] == "[REDACTED]"
@@ -1441,7 +1441,7 @@ def test_capture_files(client, django_elasticapm_client):
             reverse("elasticapm-raise-exc"), data={"a": "b", "f1": compat.BytesIO(100 * compat.b("1")), "f2": f}
         )
     error = django_elasticapm_client.events[ERROR][0]
-    if django_elasticapm_client.config.capture_body in ("errors", "all"):
+    if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert error["context"]["request"]["body"] == {"a": "b", "_files": {"f1": "f1", "f2": "django_tests.py"}}
     else:
         assert error["context"]["request"]["body"] == "[REDACTED]"

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -132,7 +132,7 @@ def test_post(flask_apm_client):
     assert request["url"]["full"] == "http://localhost/an-error/?biz=baz"
     assert request["url"]["search"] == "?biz=baz"
     assert request["method"] == "POST"
-    if flask_apm_client.client.config.capture_body in ("errors", "all"):
+    if flask_apm_client.client.config.capture_body in (constants.ERROR, "all"):
         assert request["body"] == {"foo": "bar"}
     else:
         assert request["body"] == "[REDACTED]"
@@ -171,7 +171,7 @@ def test_instrumentation(flask_apm_client):
     assert "request" in transaction["context"]
     assert transaction["context"]["request"]["url"]["full"] == "http://localhost/users/"
     assert transaction["context"]["request"]["method"] == "POST"
-    if flask_apm_client.client.config.capture_body in ("transactions", "all"):
+    if flask_apm_client.client.config.capture_body in (constants.TRANSACTION, "all"):
         assert transaction["context"]["request"]["body"] == {"foo": "bar"}
     else:
         assert transaction["context"]["request"]["body"] == "[REDACTED]"
@@ -287,7 +287,7 @@ def test_post_files(flask_apm_client):
     assert len(flask_apm_client.client.events[ERROR]) == 1
 
     event = flask_apm_client.client.events[ERROR][0]
-    if flask_apm_client.client.config.capture_body in ("errors", "all"):
+    if flask_apm_client.client.config.capture_body in (constants.ERROR, "all"):
         assert event["context"]["request"]["body"] == {
             "foo": ["bar", "baz"],
             "_files": {"f1": "bla", "f2": ["flask_tests.py", "blub"]},


### PR DESCRIPTION
## What does this pull request do?

This refactors a bit how the different `get_data_from_request/response` functions work, taking a `Config` instance as an argument, instead of direct `capture_body` / `capture_headers` values.

It also adds tests for all the different frameworks
