### PR TITLE
Rename variable elasticapm to apm

### DIFF
--- a/docs/starlette.asciidoc
+++ b/docs/starlette.asciidoc
@@ -37,9 +37,9 @@ To initialize the agent for your application using environment variables:
 from starlette.applications import Starlette
 from elasticapm.contrib.starlette import make_apm_client, ElasticAPM
 
-elasticapm = make_apm_client()
+apm = make_apm_client()
 app = Starlette()
-app.add_middleware(ElasticAPM, client=elasticapm)
+app.add_middleware(ElasticAPM, client=apm)
 ----
 
 To configure the agent using initialization arguments:
@@ -49,12 +49,12 @@ To configure the agent using initialization arguments:
 from starlette.applications import Starlette
 from elasticapm.contrib.starlette import make_apm_client, ElasticAPM
 
-elasticapm = make_apm_client({
+apm = make_apm_client({
     'SERVICE_NAME': '<SERVICE-NAME>',
     'SECRET_TOKEN': '<SECRET-TOKEN>',
 })
 app = Starlette()
-app.add_middleware(ElasticAPM, client=elasticapm)
+app.add_middleware(ElasticAPM, client=apm)
 ----
 
 [float]
@@ -69,9 +69,9 @@ is almost exactly the same as with Starlette:
 from fastapi import FastAPI
 from elasticapm.contrib.starlette import make_apm_client, ElasticAPM
 
-elasticapm = make_apm_client()
+apm = make_apm_client()
 app = FastAPI()
-app.add_middleware(ElasticAPM, client=elasticapm)
+app.add_middleware(ElasticAPM, client=apm)
 ----
 
 [float]
@@ -123,7 +123,7 @@ list of regular expressions which are matched against the transaction name:
 
 [source,python]
 ----
-elasticapm = make_apm_client({
+apm = make_apm_client({
     # ...
     'TRANSACTIONS_IGNORE_PATTERNS': ['^GET /secret', '/extra_secret']
     # ...


### PR DESCRIPTION
## What does this pull request do?

* Rename variable `elasticapm` to `apm` so that the code works for the examples `apm.client.capture_exception()` and `apm.client.capture_message('hello, world!')` in the [usage section](https://www.elastic.co/guide/en/apm/agent/python/master/starlette-support.html#starlette-usage)
* Also, avoids conflicts when `import elasticapm` is also used