### PR TITLE
mark another test as flaky

### DIFF
--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -232,6 +232,7 @@ def test_empty_processor_list(elasticapm_client):
     assert elasticapm_client.processors == []
 
 
+@pytest.mark.flaky(reruns=3)  # test is flaky on Windows
 @pytest.mark.parametrize(
     "sending_elasticapm_client",
     [{"transport_class": "elasticapm.transport.http.Transport", "async_mode": False}],


### PR DESCRIPTION
## What does this pull request do?

See https://apm-ci.elastic.co/job/apm-agent-python/job/apm-agent-python-mbp/job/master/290/testReport/junit/tests.client/client_tests/Initializing___Test___windows_3_6_none___test_send_remote_failover_sync_validating_httpserver0_sending_elasticapm_client0_/ 

Compared with other flakiness issues with pytest-localserver, the stack trace is different,
but I suspect this is because they stack trace is masked.
