### PR TITLE
aiohttp 3.0.8+ is required for Python 3.9+ compatibility

### DIFF
--- a/tests/requirements/reqs-aiohttp-3.0.txt
+++ b/tests/requirements/reqs-aiohttp-3.0.txt
@@ -1,2 +1,2 @@
-aiohttp==3.0.6
+aiohttp==3.0.8
 -r reqs-base.txt


### PR DESCRIPTION
asyncio.Task.current_task was removed in Python 3.9, and
a check for that was introduced in aiohttp 3.0.8

