### PR TITLE
Add some error handling around frame processing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,11 @@ endif::[]
 
  * capture number of affected rows for INSERT/UPDATE/DELETE SQL queries {pull}614[#614]
 
+[float]
+===== Bug fixes
+
+* Added error handling around frame processing in Django {pull}837[#837]
+
 
 [[release-notes-5.x]]
 === Python Agent version 5.x

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -29,6 +29,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+import logging
+
 from django.template.base import Node
 
 from elasticapm.utils.stacks import get_frame_info
@@ -51,11 +53,15 @@ def iterate_with_template_sources(
     locals_processor_func=None,
 ):
     template = None
+    error = False
     for f in frames:
         try:
             frame, lineno = f
         except ValueError:
             # TODO how can we possibly get anything besides a (frame, lineno) tuple here???
+            if not error:
+                error = True
+                logging.getLogger("elasticapm").error("Malformed list of frames. Frames may be missing in Kibana.")
             continue
         f_code = getattr(frame, "f_code", None)
         if f_code:

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -53,16 +53,13 @@ def iterate_with_template_sources(
     locals_processor_func=None,
 ):
     template = None
-    error = False
     for f in frames:
         try:
             frame, lineno = f
         except ValueError:
             # TODO how can we possibly get anything besides a (frame, lineno) tuple here???
-            if not error:
-                error = True
-                logging.getLogger("elasticapm").error("Malformed list of frames. Frames may be missing in Kibana.")
-            continue
+            logging.getLogger("elasticapm").error("Malformed list of frames. Frames may be missing in Kibana.")
+            break
         f_code = getattr(frame, "f_code", None)
         if f_code:
             function_name = frame.f_code.co_name

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -51,7 +51,12 @@ def iterate_with_template_sources(
     locals_processor_func=None,
 ):
     template = None
-    for frame, lineno in frames:
+    for f in frames:
+        try:
+            frame, lineno = f
+        except ValueError:
+            # TODO how can we possibly get anything besides a (frame, lineno) tuple here???
+            continue
         f_code = getattr(frame, "f_code", None)
         if f_code:
             function_name = frame.f_code.co_name


### PR DESCRIPTION
See https://discuss.elastic.co/t/python-agent-raise-valueerror/233263

This is not an ideal solution, but I've investigated every code path into this function and I cannot see how the user could see that error. For now we'll just avoid throwing the error and see if any other users see it.