### PR TITLE
s/sentry/elasticapm

### DIFF
--- a/elasticapm/contrib/django/celery/models.py
+++ b/elasticapm/contrib/django/celery/models.py
@@ -34,5 +34,5 @@ from django.core.exceptions import ImproperlyConfigured
 
 if "djcelery" not in settings.INSTALLED_APPS:
     raise ImproperlyConfigured(
-        "Put 'djcelery' in your INSTALLED_APPS setting in order to use the sentry celery client."
+        "Put 'djcelery' in your INSTALLED_APPS setting in order to use the elasticapm celery client."
     )


### PR DESCRIPTION
## What does this pull request do?

Replace the word 'sentry' with 'elasticapm' in the message for the exception that is raised when `"djcelery"` is not in `settings.INSTALLED_APPS`
