### PR TITLE
Disable pypy-3 pymssql-newest

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -111,6 +111,8 @@ exclude:
   # pymssql
   - PYTHON_VERSION: pypy-2 # currently fails with error on pypy2
     FRAMEWORK: pymssql-newest
+  - PYTHON_VERSION: pypy-3 # currently fails with error on pypy3
+    FRAMEWORK: pymssql-newest
   - PYTHON_VERSION: python-3.6 # currently fails with error on python 3.6 due to cython issues
     FRAMEWORK: pymssql-newest
   - PYTHON_VERSION: python-3.7 # currently fails with error on python 3.7 due to cython issues


### PR DESCRIPTION
This started throwing an error due to an upstream change and if I'm being honest I'm too lazy to try to track down why these two edge technologies are failing.