### PR TITLE
ci: comment PRs with the build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,7 +337,7 @@ pipeline {
           }
         }
       }
-      notifyBuildResult()
+      notifyBuildResult(prComment: true)
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Enhance the build reporting with a message in the PR that contains the build status for the last commit. It does reuse the message,