### PR TITLE
Better error handling for AWS token fetching

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Updated CLOUD_PROVIDER config to allow for new options defined in https://github.com/elastic/apm/issues/289[#289] {pull}878[#878]
+* Fixed a bug in AWS metadata collection on docker containers in AWS Elastic Beanstalk {pull}884[#884]
 
 
 [[release-notes-5.x]]

--- a/elasticapm/utils/cloud.py
+++ b/elasticapm/utils/cloud.py
@@ -48,6 +48,12 @@ def aws_metadata():
         socket.create_connection(("169.254.169.254", 80), 0.1)
 
         try:
+            # This whole block is almost unnecessary. IMDSv1 will be supported
+            # indefinitely, so the only time this block is needed is if a
+            # security-conscious user has set the metadata service to require
+            # IMDSv2. Thus, the very expansive try:except: coverage.
+
+            # TODO: should we have a config option to completely disable IMDSv2 to reduce overhead?
             ttl_header = {"X-aws-ec2-metadata-token-ttl-seconds": "300"}
             token_url = "http://169.254.169.254/latest/api/token"
             token_request = http.request("PUT", token_url, headers=ttl_header, timeout=1.0, retries=False)


### PR DESCRIPTION
## What does this pull request do?

It turns out for docker containers on AWS elastic beanstalk, the PUT for the
token fails, and fails slowly. This is not the case for the ec2 host on which
the docker container is running. This was causing issues, compounded by the
fact that I didn't have `retries=False` on that call.

I also made the timeouts shorter -- all of these calls are local, so they're very fast.

## Related issues
Fixes #880