### PR TITLE
Fix SyntaxWarning on Python 3.8

### DIFF
--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -30,6 +30,7 @@
 
 
 from __future__ import absolute_import
+import logging
 
 import flask
 from flask import request, signals
@@ -133,7 +134,7 @@ class ElasticAPM(object):
             self.client = make_client(self.client_cls, app, **defaults)
 
         # 0 is a valid log level (NOTSET), so we need to check explicitly for it
-        if self.logging or self.logging is 0:  # noqa F632
+        if self.logging or self.logging is logging.NOTSET:
             if self.logging is not True:
                 kwargs = {"level": self.logging}
             else:


### PR DESCRIPTION
## What does this pull request do?

Fixes the following warning on Python 3.8

```
/srv/brm-api_staging/venv/lib/python3.8/site-packages/elasticapm/contrib/flask/__init__.py:136: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if self.logging or self.logging is 0:  # noqa F632
```