### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,11 +2,13 @@
 
 source /usr/local/bin/bash_standard_lib.sh
 
-grep "-" .ci/.jenkins_python.yml | cut -d'-' -f2- | \
-while read -r version;
-do
-    imageName="apm-agent-python:${version}"
-    registryImageName="docker.elastic.co/observability-ci/${imageName}"
-    (retry 2 docker pull "${registryImageName}")
-    docker tag "${registryImageName}" "${imageName}"
-done
+if [ -x "$(command -v docker)" ]; then
+    grep "-" .ci/.jenkins_python.yml | cut -d'-' -f2- | \
+    while read -r version;
+    do
+        imageName="apm-agent-python:${version}"
+        registryImageName="docker.elastic.co/observability-ci/${imageName}"
+        (retry 2 docker pull "${registryImageName}")
+        docker tag "${registryImageName}" "${imageName}"
+    done
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.