### PR TITLE
Fix LoggingHandler Client requirements, plus some docs

### DIFF
--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -134,10 +134,10 @@ apm.capture_message('hello, world!')
 [[flask-logging]]
 ==== Shipping Logs to Elasticsearch
 
-Passing `logging=LEVEL` to the ElasticAPM constructor will make the agent
-automatically ship all log messages from Python's built-in `logging` module
-to Elasticsearch, with the given level or higher. `LEVEL` has to be one of
-the levels defined in the
+Enable automatic log shipping by passing `logging=LEVEL` to the ElasticAPM
+constructor. The agent will then ship all log messages with the given
+log-level or higher, from Python's built-in `logging` module to
+Elasticsearch. `LEVEL` must be one of the levels defined in the
 https://docs.python.org/3/library/logging.html#logging-levels[`logging`]
 module.
 
@@ -168,7 +168,7 @@ For fine-grained control, you can initialize a logging handler and add it,
 just as you would with any other handler.
 
 For information on how to increase the log verbosity from the APM agent, see
-the <<troubleshooting,`troubleshooting docs`>>.
+<<agent-logging,troubleshooting agent logging>>.
 
 [source,python]
 ----

--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -132,11 +132,14 @@ apm.capture_message('hello, world!')
 
 [float]
 [[flask-logging]]
-==== Logging
+==== Shipping Logs to Elasticsearch
 
-Passing `logging=LEVEL` to the ElasticAPM constructor will make the agent automatically log all log messages from Python's built-in `logging` module,
-with the given level or higher.
-`LEVEL` has to be one of the levels defined in the https://docs.python.org/3/library/logging.html#logging-levels[`logging`] module.
+Passing `logging=LEVEL` to the ElasticAPM constructor will make the agent
+automatically ship all log messages from Python's built-in `logging` module
+to Elasticsearch, with the given level or higher. `LEVEL` has to be one of
+the levels defined in the
+https://docs.python.org/3/library/logging.html#logging-levels[`logging`]
+module.
 
 [source,python]
 ----
@@ -147,7 +150,8 @@ from elasticapm.contrib.flask import ElasticAPM
 apm = ElasticAPM(app, logging=logging.ERROR)
 ----
 
-To log all messages independent of log levels to Elastic APM, pass `logging=True` to the constructor:
+To ship all log messages independent of log levels to Elastic APM, pass
+`logging=True` to the constructor:
 
 [source,python]
 ----
@@ -162,6 +166,9 @@ For shipping of less urgent logs, we recommend to use {filebeat-ref}[filebeat].
 
 For fine-grained control, you can initialize a logging handler and add it,
 just as you would with any other handler.
+
+For information on how to increase the log verbosity from the APM agent, see
+the <<troubleshooting,`troubleshooting docs`>>.
 
 [source,python]
 ----
@@ -279,4 +286,4 @@ See the {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
 [[supported-flask-and-python-versions]]
 ==== Supported Flask and Python versions
 
-A list of supported <<supported-flask,Flask>> and <<supported-python,Python>> versions can be found on our <<supported-technologies,Supported Technologies>> page.  
+A list of supported <<supported-flask,Flask>> and <<supported-python,Python>> versions can be found on our <<supported-technologies,Supported Technologies>> page.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -77,6 +77,16 @@ To get the agent to log more data, all that is needed is a
 https://docs.python.org/3/library/logging.html#handler-objects[Handler] which
 is attached either to the `elasticapm` logger or to the root logger.
 
+Note that if you attach the handler to the root logger, you also need to
+explicitly set the log level of the `elasticapm` logger:
+
+[source,python]
+----
+import logging
+apm_logger = logging.getLogger("elasticapm")
+apm_logger.setLevel(logging.DEBUG)
+----
+
 [float]
 [[django-agent-logging]]
 ==== Django

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -57,7 +57,13 @@ class LoggingHandler(logging.Handler):
             if client_cls:
                 self.client = client_cls(*args, **kwargs)
             else:
-                raise ValueError("LoggingHandler requires a Client instance. No Client was received.")
+                # In 6.0, this should raise a ValueError
+                logger = logging.getLogger("elasticapm.handlers")
+                logger.error(
+                    "LoggingHandler requires a Client instance. No Client was "
+                    "received. This will result in an error starting in v6.0"
+                )
+                self.client = Client(*args, **kwargs)
         logging.Handler.__init__(self, level=kwargs.get("level", logging.NOTSET))
 
     def emit(self, record):

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -61,7 +61,8 @@ class LoggingHandler(logging.Handler):
                 # In 6.0, this should raise a ValueError
                 warnings.warn(
                     "LoggingHandler requires a Client instance. No Client was "
-                    "received. This will result in an error starting in v6.0",
+                    "received. This will result in an error starting in v6.0 "
+                    "of the agent",
                     PendingDeprecationWarning,
                 )
                 self.client = Client(*args, **kwargs)

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -44,22 +44,20 @@ from elasticapm.utils.stacks import iter_stack_frames
 
 class LoggingHandler(logging.Handler):
     def __init__(self, *args, **kwargs):
-        client = kwargs.pop("client_cls", Client)
-        if len(args) == 1:
+        self.client = None
+        if "client" in kwargs:
+            self.client = kwargs.pop("client")
+        elif len(args) > 0:
             arg = args[0]
-            args = args[1:]
             if isinstance(arg, Client):
                 self.client = arg
-            else:
-                raise ValueError(
-                    "The first argument to %s must be a Client instance, "
-                    "got %r instead." % (self.__class__.__name__, arg)
-                )
-        elif "client" in kwargs:
-            self.client = kwargs.pop("client")
-        else:
-            self.client = client(*args, **kwargs)
 
+        if not self.client:
+            client_cls = kwargs.pop("client_cls", None)
+            if client_cls:
+                self.client = client_cls(*args, **kwargs)
+            else:
+                raise ValueError("LoggingHandler requires a Client instance. No Client was received.")
         logging.Handler.__init__(self, level=kwargs.get("level", logging.NOTSET))
 
     def emit(self, record):

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import logging
 import sys
 import traceback
+import warnings
 
 from elasticapm.base import Client
 from elasticapm.traces import execution_context
@@ -58,10 +59,10 @@ class LoggingHandler(logging.Handler):
                 self.client = client_cls(*args, **kwargs)
             else:
                 # In 6.0, this should raise a ValueError
-                logger = logging.getLogger("elasticapm.handlers")
-                logger.error(
+                warnings.warn(
                     "LoggingHandler requires a Client instance. No Client was "
-                    "received. This will result in an error starting in v6.0"
+                    "received. This will result in an error starting in v6.0",
+                    PendingDeprecationWarning,
                 )
                 self.client = Client(*args, **kwargs)
         logging.Handler.__init__(self, level=kwargs.get("level", logging.NOTSET))

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -30,6 +30,7 @@
 
 import logging
 import sys
+import warnings
 from logging import LogRecord
 
 import pytest
@@ -42,7 +43,6 @@ from elasticapm.traces import Tracer, capture_span
 from elasticapm.utils import compat
 from elasticapm.utils.stacks import iter_stack_frames
 from tests.fixtures import TempStoreClient
-from tests.utils import assert_any_record_contains
 
 
 @pytest.fixture()
@@ -347,8 +347,10 @@ def test_formatter():
     assert hasattr(record, "elasticapm_transaction_id")
 
 
-def test_logging_handler_no_client(caplog):
+def test_logging_handler_no_client(recwarn):
     # In 6.0, this should be changed to expect a ValueError instead of a log
-    with caplog.at_level("ERROR", "elasticapm.handlers"):
-        LoggingHandler()
-    assert_any_record_contains(caplog.records, "LoggingHandler requires a Client instance")
+    warnings.simplefilter("always")
+    LoggingHandler()
+    assert len(recwarn) == 1
+    w = recwarn.pop(PendingDeprecationWarning)
+    assert "LoggingHandler requires a Client instance" in w.message.args[0]

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -42,6 +42,7 @@ from elasticapm.traces import Tracer, capture_span
 from elasticapm.utils import compat
 from elasticapm.utils.stacks import iter_stack_frames
 from tests.fixtures import TempStoreClient
+from tests.utils import assert_any_record_contains
 
 
 @pytest.fixture()
@@ -212,11 +213,6 @@ def test_client_kwarg(elasticapm_client):
     assert handler.client == elasticapm_client
 
 
-def test_invalid_first_arg_type():
-    with pytest.raises(ValueError):
-        LoggingHandler(object)
-
-
 def test_logger_setup():
     handler = LoggingHandler(
         server_url="foo", service_name="bar", secret_token="baz", metrics_interval="0ms", client_cls=TempStoreClient
@@ -349,3 +345,10 @@ def test_formatter():
     formatted_time = formatter.formatTime(record)
     assert formatted_time
     assert hasattr(record, "elasticapm_transaction_id")
+
+
+def test_logging_handler_no_client(caplog):
+    # In 6.0, this should be changed to expect a ValueError instead of a log
+    with caplog.at_level("ERROR", "elasticapm.handlers"):
+        LoggingHandler()
+    assert_any_record_contains(caplog.records, "LoggingHandler requires a Client instance")

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -351,6 +351,9 @@ def test_logging_handler_no_client(recwarn):
     # In 6.0, this should be changed to expect a ValueError instead of a log
     warnings.simplefilter("always")
     LoggingHandler()
-    assert len(recwarn) == 1
-    w = recwarn.pop(PendingDeprecationWarning)
-    assert "LoggingHandler requires a Client instance" in w.message.args[0]
+    while True:
+        # If we never find our desired warning this will eventually throw an
+        # AssertionError
+        w = recwarn.pop(PendingDeprecationWarning)
+        if "LoggingHandler requires a Client instance" in w.message.args[0]:
+            return True


### PR DESCRIPTION
This is a result of some questions on a support ticket.`LoggingHandler` should not be possible to instantiate without a `Client` object (unless `client_cls` is passed in). Otherwise we can end up with a `LoggingHandler` with a default-config `Client` object that it self-creates and that can cause a lot of hard to debug issues.

The user was also trying to use `ElasticAPM(app, logging=logging.DEBUG)` to increase the log level of the agent, when it's actually meant to ship logs to Elasticsearch. I added some clarification to the docs.