### PR TITLE
Do not install flask and requets when installing starlette

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup_kwargs = dict(
         "flask": ["blinker"],
         "aiohttp": ["aiohttp"],
         "tornado": ["tornado"],
-        "starlette": ["starlette", "flask", "requests"],
+        "starlette": ["starlette"],
         "opentracing": ["opentracing>=2.0.0"],
     },
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -166,7 +166,7 @@ def test_exception(app, elasticapm_client):
 def test_traceparent_handling(app, elasticapm_client, header_name):
     client = TestClient(app)
     with mock.patch(
-        "elasticapm.contrib.flask.TraceParent.from_string", wraps=TraceParent.from_string
+        "elasticapm.contrib.starlettte.TraceParent.from_string", wraps=TraceParent.from_string
     ) as wrapped_from_string:
         response = client.get(
             "/",

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -166,7 +166,7 @@ def test_exception(app, elasticapm_client):
 def test_traceparent_handling(app, elasticapm_client, header_name):
     client = TestClient(app)
     with mock.patch(
-        "elasticapm.contrib.starlettte.TraceParent.from_string", wraps=TraceParent.from_string
+        "elasticapm.contrib.starlette.TraceParent.from_string", wraps=TraceParent.from_string
     ) as wrapped_from_string:
         response = client.get(
             "/",

--- a/tests/requirements/reqs-starlette-0.13.txt
+++ b/tests/requirements/reqs-starlette-0.13.txt
@@ -1,4 +1,2 @@
 starlette==0.13.0
-requests==2.22.0
-flask==1.1.1
 -r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?
Stops installing dependencies that aren't required, when installing with the `starlette` flag.

I'm not sure if there's a reason, but I haven't been able to find one. I noticed that when installing using `apm-agent[starlette]`, both `Flask` and `requests` were also installed, which seemed unnecessary.
I can't see any place where requests is actually used, but there was a reference to flask in a test. That test does seem flawed though, since it seems to mock `TraceParent` from the flask package, instead of the starlette package.

Not much, but it saves two dependencies that shouldn't be needed when installing.

Note that I haven't been able to run tests locally (it seems like there's a big setup required), so sorry in advance if the packages were actually required somehow, and the CI freaks out :)