### PR TITLE
Add error handling around urlparse ports

### DIFF
--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -143,7 +143,11 @@ def url_to_destination(url, service_type="external"):
     # preserve brackets for IPv6 URLs
     if "://[" in url:
         hostname = "[%s]" % hostname
-    port = parts.port
+    try:
+        port = parts.port
+    except ValueError:
+        # Malformed port, just use None rather than raising an exception
+        port = None
     default_port = default_ports.get(parts.scheme, None)
     name = "%s://%s" % (parts.scheme, hostname)
     resource = hostname

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -214,3 +214,8 @@ def test_url_to_destination(url, name, resource):
     destination = url_to_destination(url)
     assert destination["service"]["name"] == name
     assert destination["service"]["resource"] == resource
+
+
+def test_url_to_destination_bad_port():
+    destination = url_to_destination("https://www.elastic.co:bad")
+    assert destination["service"]["resource"] == "www.elastic.co:443"


### PR DESCRIPTION
## What does this pull request do?

Adds error handling around urlparse port access. If the port doesn't cast to an `int` then a ValueError will be raised. We want to suppress that error so we're a good citizen in the app.

## Related issues
Closes #798
