### PR TITLE
move most of the setup.py metadata and requirements to setup.cfg

### DIFF
--- a/elasticapm/version.py
+++ b/elasticapm/version.py
@@ -28,5 +28,5 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = (5, 8, 1, "post0")
+__version__ = (5, 8, 1, "post1")
 VERSION = ".".join(map(str, __version__))

--- a/elasticapm/version.py
+++ b/elasticapm/version.py
@@ -28,5 +28,5 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = (5, 8, 1)
+__version__ = (5, 8, 1, "post0")
 VERSION = ".".join(map(str, __version__))

--- a/elasticapm/version.py
+++ b/elasticapm/version.py
@@ -28,5 +28,5 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = (5, 8, 1, "post1")
+__version__ = (5, 8, 1, "post2")
 VERSION = ".".join(map(str, __version__))

--- a/elasticapm/version.py
+++ b/elasticapm/version.py
@@ -28,5 +28,5 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = (5, 8, 1, "post2")
+__version__ = (5, 8, 1)
 VERSION = ".".join(map(str, __version__))

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,19 +14,19 @@ description = The official Python module for Elastic APM
 long_description = file: README.rst
 license = BSD
 classifiers =
-    "Intended Audience :: Developers",
-    "Intended Audience :: System Administrators",
-    "Operating System :: OS Independent",
-    "Topic :: Software Development",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "License :: OSI Approved :: BSD License",
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    Operating System :: OS Independent
+    Topic :: Software Development
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    License :: OSI Approved :: BSD License
 project_urls =
     Documentation = https://www.elastic.co/guide/en/apm/agent/python/current/index.html
     Release notes = https://www.elastic.co/guide/en/apm/agent/python/current/release-notes.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ universal=0
 [metadata]
 license_file = LICENSE
 name = elastic-apm
-version = attr: elasticapm.version.VERSION
 url = https://github.com/elastic/apm-agent-python
 author = Elastic, Inc
 description = The official Python module for Elastic APM

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,116 @@ universal=0
 
 [metadata]
 license_file = LICENSE
+name = elastic-apm
+version = attr: elasticapm.version.VERSION
+url = https://github.com/elastic/apm-agent-python
+author = Elastic, Inc
+description = The official Python module for Elastic APM
+long_description = file: README.rst
+license = BSD
+classifiers =
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "License :: OSI Approved :: BSD License",
+project_urls =
+    Documentation = https://www.elastic.co/guide/en/apm/agent/python/current/index.html
+    Release notes = https://www.elastic.co/guide/en/apm/agent/python/current/release-notes.html
+    Source = https://github.com/elastic/apm-agent-python
+    Tracker = https://github.com/elastic/apm-agent-python/issues
+
+[options]
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4
+packages = find:
+include_package_data = true
+zip_safe = false
+install_requires =
+    urllib3
+    certifi
+    cachetools;python_version=='2.7'
+test_suite=tests
+tests_require =
+    pytest==4.6.9
+    py==1.8.1
+    more-itertools==4.1.0
+    pluggy==0.13.1
+    pytest-django==3.8.0
+    atomicwrites==1.1.5
+    coverage==5.0.3
+    pytest-cov==2.8.1
+    pytest-localserver==0.5.0
+    pytest-mock==2.0.0
+    pytest-benchmark==3.2.2
+    jsonschema==2.6.0
+    configparser==4.0.2
+    contextlib2==0.6.0
+    importlib-metadata==1.5.0
+    packaging==20.1
+    Mako==1.1.0
+    glob2==0.7
+    parse==1.15.0
+    parse-type==0.5.2
+    pytest-bdd==3.2.1
+    pytest-rerunfailures==8.0
+
+
+    docutils==0.14
+    pathlib==1.0.1
+    py-cpuinfo==3.3.0
+    statistics==1.0.3.5
+
+    urllib3
+    certifi
+    Jinja2
+    Logbook
+    MarkupSafe
+    WebOb
+    Werkzeug
+    anyjson
+    argparse
+    blinker>=1.1
+    greenlet
+    itsdangerous
+    mock
+    msgpack-python
+    pep8
+    pytz
+
+    pytest-asyncio==0.10.0 ; python_version >= '3.7'
+    asynctest==0.12.2 ; python_version >= '3.7'
+    aiohttp ; python_version >= '3.7'
+    tornado ; python_version >= '3.7'
+    starlette ; python_version >= '3.7'
+    pytest-asyncio ; python_version >= '3.7'
+    pytest-mock ; python_version >= '3.7'
+
+    cachetools==2.0.1 ; python_version == '2.7'
+
+[options.extras_require]
+flask =
+    blinker
+aiohttp =
+    aiohttp
+tornado =
+    tornado
+starlette =
+    starlette
+opentracing =
+    opentracing>=2.0.0
+
+[options.packages.find]
+exclude =
+    tests
+    tests.*
 
 [tool:pytest]
 python_files=tests.py test_*.py *_tests.py

--- a/setup.py
+++ b/setup.py
@@ -50,15 +50,16 @@ for m in ("multiprocessing", "billiard"):
     except ImportError:
         pass
 
-import ast
 import os
 import sys
-from codecs import open
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
-from setuptools import Extension, find_packages, setup
+import pkg_resources
+from setuptools import Extension, setup
 from setuptools.command.test import test as TestCommand
+
+pkg_resources.require("setuptools>=39.2")
 
 if sys.platform == "win32":
     build_ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError, IOError)
@@ -84,67 +85,6 @@ class optional_build_ext(build_ext):
             raise BuildExtFailed()
 
 
-def get_version():
-    """
-    Get version without importing from elasticapm. This avoids any side effects
-    from importing while installing and/or building the module
-    :return: a string, indicating the version
-    """
-    version_file = open(os.path.join("elasticapm", "version.py"), encoding="utf-8")
-    for line in version_file:
-        if line.startswith("__version__"):
-            version_tuple = ast.literal_eval(line.split(" = ")[1])
-            return ".".join(map(str, version_tuple))
-    return "unknown"
-
-
-tests_require = [
-    "py>=1.4.26",
-    "pytest>=2.6.4",
-    "pytest-django==2.8.0",
-    "pytest-capturelog>=0.7",
-    "blinker>=1.1",
-    "celery",
-    "django-celery",
-    "Flask>=0.8",
-    "starlette",
-    "logbook",
-    "mock",
-    "pep8",
-    "webob",
-    "pytz",
-    "redis",
-    "requests",
-    "jinja2",
-    "pytest-benchmark",
-    "urllib3-mock",
-    "Twisted",
-    # isort
-    "apipkg",
-    "execnet",
-    "isort",
-    "pytest-cache",
-    "pytest-isort",
-    "graphene"
-]
-
-if sys.version_info[0] == 2:
-    tests_require += ["unittest2", "python-memcached"]
-else:
-    tests_require += ["python3-memcached"]
-
-
-try:
-    import __pypy__
-except ImportError:
-    tests_require += ["psycopg2"]
-
-if sys.version_info >= (3, 5):
-    tests_require += ["aiohttp", "tornado", "starlette", "pytest-asyncio", "pytest-mock"]
-
-install_requires = ["urllib3", "certifi", "cachetools;python_version=='2.7'"]
-
-
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
@@ -165,47 +105,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-setup_kwargs = dict(
-    name="elastic-apm",
-    version=get_version(),
-    author="Elastic, Inc",
-    license="BSD",
-    url="https://github.com/elastic/apm-agent-python",
-    description="The official Python module for Elastic APM",
-    long_description=open(os.path.join(os.path.dirname(__file__), "README.rst"), encoding="utf-8").read(),
-    packages=find_packages(exclude=("tests",)),
-    zip_safe=False,
-    install_requires=install_requires,
-    tests_require=tests_require,
-    extras_require={
-        "tests": tests_require,
-        "flask": ["blinker"],
-        "aiohttp": ["aiohttp"],
-        "tornado": ["tornado"],
-        "starlette": ["starlette"],
-        "opentracing": ["opentracing>=2.0.0"],
-    },
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
-    cmdclass={"test": PyTest},
-    test_suite="tests",
-    include_package_data=True,
-    entry_points={"paste.filter_app_factory": ["elasticapm = elasticapm.contrib.paste:filter_factory"]},
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "Operating System :: OS Independent",
-        "Topic :: Software Development",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "License :: OSI Approved :: BSD License",
-    ],
-)
+setup_kwargs = dict(cmdclass={"test": PyTest})
 
 
 def run_setup(with_extensions):


### PR DESCRIPTION
This should make this information easier to discover for tools like Snyk.

Also, it's the new and fresh way to do things :)

