### PR TITLE
pin pytest-asyncio to 0.10.0

### DIFF
--- a/tests/requirements/requirements-base.txt
+++ b/tests/requirements/requirements-base.txt
@@ -44,7 +44,7 @@ pep8
 pytz
 
 
-pytest-asyncio ; python_version >= '3.5'
+pytest-asyncio==0.10.0 ; python_version >= '3.5'
 asynctest==0.12.2 ; python_version >= '3.5'
 
 cachetools==2.0.1 ; python_version == '2.7'


### PR DESCRIPTION
## What does this pull request do?

The recently released 0.11.0 requires pytest 5+, which doesn't support
Python 2.7

