### PR TITLE
Add asyncpg instrumentation

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -267,6 +267,17 @@ exclude:
     FRAMEWORK: aiopg-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aiopg-newest
+  # asyncpg
+  - PYTHON_VERSION: python-2.7
+    FRAMEWORK: asyncpg-newest
+  - PYTHON_VERSION: pypy-2
+    FRAMEWORK: asyncpg-newest
+  - PYTHON_VERSION: pypy-3
+    FRAMEWORK: asyncpg-newest
+  - PYTHON_VERSION: python-3.5
+    FRAMEWORK: asyncpg-newest
+  - PYTHON_VERSION: python-3.6
+    FRAMEWORK: asyncpg-newest
   # psutil
   - PYTHON_VERSION: pypy-2  #currently fails on pypy2 (https://github.com/giampaolo/psutil/issues/1659)
     FRAMEWORK: psutil-newest

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -36,6 +36,7 @@ FRAMEWORK:
   - mysqlclient-newest
   - aiohttp-newest
   - aiopg-newest
+  - asyncpg-newest
   - tornado-newest
   - starlette-newest
   - pymemcache-newest

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -65,6 +65,7 @@ FRAMEWORK:
   - aiohttp-4.0
   - aiohttp-newest
   - aiopg-newest
+  - asyncpg-newest
   - tornado-newest
   - starlette-0.13
   - starlette-newest

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -217,6 +217,20 @@ Collected trace data:
  * parametrized SQL query
 
 [float]
+[[automatic-instrumentation-db-asynpg]]
+==== asynpg
+
+Library: `asyncpg` (`>=0.20.0`)
+
+Instrumented methods:
+
+ * `async.connection.Connection._do_execute`
+
+Collected trace data:
+
+ * parametrized SQL query
+
+[float]
 [[automatic-instrumentation-db-pyodbc]]
 ==== PyODBC
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -224,7 +224,8 @@ Library: `asyncpg` (`>=0.20.0`)
 
 Instrumented methods:
 
- * `async.connection.Connection._do_execute`
+ * `async.connection.Connection.execute`
+ * `async.connection.Connection.executemany`
 
 Collected trace data:
 

--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -1,0 +1,61 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2020, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from elasticapm.contrib.asyncio.traces import async_capture_span
+from elasticapm.instrumentation.packages.asyncio.base import AsyncAbstractInstrumentedModule
+from elasticapm.instrumentation.packages.dbapi2 import extract_signature
+
+
+class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
+    name = "asyncpg"
+
+    instrument_list = [("asyncpg.connection", "Connection._execute")]
+
+    async def call(self, module, method, wrapped, instance, args, kwargs):
+        if method == "Connection._do_execute":
+            query = args[0] if len(args) else kwargs["query"]
+            query = _bake_sql(instance.raw, query)
+            name = extract_signature(query)
+            context = {"db": {"type": "sql", "statement": query}}
+            action = "query"
+        else:
+            raise AssertionError("call from uninstrumented method")
+        async with async_capture_span(
+            name, leaf=True, span_type="db", span_subtype="postgres", span_action=action, extra=context
+        ):
+            return await wrapped(*args, **kwargs)
+
+
+def _bake_sql(cursor, sql):
+    # if this is a Composable object, use its `as_string` method
+    # see http://initd.org/psycopg/docs/sql.html
+    if hasattr(sql, "as_string"):
+        return sql.as_string(cursor)
+    return sql

--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -36,6 +36,11 @@ from elasticapm.instrumentation.packages.dbapi2 import extract_signature
 class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
     name = "asyncpg"
 
+    """
+    We instrument the higher level Connection.execute and Connection.executemany
+    over Connection._do_execute as Connection.execute can call the Cython
+    BaseProtocol.query which is not instrumentable
+    """
     instrument_list = [
         ("asyncpg.connection", "Connection.execute"),
         ("asyncpg.connection", "Connection.executemany"),

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -72,6 +72,7 @@ if sys.version_info >= (3, 7):
             "elasticapm.instrumentation.packages.asyncio.elasticsearch.ElasticSearchAsyncConnection",
             "elasticapm.instrumentation.packages.asyncio.elasticsearch.AsyncElasticsearchInstrumentation",
             "elasticapm.instrumentation.packages.asyncio.aiopg.AioPGInstrumentation",
+            "elasticapm.instrumentation.packages.asyncio.asyncpg.AsyncPGInstrumentation",
             "elasticapm.instrumentation.packages.tornado.TornadoRequestExecuteInstrumentation",
             "elasticapm.instrumentation.packages.tornado.TornadoHandleRequestExceptionInstrumentation",
             "elasticapm.instrumentation.packages.tornado.TornadoRenderInstrumentation",

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ markers =
     pymssql
     aiohttp
     aiopg
+    asyncpg
     tornado
     starlette
     graphene

--- a/tests/instrumentation/asyncio/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio/asyncpg_tests.py
@@ -1,0 +1,86 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2020, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest  # isort:skip
+
+asyncpg = pytest.importorskip("asyncpg")  # isort:skip
+
+import os
+
+from elasticapm.conf import constants
+
+
+pytestmark = [pytest.mark.asyncpg, pytest.mark.asyncio]
+
+
+def dsn():
+    return "postgres://{user}:{password}@{host}:{port}/{database}".format(
+        database=os.environ.get("POSTGRES_DB") or "elasticapm_test",
+        user=os.environ.get("POSTGRES_USER") or "postgres",
+        password=os.environ.get("POSTGRES_PASSWORD") or "postgres",
+        host=os.environ.get("POSTGRES_HOST") or "localhost",
+        port=os.environ.get("POSTGRES_PORT") or "5432",
+    )
+
+
+@pytest.fixture()
+async def connection(request):
+    conn = await asyncpg.connect(dsn())
+
+    def rollback():
+        conn.execute("ROLLBACK")
+        conn.close()
+
+    request.addfinalizer(rollback)
+
+    await conn.execute(
+        "BEGIN;"
+        "CREATE TABLE test(id int, name VARCHAR(5) NOT NULL);"
+        "INSERT INTO test VALUES (1, 'one'), (2, 'two'), (3, 'three');"
+    )
+
+    return connection
+
+
+async def test_select_sleep(instrument, connection, elasticapm_client):
+    elasticapm_client.begin_transaction("test")
+    await connection.execute("SELECT pg_sleep(0.1);")
+    elasticapm_client.end_transaction("test")
+
+    transaction = elasticapm_client.events[constants.TRANSACTION][0]
+    spans = elasticapm_client.spans_for_transaction(transaction)
+
+    assert len(spans) == 1
+    span = spans[0]
+    assert 100 < span["duration"] < 110
+    assert transaction["id"] == span["transaction_id"]
+    assert span["subtype"] == "postgres"
+    assert span["action"] == "query"
+    assert span["sync"] == False

--- a/tests/requirements/reqs-asyncpg-newest.txt
+++ b/tests/requirements/reqs-asyncpg-newest.txt
@@ -1,0 +1,2 @@
+asyncpg
+-r reqs-base.txt

--- a/tests/scripts/download_json_schema.sh
+++ b/tests/scripts/download_json_schema.sh
@@ -8,9 +8,9 @@ download_schema()
     for run in 1 2 3 4 5
     do
         if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi

--- a/tests/scripts/download_json_schema.sh
+++ b/tests/scripts/download_json_schema.sh
@@ -8,9 +8,9 @@ download_schema()
     for run in 1 2 3 4 5
     do
         if [ -x "$(command -v gtar)" ]; then
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | gtar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
         else
-            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --wildcards --directory=${1} --strip-components=1 "*/docs/spec/*"
+            curl --silent --fail https://codeload.github.com/elastic/apm-server/tar.gz/${2} | tar xzvf - --directory=${1} --strip-components=1 "*/docs/spec/*"
         fi
         result=$?
         if [ $result -eq 0 ]; then break; fi

--- a/tests/scripts/envs/asyncpg.sh
+++ b/tests/scripts/envs/asyncpg.sh
@@ -1,0 +1,8 @@
+export PYTEST_MARKER="-m asyncpg"
+export DOCKER_DEPS="postgres"
+export POSTGRES_HOST="postgres"
+export POSTGRES_USER="postgres"
+export POSTGRES_PASSWORD="postgres"
+export POSTGRES_DB="elasticapm_test"
+export POSTGRES_HOST="postgres"
+export POSTGRES_PORT="5432"


### PR DESCRIPTION
## What does this pull request do?

This PR adds proper instrumentation for `asyncpg`

I've noticed there's another PR open to also add asyncpg instrumentation: https://github.com/elastic/apm-agent-python/pull/889, however it has some implementation issues. Feel free to close this one out, I'd be happy to merge my changes in to the existing PR.

## Related issues
closes https://github.com/elastic/apm-agent-python/issues/755