### PR TITLE
ci: run benchmark on a PR basis if comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:full\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:(full|benchmark)\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -212,6 +212,7 @@ pipeline {
           anyOf {
             branch 'master'
             expression { return params.Run_As_Master_Branch }
+            expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
           }
           expression { return params.bench_ci }
         }


### PR DESCRIPTION
## What does this pull request do?

Enable the benchmark stage on a PR basis if using the GH comment `jenkins run the benchmark tests please` or a more minimalistic comment with `jenkins run benchmark tests` or even with `run benchmark tests`

## Tests

https://github.com/elastic/apm-agent-python/pull/851#issuecomment-638190676 caused the `build #2`:

![image](https://user-images.githubusercontent.com/2871786/83641750-d92ccc00-a5a5-11ea-890c-eeed603adc62.png)

![image](https://user-images.githubusercontent.com/2871786/83662226-24070d80-a5bf-11ea-9a58-a0737ba579bd.png)

