### PR TITLE
Support uwsgi installed but not being used

### DIFF
--- a/elasticapm/utils/compat.py
+++ b/elasticapm/utils/compat.py
@@ -183,7 +183,7 @@ try:
             return f
 
 
-except ImportError:
+except (ImportError, AttributeError):
 
     def postfork(f):
         return f


### PR DESCRIPTION
The `ImportError` will be raised if `uwsgi` package is not installed. But if installed yet not _in use_, like during a Django's `./manage.py runserver` or on tests, the raised error will be AttributeError over uwsgi.masterpid .
