### PR TITLE
Skip new elasticsearch_async tests for <py3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ flake8:
 	flake8
 
 test:
-	if [[ "$$PYTHON_VERSION" =~ ^(3.6|3.7|3.8|nightly|pypy3)$$ ]] ; then \
+	if [[ "$$PYTHON_VERSION" =~ ^(3.7|3.8|nightly|pypy3)$$ ]] ; then \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT); \
-	elif [[ "$$PYTHON_VERSION" =~ ^3\.5$$ ]] ; then \
+	elif [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6)$$ ]] ; then \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/asyncio/*'; \
 	else \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/py3_*.py' --ignore-glob='*/asyncio/*'; \

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ flake8:
 	flake8
 
 test:
-	if [[ "$$PYTHON_VERSION" =~ ^(3.7|3.8|nightly|pypy3)$$ ]] ; then \
+	if [[ "$$PYTHON_VERSION" =~ ^(3.7|3.8|nightly)$$ ]] ; then \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT); \
-	elif [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6)$$ ]] ; then \
+	elif [[ "$$PYTHON_VERSION" =~ ^(3.5|3.6|pypy3)$$ ]] ; then \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/asyncio/*'; \
 	else \
 		py.test -v $(PYTEST_ARGS) $(PYTEST_MARKER) $(PYTEST_JUNIT) --ignore-glob='*/py3_*.py' --ignore-glob='*/asyncio/*'; \

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -31,6 +31,7 @@
 import sys
 
 from elasticapm.utils.module_import import import_string
+
 _cls_register = {
     "elasticapm.instrumentation.packages.botocore.BotocoreInstrumentation",
     "elasticapm.instrumentation.packages.jinja2.Jinja2Instrumentation",
@@ -60,10 +61,10 @@ _cls_register = {
     "elasticapm.instrumentation.packages.django.template.DjangoTemplateSourceInstrumentation",
     "elasticapm.instrumentation.packages.urllib.UrllibInstrumentation",
     "elasticapm.instrumentation.packages.graphql.GraphQLExecutorInstrumentation",
-    "elasticapm.instrumentation.packages.graphql.GraphQLBackendInstrumentation"
+    "elasticapm.instrumentation.packages.graphql.GraphQLBackendInstrumentation",
 }
 
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3, 7):
     _cls_register.update(
         [
             "elasticapm.instrumentation.packages.asyncio.sleep.AsyncIOSleepInstrumentation",

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -45,7 +45,7 @@ pep8
 pytz
 
 
-pytest-asyncio==0.10.0 ; python_version >= '3.5'
-asynctest==0.12.2 ; python_version >= '3.5'
+pytest-asyncio==0.10.0 ; python_version >= '3.7'
+asynctest==0.12.2 ; python_version >= '3.7'
 
 cachetools==2.0.1 ; python_version == '2.7'


### PR DESCRIPTION
## What does this pull request do?

The old elasticsearch-async tests were skipped on py3.5 due to [this requirements line](https://github.com/elastic/apm-agent-python/blob/e9dcba55185d90601b4a048483c054ea36d108cd/tests/requirements/reqs-elasticsearch-7.txt#L2). However, as of 7.8.0, the main elasticsearch-py library contains async support, so we need an explicit `skipif` for the new tests on py3.5.
