### PR TITLE
docs: add disable instructions

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -7,6 +7,7 @@ python agent.
 * <<easy-fixes>>
 * <<django-test>>
 * <<agent-logging>>
+* <<disable-agent>>
 
 [float]
 [[easy-fixes]]
@@ -154,3 +155,18 @@ logger.addHandler(console_handler)
 See the https://docs.python.org/3/library/logging.html[python logging docs]
 for more details about Handlers (and information on how to format your logs
 using Formatters).
+
+[float]
+[[disable-agent]]
+=== Disable the Agent
+
+In the unlikely event the agent causes disruptions to a production application,
+you can disable the agent while you troubleshoot.
+
+If you have access to <<dynamic-configuration,dynamic configuration>>,
+you can disable the recording of events by setting <<config-recording,`recording`>> to `false`.
+When changed at runtime from a supported source, there's no need to restart your application.
+
+If that doesn't work, or you don't have access to dynamic configuration, you can disable the agent by setting
+<<config-enabled,`enabled`>> to `false`.
+You'll need to restart your application for the changes to take effect.


### PR DESCRIPTION
## What does this pull request do?

To assist support, we're adding disable instructions to each Agent's troubleshooting docs.

<img width="693" alt="Screen Shot 2020-07-29 at 12 47 51 PM" src="https://user-images.githubusercontent.com/5618806/88845948-be3b9a00-d199-11ea-9964-bf0e9640d8bd.png">


## Related issues

For https://github.com/elastic/observability-docs/issues/35.
