### PR TITLE
implement "outcome" property for transactions and spans

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -234,6 +234,44 @@ elasticapm.set_transaction_result('SUCCESS')
  * `override`: if `True` (the default), overrides any previously set result.
     If `False`, only sets the result if the result hasn't already been set.
 
+[float]
+[[api-set-transaction-success]]
+==== `elasticapm.set_transaction_success()`
+
+Marks the current transaction as successful.
+This should only be called at the end of a transaction after the outcome is determined.
+For supported frameworks, the transaction outcome is set automatically if it has not been set yet. 
+
+This value is used for error rate calculations.
+
+Example:
+
+[source,python]
+----
+import elasticapm
+
+elasticapm.set_transaction_success()
+----
+
+[float]
+[[api-set-transaction-failure]]
+==== `elasticapm.set_transaction_failure()`
+
+Marks the current transaction as failed.
+This should only be called at the end of a transaction after the outcome is determined.
+For supported frameworks, the transaction outcome is set automatically if it has not been set yet. 
+
+This value is used for error rate calculations.
+
+Example:
+
+[source,python]
+----
+import elasticapm
+
+elasticapm.set_transaction_success()
+----
+
 
 [float]
 [[api-get-transaction-id]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -240,12 +240,21 @@ elasticapm.set_transaction_result('SUCCESS')
 
 Sets the outcome of the transaction. The value can either be `"success"`, `"failure"` or `"unknown"`.
 This should only be called at the end of a transaction after the outcome is determined.
-For supported frameworks, the transaction outcome is set automatically if it has not been set yet.
+
+The `outcome` is used for error rate calculations.
+`success` denotes that a transaction has concluded successful, while `failure` indicates that the transaction failed
+to finish successfully.
+If the `outcome` is set to `unknown`, the transaction will not be included in error rate calculations.
+
+For supported web frameworks, the transaction outcome is set automatically if it has not been set yet, based on the
+HTTP status code.
+A status code below `500` is considered a `success`, while any value of `500` or higher is counted as a `failure`.
 
 If your transaction results in an HTTP response, you can alternatively provide the HTTP status code.
 
 NOTE: While the `outcome` and `result` field look very similar, they serve different purposes.
-      While the `result` field can hold an arbitrary string value, `outcome` is limited to three different values,
+      Other than the `result` field, which canhold an arbitrary string value,
+      `outcome` is limited to three different values,
       `"success"`, `"failure"` and `"unknown"`.
       This allows the APM app to perform error rate calculations on these values.
 
@@ -268,6 +277,12 @@ elasticapm.set_transaction_outcome(OUTCOME.SUCCESS)
 elasticapm.set_transaction_outcome(OUTCOME.FAILURE)
 elasticapm.set_transaction_outcome(OUTCOME.UNKNOWN)
 ----
+
+ * `outcome`: One of `"success"`, `"failure"` or `"unknown"`. Can be omitted if `http_status_code` is provided.
+ * `http_status_code`: if the transaction represents an HTTP response, its status code can be provided to determine the `outcome` automatically.
+ * `override`: if `True` (the default), any previously set `outcome` will be overriden. 
+               If `False`, the outcome will only be set if it was not set before.
+
 
 [float]
 [[api-get-transaction-id]]

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -235,14 +235,19 @@ elasticapm.set_transaction_result('SUCCESS')
     If `False`, only sets the result if the result hasn't already been set.
 
 [float]
-[[api-set-transaction-success]]
-==== `elasticapm.set_transaction_success()`
+[[api-set-transaction-outcome]]
+==== `elasticapm.set_transaction_outcome()`
 
-Marks the current transaction as successful.
+Sets the outcome of the transaction. The value can either be `"success"`, `"failure"` or `"unknown"`.
 This should only be called at the end of a transaction after the outcome is determined.
-For supported frameworks, the transaction outcome is set automatically if it has not been set yet. 
+For supported frameworks, the transaction outcome is set automatically if it has not been set yet.
 
-This value is used for error rate calculations.
+If your transaction results in an HTTP response, you can alternatively provide the HTTP status code.
+
+NOTE: While the `outcome` and `result` field look very similar, they serve different purposes.
+      While the `result` field can hold an arbitrary string value, `outcome` is limited to three different values,
+      `"success"`, `"failure"` and `"unknown"`.
+      This allows the APM app to perform error rate calculations on these values.
 
 Example:
 
@@ -250,28 +255,19 @@ Example:
 ----
 import elasticapm
 
-elasticapm.set_transaction_success()
+elasticapm.set_transaction_outcome("success")
+
+# Using an HTTP status code
+elasticapm.set_transaction_outcome(http_status_code=200)
+
+# Using predefined constants:
+
+from elasticapm.conf.constants import OUTCOME
+
+elasticapm.set_transaction_outcome(OUTCOME.SUCCESS)
+elasticapm.set_transaction_outcome(OUTCOME.FAILURE)
+elasticapm.set_transaction_outcome(OUTCOME.UNKNOWN)
 ----
-
-[float]
-[[api-set-transaction-failure]]
-==== `elasticapm.set_transaction_failure()`
-
-Marks the current transaction as failed.
-This should only be called at the end of a transaction after the outcome is determined.
-For supported frameworks, the transaction outcome is set automatically if it has not been set yet. 
-
-This value is used for error rate calculations.
-
-Example:
-
-[source,python]
-----
-import elasticapm
-
-elasticapm.set_transaction_success()
-----
-
 
 [float]
 [[api-get-transaction-id]]

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -40,8 +40,10 @@ from elasticapm.traces import (  # noqa: F401
     label,
     set_context,
     set_custom_context,
+    set_transaction_failure,
     set_transaction_name,
     set_transaction_result,
+    set_transaction_success,
     set_user_context,
     tag,
 )

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -40,10 +40,9 @@ from elasticapm.traces import (  # noqa: F401
     label,
     set_context,
     set_custom_context,
-    set_transaction_failure,
     set_transaction_name,
+    set_transaction_outcome,
     set_transaction_result,
-    set_transaction_success,
     set_user_context,
     tag,
 )

--- a/elasticapm/conf/constants.py
+++ b/elasticapm/conf/constants.py
@@ -30,6 +30,7 @@
 
 import decimal
 import re
+from collections import namedtuple
 
 EVENTS_API_PATH = "intake/v2/events"
 AGENT_CONFIG_PATH = "config/v1/agents"
@@ -68,6 +69,10 @@ BASE_SANITIZE_FIELD_NAMES = [
     "access_token",
     "sessionid",
 ]
+
+OUTCOME = namedtuple("OUTCOME", ["SUCCESS", "FAILURE", "UNKNOWN"])(
+    SUCCESS="success", FAILURE="failure", UNKNOWN="unknown"
+)
 
 try:
     # Python 2

--- a/elasticapm/contrib/aiohttp/middleware.py
+++ b/elasticapm/contrib/aiohttp/middleware.py
@@ -72,6 +72,7 @@ def tracing_middleware(app):
         try:
             response = await handler(request)
             elasticapm.set_transaction_result("HTTP {}xx".format(response.status // 100), override=False)
+            elasticapm.set_transaction_outcome(http_status_code=response.status, override=False)
             elasticapm.set_context(
                 lambda: get_data_from_response(response, elasticapm_client.config, constants.TRANSACTION), "response"
             )
@@ -82,6 +83,7 @@ def tracing_middleware(app):
                     context={"request": get_data_from_request(request, elasticapm_client.config, constants.ERROR)}
                 )
                 elasticapm.set_transaction_result("HTTP 5xx", override=False)
+                elasticapm.set_transaction_outcome(http_status_code=500, override=False)
                 elasticapm.set_context({"status_code": 500}, "response")
                 # some exceptions are response-like, e.g. have headers and status code. Let's try and capture them
                 if isinstance(exc, (Response, HTTPException)):

--- a/elasticapm/contrib/celery/__init__.py
+++ b/elasticapm/contrib/celery/__init__.py
@@ -70,7 +70,7 @@ def register_instrumentation(client):
             outcome = constants.OUTCOME.FAILURE
         else:
             outcome = constants.OUTCOME.UNKNOWN
-        elasticapm.set_transaction_outcome(outcome)
+        elasticapm.set_transaction_outcome(outcome, override=False)
         client.end_transaction(name, state)
 
     dispatch_uid = "elasticapm-tracing-%s"

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -184,6 +184,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
                 )
                 elasticapm.set_context(lambda: self.client.get_user_info(request), "user")
                 elasticapm.set_transaction_result("HTTP {}xx".format(response.status_code // 100), override=False)
+                elasticapm.set_transaction_outcome(http_status_code=response.status_code, override=False)
         except Exception:
             self.client.error_logger.error("Exception during timing of request", exc_info=True)
         return response

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -195,8 +195,10 @@ class ElasticAPM(object):
             )
             if response.status_code:
                 result = "HTTP {}xx".format(response.status_code // 100)
+                elasticapm.set_transaction_outcome(http_status_code=response.status_code, override=False)
             else:
                 result = response.status
+                elasticapm.set_transaction_outcome(http_status_code=response.status, override=False)
             elasticapm.set_transaction_result(result, override=False)
             # Instead of calling end_transaction here, we defer the call until the response is closed.
             # This ensures that we capture things that happen until the WSGI server closes the response.

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -133,11 +133,13 @@ class ElasticAPM(BaseHTTPMiddleware):
 
         try:
             response = await call_next(request)
+            elasticapm.set_transaction_outcome(constants.OUTCOME.SUCCESS, override=False)
         except Exception:
             await self.capture_exception(
                 context={"request": await get_data_from_request(request, self.client.config, constants.ERROR)}
             )
             elasticapm.set_transaction_result("HTTP 5xx", override=False)
+            elasticapm.set_transaction_outcome(constants.OUTCOME.FAILURE, override=False)
             elasticapm.set_context({"status_code": 500}, "response")
 
             raise

--- a/elasticapm/instrumentation/packages/urllib.py
+++ b/elasticapm/instrumentation/packages/urllib.py
@@ -98,9 +98,10 @@ class UrllibInstrumentation(AbstractInstrumentedModule):
             self._set_disttracing_headers(request_object, trace_parent, transaction)
             response = wrapped(*args, **kwargs)
             if response:
+                status = getattr(response, "status", None) or response.getcode()  # Python 2 compat
                 if span.context:
-                    span.context["http"]["status_code"] = response.status
-                span.set_success() if response.status < 400 else span.set_failure()
+                    span.context["http"]["status_code"] = status
+                span.set_success() if status < 400 else span.set_failure()
             return response
 
     def mutate_unsampled_call_args(self, module, method, wrapped, instance, args, kwargs, transaction):

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -285,7 +285,7 @@ class Transaction(BaseSpan):
             start=start,
         )
 
-    def end_span(self, skip_frames=0, duration=None, outcome=None):
+    def end_span(self, skip_frames=0, duration=None, outcome="unknown"):
         """
         End the currently active span
         :param skip_frames: numbers of frames to skip in the stack trace

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -729,6 +729,13 @@ def tag(**tags):
 
 
 def set_transaction_name(name, override=True):
+    """
+    Sets the name of the transaction
+
+    :param name: the name of the transaction
+    :param override: if set to False, the name is only set if no name has been set before
+    :return: None
+    """
     transaction = execution_context.get_transaction()
     if not transaction:
         return
@@ -737,11 +744,50 @@ def set_transaction_name(name, override=True):
 
 
 def set_transaction_result(result, override=True):
+    """
+    Sets the result of the transaction. The result could be e.g. the HTTP status class (e.g "HTTP 5xx") for
+    HTTP requests, or "success"/"fail" for background tasks.
+
+    :param name: the name of the transaction
+    :param override: if set to False, the name is only set if no name has been set before
+    :return: None
+    """
+
     transaction = execution_context.get_transaction()
     if not transaction:
         return
     if transaction.result is None or override:
         transaction.result = result
+
+
+def set_transaction_success():
+    """
+    Marks this transaction as successful. This should only be done at the end of a transaction
+    when the outcome is determined.
+
+    This value is used for error rate calculations.
+
+    :return: None
+    """
+    transaction = execution_context.get_transaction()
+    if not transaction:
+        return
+    transaction.set_success()
+
+
+def set_transaction_failure():
+    """
+    Marks this transaction as failed. This should only be done at the end of a transaction
+    when the outcome is determined.
+
+    This value is used for error rate calculations.
+
+    :return: None
+    """
+    transaction = execution_context.get_transaction()
+    if not transaction:
+        return
+    transaction.set_failure()
 
 
 def get_transaction_id():

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -294,7 +294,7 @@ class Transaction(BaseSpan):
             raise LookupError()
 
         # only overwrite span outcome if it is still unknown
-        if span.outcome == "unknown":
+        if not span.outcome or span.outcome == "unknown":
             span.outcome = outcome
 
         span.end(skip_frames=skip_frames, duration=duration)

--- a/tests/contrib/asyncio/aiohttp_web_tests.py
+++ b/tests/contrib/asyncio/aiohttp_web_tests.py
@@ -76,6 +76,7 @@ async def test_get(aiohttp_client, aioeapm):
 
     assert transaction["name"] == "GET /"
     assert transaction["result"] == "HTTP 2xx"
+    assert transaction["outcome"] == "success"
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
@@ -99,6 +100,7 @@ async def test_exception(aiohttp_client, aioeapm):
 
     assert transaction["name"] == "GET /boom"
     assert transaction["result"] == "HTTP 5xx"
+    assert transaction["outcome"] == "failure"
     assert transaction["type"] == "request"
     request = transaction["context"]["request"]
     assert request["method"] == "GET"

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -86,6 +86,7 @@ def test_get(app, elasticapm_client):
 
     assert transaction["name"] == "GET /"
     assert transaction["result"] == "HTTP 2xx"
+    assert transaction["outcome"] == "success"
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
@@ -119,6 +120,7 @@ def test_post(app, elasticapm_client):
 
     assert transaction["name"] == "POST /"
     assert transaction["result"] == "HTTP 2xx"
+    assert transaction["outcome"] == "success"
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
@@ -149,6 +151,7 @@ def test_exception(app, elasticapm_client):
 
     assert transaction["name"] == "GET /raise-exception"
     assert transaction["result"] == "HTTP 5xx"
+    assert transaction["outcome"] == "failure"
     assert transaction["type"] == "request"
     request = transaction["context"]["request"]
     assert request["method"] == "GET"

--- a/tests/contrib/asyncio/tornado/tornado_tests.py
+++ b/tests/contrib/asyncio/tornado/tornado_tests.py
@@ -119,6 +119,7 @@ async def test_get(app, base_url, http_client):
 
     assert transaction["name"] == "GET HelloHandler"
     assert transaction["result"] == "HTTP 2xx"
+    assert transaction["outcome"] == "success"
     assert transaction["type"] == "request"
     assert transaction["span_count"]["started"] == 1
     request = transaction["context"]["request"]
@@ -141,6 +142,7 @@ async def test_exception(app, base_url, http_client):
 
     assert transaction["name"] == "GET BoomHandler"
     assert transaction["result"] == "HTTP 5xx"
+    assert transaction["outcome"] == "failure"
     assert transaction["type"] == "request"
     request = transaction["context"]["request"]
     assert request["method"] == "GET"

--- a/tests/contrib/celery/django_tests.py
+++ b/tests/contrib/celery/django_tests.py
@@ -57,6 +57,7 @@ def test_failing_celery_task(django_elasticapm_client):
     assert transaction["name"] == "tests.contrib.django.testapp.tasks.failing_task"
     assert transaction["type"] == "celery"
     assert transaction["result"] == "FAILURE"
+    assert transaction["outcome"] == "failure"
 
 
 def test_successful_celery_task_instrumentation(django_elasticapm_client):
@@ -68,3 +69,4 @@ def test_successful_celery_task_instrumentation(django_elasticapm_client):
     assert transaction["name"] == "tests.contrib.django.testapp.tasks.successful_task"
     assert transaction["type"] == "celery"
     assert transaction["result"] == "SUCCESS"
+    assert transaction["outcome"] == "success"

--- a/tests/contrib/celery/flask_tests.py
+++ b/tests/contrib/celery/flask_tests.py
@@ -59,6 +59,7 @@ def test_task_failure(flask_celery):
     assert transaction["name"] == "tests.contrib.celery.flask_tests.failing_task"
     assert transaction["type"] == "celery"
     assert transaction["result"] == "FAILURE"
+    assert transaction["outcome"] == "failure"
 
 
 def test_task_instrumentation(flask_celery):
@@ -76,3 +77,4 @@ def test_task_instrumentation(flask_celery):
     assert transaction["name"] == "tests.contrib.celery.flask_tests.successful_task"
     assert transaction["type"] == "celery"
     assert transaction["result"] == "SUCCESS"
+    assert transaction["outcome"] == "failure"

--- a/tests/contrib/celery/flask_tests.py
+++ b/tests/contrib/celery/flask_tests.py
@@ -77,4 +77,4 @@ def test_task_instrumentation(flask_celery):
     assert transaction["name"] == "tests.contrib.celery.flask_tests.successful_task"
     assert transaction["type"] == "celery"
     assert transaction["result"] == "SUCCESS"
-    assert transaction["outcome"] == "failure"
+    assert transaction["outcome"] == "success"

--- a/tests/contrib/django/testapp/middleware.py
+++ b/tests/contrib/django/testapp/middleware.py
@@ -49,3 +49,12 @@ class BrokenResponseMiddleware(MiddlewareMixin):
 class BrokenViewMiddleware(MiddlewareMixin):
     def process_view(self, request, func, args, kwargs):
         raise ImportError("view")
+
+
+class SetTransactionUnsampled(MiddlewareMixin):
+    def process_request(self, request):
+        from elasticapm.traces import execution_context
+
+        transaction = execution_context.get_transaction()
+        if transaction:
+            transaction.is_sampled = False

--- a/tests/contrib/django/testapp/urls.py
+++ b/tests/contrib/django/testapp/urls.py
@@ -49,6 +49,7 @@ urlpatterns = (
     url(r"^render-user-template$", views.render_user_view, name="render-user-template"),
     url(r"^no-error$", views.no_error, name="elasticapm-no-error"),
     url(r"^no-error-slash/$", views.no_error, name="elasticapm-no-error-slash"),
+    url(r"^http-error/(?P<status>[0-9]{3})$", views.http_error, name="elasticapm-http-error"),
     url(r"^logging$", views.logging_view, name="elasticapm-logging"),
     url(r"^ignored-exception/$", views.ignored_exception, name="elasticapm-ignored-exception"),
     url(r"^fake-login$", views.fake_login, name="elasticapm-fake-login"),

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -55,6 +55,13 @@ def no_error(request, id=None):
     return resp
 
 
+def http_error(request, status=None):
+    if status:
+        status = int(status)
+    resp = HttpResponse(status=status)
+    return resp
+
+
 def fake_login(request):
     return HttpResponse("")
 

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -168,6 +168,7 @@ def test_instrumentation(flask_apm_client):
     transaction = transactions[0]
     assert transaction["type"] == "request"
     assert transaction["result"] == "HTTP 2xx"
+    assert transaction["outcome"] == "success"
     assert "request" in transaction["context"]
     assert transaction["context"]["request"]["url"]["full"] == "http://localhost/users/"
     assert transaction["context"]["request"]["method"] == "POST"

--- a/tests/instrumentation/asyncio/aiohttp_client_tests.py
+++ b/tests/instrumentation/asyncio/aiohttp_client_tests.py
@@ -62,7 +62,7 @@ async def test_http_get(instrument, event_loop, elasticapm_client, waiting_https
     assert span["subtype"] == "http"
     assert span["sync"] is False
     assert span["context"]["http"]["url"] == waiting_httpserver.url
-    assert span["context"]["http"]["status_code"] == 200
+    assert span["context"]["http"]["status_code"] == 204
     assert spans[0]["context"]["destination"]["service"] == {
         "name": "http://127.0.0.1:%d" % waiting_httpserver.server_address[1],
         "resource": "127.0.0.1:%d" % waiting_httpserver.server_address[1],

--- a/tests/instrumentation/asyncio/aiohttp_client_tests.py
+++ b/tests/instrumentation/asyncio/aiohttp_client_tests.py
@@ -62,11 +62,44 @@ async def test_http_get(instrument, event_loop, elasticapm_client, waiting_https
     assert span["subtype"] == "http"
     assert span["sync"] is False
     assert span["context"]["http"]["url"] == waiting_httpserver.url
+    assert span["context"]["http"]["status_code"] == 200
     assert spans[0]["context"]["destination"]["service"] == {
         "name": "http://127.0.0.1:%d" % waiting_httpserver.server_address[1],
         "resource": "127.0.0.1:%d" % waiting_httpserver.server_address[1],
         "type": "external",
     }
+    assert spans[0]["outcome"] == "success"
+
+
+@pytest.mark.parametrize("status_code", [400, 500])
+async def test_http_get_error(instrument, event_loop, elasticapm_client, waiting_httpserver, status_code):
+    assert event_loop.is_running()
+    elasticapm_client.begin_transaction("test")
+    waiting_httpserver.serve_content("", code=status_code)
+    url = waiting_httpserver.url
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(waiting_httpserver.url) as resp:
+            status = resp.status
+            text = await resp.text()
+
+    elasticapm_client.end_transaction()
+    transaction = elasticapm_client.events[constants.TRANSACTION][0]
+    spans = elasticapm_client.spans_for_transaction(transaction)
+    assert len(spans) == 1
+    span = spans[0]
+    assert span["name"] == "GET %s:%s" % waiting_httpserver.server_address
+    assert span["type"] == "external"
+    assert span["subtype"] == "http"
+    assert span["sync"] is False
+    assert span["context"]["http"]["url"] == waiting_httpserver.url
+    assert span["context"]["http"]["status_code"] == status_code
+    assert spans[0]["context"]["destination"]["service"] == {
+        "name": "http://127.0.0.1:%d" % waiting_httpserver.server_address[1],
+        "resource": "127.0.0.1:%d" % waiting_httpserver.server_address[1],
+        "type": "external",
+    }
+    assert spans[0]["outcome"] == "failure"
 
 
 @pytest.mark.parametrize(

--- a/tests/instrumentation/base_tests.py
+++ b/tests/instrumentation/base_tests.py
@@ -228,7 +228,21 @@ def test_transaction_outcome(elasticapm_client, caplog, outcome, http_status_cod
         elasticapm.set_transaction_outcome(outcome=outcome, http_status_code=http_status_code)
     assert transaction.outcome == result
     if log_message is None:
-        assert not caplog.records
+        assert not [True for record in caplog.records if record.name == "elasticapm.traces"]
     else:
         record = caplog.records[0]
         assert log_message in record.getMessage()
+
+
+def test_transaction_outcome_override(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
+    elasticapm.set_transaction_outcome(constants.OUTCOME.FAILURE)
+
+    assert transaction.outcome == constants.OUTCOME.FAILURE
+
+    elasticapm.set_transaction_outcome(constants.OUTCOME.SUCCESS, override=False)
+    # still a failure
+    assert transaction.outcome == constants.OUTCOME.FAILURE
+
+    elasticapm.set_transaction_outcome(constants.OUTCOME.SUCCESS, override=True)
+    assert transaction.outcome == constants.OUTCOME.SUCCESS

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -59,11 +59,13 @@ def test_requests_instrumentation(instrument, elasticapm_client, waiting_httpser
     assert spans[0]["type"] == "external"
     assert spans[0]["subtype"] == "http"
     assert url == spans[0]["context"]["http"]["url"]
+    assert 200 == spans[0]["context"]["http"]["status_code"]
     assert spans[0]["context"]["destination"]["service"] == {
         "name": "http://127.0.0.1:%d" % parsed_url.port,
         "resource": "127.0.0.1:%d" % parsed_url.port,
         "type": "external",
     }
+    assert spans[0]["outcome"] == "success"
 
     assert constants.TRACEPARENT_HEADER_NAME in waiting_httpserver.requests[0].headers
     trace_parent = TraceParent.from_string(waiting_httpserver.requests[0].headers[constants.TRACEPARENT_HEADER_NAME])
@@ -72,6 +74,31 @@ def test_requests_instrumentation(instrument, elasticapm_client, waiting_httpser
     # this should be the span id of `requests`, not of urllib3
     assert trace_parent.span_id == spans[0]["id"]
     assert trace_parent.trace_options.recorded
+
+
+@pytest.mark.parametrize("status_code", [400, 500])
+def test_requests_instrumentation_error(instrument, elasticapm_client, waiting_httpserver, status_code):
+    waiting_httpserver.serve_content("", code=status_code)
+    url = waiting_httpserver.url + "/hello_world"
+    parsed_url = compat.urlparse.urlparse(url)
+    elasticapm_client.begin_transaction("transaction.test")
+    with capture_span("test_request", "test"):
+        requests.get(url, allow_redirects=False)
+    elasticapm_client.end_transaction("MyView")
+
+    transactions = elasticapm_client.events[TRANSACTION]
+    spans = elasticapm_client.spans_for_transaction(transactions[0])
+    assert spans[0]["name"].startswith("GET 127.0.0.1:")
+    assert spans[0]["type"] == "external"
+    assert spans[0]["subtype"] == "http"
+    assert url == spans[0]["context"]["http"]["url"]
+    assert status_code == spans[0]["context"]["http"]["status_code"]
+    assert spans[0]["context"]["destination"]["service"] == {
+        "name": "http://127.0.0.1:%d" % parsed_url.port,
+        "resource": "127.0.0.1:%d" % parsed_url.port,
+        "type": "external",
+    }
+    assert spans[0]["outcome"] == "failure"
 
 
 def test_requests_instrumentation_via_session(instrument, elasticapm_client, waiting_httpserver):

--- a/tests/instrumentation/urllib_tests.py
+++ b/tests/instrumentation/urllib_tests.py
@@ -39,7 +39,7 @@ from elasticapm.utils.disttracing import TraceParent
 
 try:
     from urllib.request import urlopen
-    from urllib.error import URLError
+    from urllib.error import URLError, HTTPError
 
     request_method = "http.client.HTTPConnection.request"
     getresponse_method = "http.client.HTTPConnection.getresponse"
@@ -77,16 +77,46 @@ def test_urllib(instrument, elasticapm_client, waiting_httpserver):
     assert spans[0]["type"] == "external"
     assert spans[0]["subtype"] == "http"
     assert spans[0]["context"]["http"]["url"] == url
+    assert spans[0]["context"]["http"]["status_code"] == 200
     assert spans[0]["context"]["destination"]["service"] == {
         "name": "http://127.0.0.1:%d" % parsed_url.port,
         "resource": "127.0.0.1:%d" % parsed_url.port,
         "type": "external",
     }
     assert spans[0]["parent_id"] == spans[1]["id"]
+    assert spans[0]["outcome"] == "success"
 
     assert spans[1]["name"] == "test_name"
     assert spans[1]["type"] == "test_type"
     assert spans[1]["parent_id"] == transactions[0]["id"]
+
+
+@pytest.mark.parametrize("status_code", [400, 500])
+def test_urllib_error(instrument, elasticapm_client, waiting_httpserver, status_code):
+    waiting_httpserver.serve_content("", code=status_code)
+    url = waiting_httpserver.url + "/hello_world"
+    parsed_url = urlparse.urlparse(url)
+    elasticapm_client.begin_transaction("transaction")
+    expected_sig = "GET {0}".format(parsed_url.netloc)
+    with capture_span("test_name", "test_type"):
+
+        url = "http://{0}/hello_world".format(parsed_url.netloc)
+        try:
+            r = urlopen(url)
+        except HTTPError:
+            pass
+
+    elasticapm_client.end_transaction("MyView")
+
+    transactions = elasticapm_client.events[TRANSACTION]
+    spans = elasticapm_client.spans_for_transaction(transactions[0])
+
+    assert spans[0]["name"] == expected_sig
+    assert spans[0]["type"] == "external"
+    assert spans[0]["subtype"] == "http"
+    assert spans[0]["context"]["http"]["url"] == url
+    assert spans[0]["context"]["http"]["status_code"] == status_code
+    assert spans[0]["outcome"] == "failure"
 
 
 @mock.patch(request_method)

--- a/tests/instrumentation/urllib_tests.py
+++ b/tests/instrumentation/urllib_tests.py
@@ -45,7 +45,7 @@ try:
     getresponse_method = "http.client.HTTPConnection.getresponse"
 except ImportError:
     from urllib2 import urlopen
-    from urllib2 import URLError
+    from urllib2 import URLError, HTTPError
 
     request_method = "httplib.HTTPConnection.request"
     getresponse_method = "httplib.HTTPConnection.getresponse"


### PR DESCRIPTION
This implements https://github.com/elastic/apm/pull/299.

Additionally, the "status_code" attribute has been added to HTTP spans.