### PR TITLE
iterate over a copy of metrics to avoid threading issues

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -18,10 +18,14 @@ endif::[]
 ===== Bug fixes
 ////
 
-//=== Unreleased
+=== Unreleased
 
 // Unreleased changes go here
 // When the next release happens, nest these changes under the "Python Agent version 5.x" heading
+
+[float]
+===== Bug fixes
+ * Fixed an issue with metrics collection raising RuntimeErrors {pull}802[#802]
 
 [[release-notes-5.x]]
 === Python Agent version 5.x

--- a/elasticapm/metrics/base_metrics.py
+++ b/elasticapm/metrics/base_metrics.py
@@ -192,7 +192,8 @@ class MetricsSet(object):
         timestamp = int(time.time() * 1000000)
         samples = defaultdict(dict)
         if self._counters:
-            for (name, labels), c in compat.iteritems(self._counters):
+            # iterate over a copy of the dict to avoid threading issues, see #717
+            for (name, labels), c in compat.iteritems(self._counters.copy()):
                 if c is not noop_metric:
                     val = c.val
                     if val or not c.reset_on_collect:
@@ -200,7 +201,7 @@ class MetricsSet(object):
                     if c.reset_on_collect:
                         c.reset()
         if self._gauges:
-            for (name, labels), g in compat.iteritems(self._gauges):
+            for (name, labels), g in compat.iteritems(self._gauges.copy()):
                 if g is not noop_metric:
                     val = g.val
                     if val or not g.reset_on_collect:
@@ -208,7 +209,7 @@ class MetricsSet(object):
                     if g.reset_on_collect:
                         g.reset()
         if self._timers:
-            for (name, labels), t in compat.iteritems(self._timers):
+            for (name, labels), t in compat.iteritems(self._timers.copy()):
                 if t is not noop_metric:
                     val, count = t.val
                     if val or not t.reset_on_collect:


### PR DESCRIPTION
## What does this pull request do?

Use a copy for iterating over metrics during collection.
This avoids and issue where a new metric could be added
to a dictionary while iterating over it, raising a 
RuntimeError.

## Related issues
closes #717
