### PR TITLE
Fix elasticsearch-py tests for new upstream release

### DIFF
--- a/tests/instrumentation/asyncio/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio/elasticsearch_async_client_tests.py
@@ -112,7 +112,10 @@ async def test_create(instrument, elasticapm_client, elasticsearch_async):
 
     for i, span in enumerate(spans):
         if ES_VERSION[0] >= 5:
-            assert span["name"] == "ES PUT /tweets/%s/%d/_create" % (document_type, i + 1)
+            assert span["name"] in (
+                "ES PUT /tweets/%s/%d/_create" % (document_type, i + 1),
+                "ES PUT /tweets/_create/%d" % (i + 1),
+            )
         else:
             assert span["name"] == "ES PUT /tweets/%s/%d" % (document_type, i + 1)
         assert span["type"] == "db"

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -114,7 +114,10 @@ def test_create(instrument, elasticapm_client, elasticsearch):
 
     for i, span in enumerate(spans):
         if ES_VERSION[0] >= 5:
-            assert span["name"] == "ES PUT /tweets/%s/%d/_create" % (document_type, i + 1)
+            assert span["name"] in (
+                "ES PUT /tweets/%s/%d/_create" % (document_type, i + 1),
+                "ES PUT /tweets/_create/%d" % i + 1,
+            )
         else:
             assert span["name"] == "ES PUT /tweets/%s/%d" % (document_type, i + 1)
         assert span["type"] == "db"

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -116,7 +116,7 @@ def test_create(instrument, elasticapm_client, elasticsearch):
         if ES_VERSION[0] >= 5:
             assert span["name"] in (
                 "ES PUT /tweets/%s/%d/_create" % (document_type, i + 1),
-                "ES PUT /tweets/_create/%d" % i + 1,
+                "ES PUT /tweets/_create/%d" % (i + 1),
             )
         else:
             assert span["name"] == "ES PUT /tweets/%s/%d" % (document_type, i + 1)


### PR DESCRIPTION
More small transaction name changes due to API flexibility.
