### PR TITLE
print error message when submit fails in Django test command

### DIFF
--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import
 
+import logging
 import sys
 
 from django.conf import settings
@@ -132,6 +133,19 @@ class Command(BaseCommand):
     def handle_test(self, command, **options):
         """Send a test error to APM Server"""
         # can't be async for testing
+
+        class LogCaptureHandler(logging.Handler):
+            def __init__(self, level=logging.NOTSET):
+                self.logs = []
+                super(LogCaptureHandler, self).__init__(level)
+
+            def handle(self, record):
+                self.logs.append(record)
+
+        handler = LogCaptureHandler()
+        logger = logging.getLogger("elasticapm.transport")
+        logger.addHandler(handler)
+
         config = {"async_mode": False}
         for key in ("service_name", "secret_token"):
             if options.get(key):
@@ -150,14 +164,17 @@ class Command(BaseCommand):
             raise TestException("Hi there!")
         except TestException:
             client.capture_exception()
-            if not client.error_logger.errors:
-                self.write(
-                    "Success! We tracked the error successfully! \n"
-                    "You should see it in the APM app in Kibana momentarily. \n"
-                    'Look for "TestException: Hi there!" in the Errors tab of the %s app' % client.config.service_name
-                )
-        finally:
-            client.close()
+        client.close()
+        if not handler.logs:
+            self.write(
+                "Success! We tracked the error successfully! \n"
+                "You should see it in the APM app in Kibana momentarily. \n"
+                'Look for "TestException: Hi there!" in the Errors tab of the %s app' % client.config.service_name
+            )
+        else:
+            self.write("Oops. That didn't work. The following error occured: \n\n", red)
+            for entry in handler.logs:
+                self.write(entry.getMessage(), red)
 
     def handle_check(self, command, **options):
         """Check your settings for common misconfigurations"""

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -45,13 +45,6 @@ from elasticapm.utils.threading import ThreadManager
 logger = get_logger("elasticapm.transport")
 
 
-class TransportException(Exception):
-    def __init__(self, message, data=None, print_trace=True):
-        super(TransportException, self).__init__(message)
-        self.data = data
-        self.print_trace = print_trace
-
-
 class Transport(ThreadManager):
     """
     All transport implementations need to subclass this class

--- a/elasticapm/transport/exceptions.py
+++ b/elasticapm/transport/exceptions.py
@@ -32,17 +32,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-class InvalidScheme(ValueError):
-    """
-    Raised when a transport is constructed using a URI which is not
-    handled by the transport
-    """
-
-
-class DuplicateScheme(Exception):
-    """
-    Raised when registering a handler for a particular scheme which
-    is already registered
-    """
-
-    pass
+class TransportException(Exception):
+    def __init__(self, message, data=None, print_trace=True):
+        super(TransportException, self).__init__(message)
+        self.data = data
+        self.print_trace = print_trace

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -38,7 +38,7 @@ import certifi
 import urllib3
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
-from elasticapm.transport.base import TransportException
+from elasticapm.transport.exceptions import TransportException
 from elasticapm.transport.http_base import HTTPTransportBase
 from elasticapm.utils import compat, json_encoder, read_pem_file
 from elasticapm.utils.logging import get_logger

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1291,6 +1291,20 @@ def test_test_exception(urlopen_mock):
     assert "Success! We tracked the error successfully!" in output
 
 
+@pytest.mark.parametrize(
+    "django_elasticapm_client", [{"transport_class": "elasticapm.transport.http.Transport"}], indirect=True
+)
+def test_test_exception_fails(django_elasticapm_client):
+    stdout = compat.StringIO()
+    with override_settings(
+        ELASTIC_APM={"TRANSPORT_CLASS": "elasticapm.transport.http.Transport"},
+        **middleware_setting(django.VERSION, ["foo", "elasticapm.contrib.django.middleware.TracingMiddleware"])
+    ):
+        call_command("elasticapm", "test", stdout=stdout, stderr=stdout)
+    output = stdout.getvalue()
+    assert "Oops" in output
+
+
 def test_tracing_middleware_uses_test_client(client, django_elasticapm_client):
     with override_settings(
         **middleware_setting(django.VERSION, ["elasticapm.contrib.django.middleware.TracingMiddleware"])

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -37,7 +37,8 @@ import timeit
 import mock
 import pytest
 
-from elasticapm.transport.base import Transport, TransportException, TransportState
+from elasticapm.transport.base import Transport, TransportState
+from elasticapm.transport.exceptions import TransportException
 from elasticapm.utils import compat
 from tests.fixtures import DummyTransport, TempStoreClient
 from tests.utils import assert_any_record_contains

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -37,7 +37,7 @@ import urllib3.poolmanager
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from elasticapm.conf import constants
-from elasticapm.transport.base import TransportException
+from elasticapm.transport.exceptions import TransportException
 from elasticapm.transport.http import Transport
 from elasticapm.utils import compat
 


### PR DESCRIPTION
## What does this pull request do?

Due to a refactor in the past, the Django test command did
not print an error anymore when sending a message to the
APM Server failed. Added a fix and test.