### PR TITLE
don't touch body if capture_body is False

### DIFF
--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -131,21 +131,25 @@ class DjangoClient(Client):
             result["headers"] = request_headers
 
         if request.method in constants.HTTP_WITH_BODY:
-            content_type = request.META.get("CONTENT_TYPE")
-            if content_type == "application/x-www-form-urlencoded":
-                data = compat.multidict_to_dict(request.POST)
-            elif content_type and content_type.startswith("multipart/form-data"):
-                data = compat.multidict_to_dict(request.POST)
-                if request.FILES:
-                    data["_files"] = {field: file.name for field, file in compat.iteritems(request.FILES)}
-            else:
-                try:
-                    data = request.body
-                except Exception as e:
-                    self.logger.debug("Can't capture request body: %s", compat.text_type(e))
-                    data = "<unavailable>"
             capture_body = self.config.capture_body in ("all", event_type)
-            result["body"] = data if (capture_body or not data) else "[REDACTED]"
+            if not capture_body:
+                result["body"] = "[REDACTED]"
+            else:
+                content_type = request.META.get("CONTENT_TYPE")
+                if content_type == "application/x-www-form-urlencoded":
+                    data = compat.multidict_to_dict(request.POST)
+                elif content_type and content_type.startswith("multipart/form-data"):
+                    data = compat.multidict_to_dict(request.POST)
+                    if request.FILES:
+                        data["_files"] = {field: file.name for field, file in compat.iteritems(request.FILES)}
+                else:
+                    try:
+                        data = request.body
+                    except Exception as e:
+                        self.logger.debug("Can't capture request body: %s", compat.text_type(e))
+                        data = "<unavailable>"
+                if data is not None:
+                    result["body"] = data
 
         if hasattr(request, "get_raw_uri"):
             # added in Django 1.9

--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -58,17 +58,20 @@ async def get_data_from_request(request: Request, config: Config, event_type: st
         result["headers"] = dict(request.headers)
 
     if request.method in constants.HTTP_WITH_BODY:
-        body = None
-        try:
-            body = await get_body(request)
-            if request.headers.get("content-type") == "application/x-www-form-urlencoded":
-                body = await query_params_to_dict(body)
-            else:
-                body = json.loads(body)
-        except Exception:
-            pass
-        if body is not None:
-            result["body"] = body if config.capture_body in ("all", event_type) else "[REDACTED]"
+        if config.capture_body not in ("all", event_type):
+            result["body"] = "[REDACTED]"
+        else:
+            body = None
+            try:
+                body = await get_body(request)
+                if request.headers.get("content-type") == "application/x-www-form-urlencoded":
+                    body = await query_params_to_dict(body)
+                else:
+                    body = json.loads(body)
+            except Exception:
+                pass
+            if body is not None:
+                result["body"] = body
 
     result["url"] = get_url_dict(str(request.url))
 


### PR DESCRIPTION
## What does this pull request do?

So far, we still looked at the request body, even if capture_body
was disabled. This was so we only set the `[REDACTED]` flag if
there actually was a body. Unfortunately, this interferes with
streaming requests.

I haven't found a way to properly test this. Any suggestions?

## Related issues
closes #816
