### PR TITLE
added testing utility to capture messages from given logger

### DIFF
--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -30,7 +30,6 @@
 
 import decimal
 import logging
-import time
 from collections import defaultdict
 
 import mock
@@ -40,6 +39,7 @@ import elasticapm
 from elasticapm.conf import Config
 from elasticapm.conf.constants import SPAN, TRANSACTION
 from elasticapm.traces import Tracer, capture_span, execution_context
+from tests.utils import capture_from_logger
 
 
 @pytest.fixture()
@@ -229,9 +229,9 @@ def test_label_transaction():
 
 
 def test_label_while_no_transaction(caplog):
-    with caplog.at_level(logging.WARNING, "elasticapm.errors"):
+    with capture_from_logger(caplog, logging.WARNING, "elasticapm.errors") as records:
         elasticapm.label(foo="bar")
-    record = caplog.records[0]
+    record = records[0]
     assert record.levelno == logging.WARNING
     assert "foo" in record.args
 
@@ -308,9 +308,9 @@ def test_tag_transaction():
 
 
 def test_tag_while_no_transaction(caplog):
-    with caplog.at_level(logging.WARNING, "elasticapm.errors"):
+    with capture_from_logger(caplog, logging.WARNING, "elasticapm.errors") as records:
         elasticapm.tag(foo="bar")
-    record = caplog.records[0]
+    record = records[0]
     assert record.levelno == logging.WARNING
     assert "foo" in record.args
 

--- a/tests/metrics/base_tests.py
+++ b/tests/metrics/base_tests.py
@@ -38,6 +38,7 @@ import pytest
 from elasticapm.conf import constants
 from elasticapm.metrics.base_metrics import Counter, Gauge, MetricsRegistry, MetricsSet, NoopMetric, Timer
 from tests.fixtures import TempStoreClient
+from tests.utils import capture_from_logger
 
 
 class DummyMetricSet(MetricsSet):
@@ -128,7 +129,7 @@ def test_metrics_multithreaded(elasticapm_client):
 @mock.patch("elasticapm.metrics.base_metrics.DISTINCT_LABEL_LIMIT", 3)
 def test_metric_limit(caplog, elasticapm_client):
     m = MetricsSet(MetricsRegistry(elasticapm_client))
-    with caplog.at_level(logging.WARNING, logger="elasticapm.metrics"):
+    with capture_from_logger(caplog, logging.WARNING, logger="elasticapm.metrics") as records:
         for i in range(2):
             counter = m.counter("counter", some_label=i)
             gauge = m.gauge("gauge", some_label=i)
@@ -142,8 +143,8 @@ def test_metric_limit(caplog, elasticapm_client):
                 assert isinstance(gauge, NoopMetric)
                 assert isinstance(counter, NoopMetric)
 
-    assert len(caplog.records) == 1
-    record = caplog.records[0]
+    assert len(records) == 1
+    record = records[0]
     assert "The limit of 3 metricsets has been reached" in record.message
 
 

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -42,6 +42,7 @@ import elasticapm
 from elasticapm import Client, processors
 from elasticapm.conf.constants import BASE_SANITIZE_FIELD_NAMES, ERROR, SPAN, TRANSACTION
 from elasticapm.utils import compat
+from tests.utils import capture_from_logger
 
 
 @pytest.fixture()
@@ -464,12 +465,12 @@ def test_drop_events_in_processor(elasticapm_client, caplog):
     shouldnt_be_called_processor = mock.Mock(event_types=[])
 
     elasticapm_client._transport._processors = [dropping_processor, shouldnt_be_called_processor]
-    with caplog.at_level(logging.DEBUG, logger="elasticapm.transport"):
+    with capture_from_logger(caplog, logging.DEBUG, logger="elasticapm.transport") as records:
         elasticapm_client.queue(SPAN, {"some": "data"})
     assert dropping_processor.call_count == 1
     assert shouldnt_be_called_processor.call_count == 0
     assert elasticapm_client._transport.events[SPAN][0] is None
-    record = caplog.records[0]
+    record = records[0]
     assert record.message == "Dropped event of type span due to processor mock.mock.dropper"
     assert record.levelname == "DEBUG"
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -27,7 +27,28 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import contextlib
 
 
 def assert_any_record_contains(records, message):
     assert any(message in record.message for record in records)
+
+
+@contextlib.contextmanager
+def capture_from_logger(caplog, level, logger):
+    """
+    Captures records from given logger *only*.
+
+    We use caplog.at_level to capture log messages, then filter out messages from other loggers.
+
+    The records will only be available after leaving the context manager
+
+    :param caplog: a pytest caplog fixture
+    :param level: the desired level
+    :param logger: the desired logger
+    :return:
+    """
+    container = []
+    with caplog.at_level(level, logger=logger):
+        yield container
+    container.extend(record for record in caplog.records if record.name == logger)

--- a/tests/utils/test_disttracing_header.py
+++ b/tests/utils/test_disttracing_header.py
@@ -30,10 +30,12 @@
 
 from __future__ import absolute_import
 
+import logging
+
 import pytest
 
 from elasticapm.utils.disttracing import TraceParent
-from tests.utils import assert_any_record_contains
+from tests.utils import assert_any_record_contains, capture_from_logger
 
 
 @pytest.mark.parametrize("tracing_bits,expected", [("00", {"recorded": 0}), ("01", {"recorded": 1})])
@@ -59,32 +61,32 @@ def test_trace_parent_to_str():
 
 def test_trace_parent_wrong_version(caplog):
     header = "xx-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
-    with caplog.at_level("DEBUG", "elasticapm.utils"):
+    with capture_from_logger(caplog, logging.DEBUG, "elasticapm.utils") as records:
         trace_parent = TraceParent.from_string(header)
     assert trace_parent is None
-    assert_any_record_contains(caplog.records, "Invalid version field, value xx")
+    assert_any_record_contains(records, "Invalid version field, value xx")
 
 
 def test_trace_parent_wrong_version_255(caplog):
     """Version FF or 255 is explicitly forbidden"""
     header = "ff-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-03"
-    with caplog.at_level("DEBUG", "elasticapm.utils"):
+    with capture_from_logger(caplog, logging.DEBUG, "elasticapm.utils") as records:
         trace_parent = TraceParent.from_string(header)
     assert trace_parent is None
-    assert_any_record_contains(caplog.records, "Invalid version field, value 255")
+    assert_any_record_contains(records, "Invalid version field, value 255")
 
 
 def test_trace_parent_wrong_trace_options_field(caplog):
     header = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-xx"
-    with caplog.at_level("DEBUG", "elasticapm.utils"):
+    with capture_from_logger(caplog, logging.DEBUG, "elasticapm.utils") as records:
         trace_parent = TraceParent.from_string(header)
     assert trace_parent is None
-    assert_any_record_contains(caplog.records, "Invalid trace-options field, value xx")
+    assert_any_record_contains(records, "Invalid trace-options field, value xx")
 
 
 def test_trace_parent_wrong_format(caplog):
     header = "00"
-    with caplog.at_level("DEBUG", "elasticapm.utils"):
+    with capture_from_logger(caplog, logging.DEBUG, "elasticapm.utils") as records:
         trace_parent = TraceParent.from_string(header)
     assert trace_parent is None
-    assert_any_record_contains(caplog.records, "Invalid traceparent header format, value 00")
+    assert_any_record_contains(records, "Invalid traceparent header format, value 00")


### PR DESCRIPTION
## What does this pull request do?

So far, the usage of caplog.at_level in our code base was erroneous. It assumed that when providing a logger, only messages of that logger would appear in caplog.records. Instead, it would only set the level on the logger, but capture all logs with the given level. This could lead to flaky tests if other code would log at that level during the test.

