### PR TITLE
Add instrumentation for httpx

### DIFF
--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -39,3 +39,4 @@ FRAMEWORK:
   - tornado-newest
   - starlette-newest
   - pymemcache-newest
+  - httpx-newest

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -70,3 +70,4 @@ FRAMEWORK:
   - starlette-newest
   - pymemcache-3.0
   - pymemcache-newest
+  - httpx-newest

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ endif::[]
 ===== Features
 
  * capture number of affected rows for INSERT/UPDATE/DELETE SQL queries {pull}614[#614]
+ * Add instrumentation support for https://github.com/encode/httpx[`httpx`] {pull}xxx[#xxx]
 
 
 [[release-notes-5.x]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,7 +26,7 @@ endif::[]
 ===== Features
 
  * capture number of affected rows for INSERT/UPDATE/DELETE SQL queries {pull}614[#614]
- * Add instrumentation support for https://github.com/encode/httpx[`httpx`] {pull}xxx[#xxx]
+ * Add instrumentation support for https://github.com/encode/httpx[`httpx`] {pull}844[#844]
 
 
 [[release-notes-5.x]]

--- a/elasticapm/instrumentation/packages/asyncio/httpx.py
+++ b/elasticapm/instrumentation/packages/asyncio/httpx.py
@@ -1,0 +1,57 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from elasticapm.contrib.asyncio.traces import async_capture_span
+from elasticapm.instrumentation.packages.asyncio.base import AsyncAbstractInstrumentedModule
+from elasticapm.utils import get_host_from_url, sanitize_url, url_to_destination
+
+
+class HttpxAsyncClientInstrumentation(AsyncAbstractInstrumentedModule):
+    name = "httpx"
+
+    instrument_list = [("httpx", "AsyncClient.send")]
+
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        request = kwargs.get("request", args[0])
+
+        request_method = request.method.upper()
+        url = str(request.url)
+        name = "{request_method} {host}".format(request_method=request_method, host=get_host_from_url(url))
+        url = sanitize_url(url)
+        destination = url_to_destination(url)
+
+        async with async_capture_span(
+            name,
+            span_type="external",
+            span_subtype="http",
+            extra={"http": {"url": url}, "destination": destination},
+            leaf=True,
+        ):
+            return await wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/packages/httpx.py
+++ b/elasticapm/instrumentation/packages/httpx.py
@@ -1,0 +1,57 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
+from elasticapm.traces import capture_span
+from elasticapm.utils import get_host_from_url, sanitize_url, url_to_destination
+
+
+class HttpxClientInstrumentation(AbstractInstrumentedModule):
+    name = "httpx"
+
+    instrument_list = [("httpx", "Client.send")]
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        request = kwargs.get("request", args[0])
+
+        request_method = request.method.upper()
+        url = str(request.url)
+        name = "{request_method} {host}".format(request_method=request_method, host=get_host_from_url(url))
+        url = sanitize_url(url)
+        destination = url_to_destination(url)
+
+        with capture_span(
+            name,
+            span_type="external",
+            span_subtype="http",
+            extra={"http": {"url": url}, "destination": destination},
+            leaf=True,
+        ):
+            return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -34,6 +34,7 @@ from elasticapm.utils.module_import import import_string
 
 _cls_register = {
     "elasticapm.instrumentation.packages.botocore.BotocoreInstrumentation",
+    "elasticapm.instrumentation.packages.httpx.HttpxClientInstrumentation",
     "elasticapm.instrumentation.packages.jinja2.Jinja2Instrumentation",
     "elasticapm.instrumentation.packages.psycopg2.Psycopg2Instrumentation",
     "elasticapm.instrumentation.packages.psycopg2.Psycopg2ExtensionsInstrumentation",
@@ -67,6 +68,7 @@ if sys.version_info >= (3, 5):
         [
             "elasticapm.instrumentation.packages.asyncio.sleep.AsyncIOSleepInstrumentation",
             "elasticapm.instrumentation.packages.asyncio.aiohttp_client.AioHttpClientInstrumentation",
+            "elasticapm.instrumentation.packages.asyncio.httpx.HttpxAsyncClientInstrumentation",
             "elasticapm.instrumentation.packages.asyncio.elasticsearch.ElasticSearchAsyncConnection",
             "elasticapm.instrumentation.packages.asyncio.aiopg.AioPGInstrumentation",
             "elasticapm.instrumentation.packages.tornado.TornadoRequestExecuteInstrumentation",

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ include_trailing_comma=true
 known_standard_library=importlib,types,asyncio,contextvars
 known_django=django
 known_first_party=elasticapm,tests
-known_third_party=StringIO,__pypy__,aiohttp,async_timeout,boto3,cachetools,cassandra,celery,certifi,elasticsearch,flask,jinja2,jsonschema,logbook,memcache,mock,pkg_resources,psycopg2,psycopg2cffi,pymongo,pytest,pytest_localserver,redis,requests,setuptools,simplejson,twisted,urllib2,urllib3,urllib3_mock,urlparse,uwsgi,webob,werkzeug,zope,asynctest,opentracing,eventlet,tornado,starlette,multidict,pytest_bdd,pymemcache
+known_third_party=StringIO,__pypy__,aiohttp,async_timeout,boto3,cachetools,cassandra,celery,certifi,elasticsearch,flask,jinja2,jsonschema,logbook,memcache,mock,pkg_resources,psycopg2,psycopg2cffi,pymongo,pytest,pytest_localserver,redis,requests,setuptools,simplejson,twisted,urllib2,urllib3,urllib3_mock,urlparse,uwsgi,webob,werkzeug,zope,asynctest,opentracing,eventlet,tornado,starlette,multidict,pytest_bdd,pymemcache,httpx
 default_section=FIRSTPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 

--- a/setup.py
+++ b/setup.py
@@ -125,6 +125,7 @@ tests_require = [
     "isort",
     "pytest-cache",
     "pytest-isort",
+    "httpx",
 ]
 
 if sys.version_info[0] == 2:

--- a/tests/requirements/reqs-httpx-0.12.txt
+++ b/tests/requirements/reqs-httpx-0.12.txt
@@ -1,0 +1,2 @@
+httpx==0.12.*
+-r reqs-base.txt

--- a/tests/requirements/reqs-httpx-newest.txt
+++ b/tests/requirements/reqs-httpx-newest.txt
@@ -1,0 +1,2 @@
+httpx>=0.13.0
+-r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?
Adds instrumentation for `httpx.Client` and `httpx.AsyncClient`.

Inspiration taken from the `requests` instrumentation, as the interface is more or less the same.

**TODO**
- [ ] Add tests
- [x] Add PR link in Changelog

## Related issues
closes #739
