### PR TITLE
[CI] skip pre/post tags when opbeans-python version bump

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -295,6 +295,13 @@ pipeline {
           environment {
             REPO_NAME = "${OPBEANS_REPO}"
           }
+          when {
+            beforeInput true
+            anyOf {
+              tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+              expression { return params.Run_As_Master_Branch }
+            }
+          }
           steps {
             deleteDir()
             dir("${OPBEANS_REPO}"){


### PR DESCRIPTION
## What does this pull request do?

Use `<major>.<minor>.<patch>` versions when bumping the agent version in the opbeans-python