### PR TITLE
disable building binary wheels for pypy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,7 +169,8 @@ pipeline {
               dir("${BASE_DIR}"){
                 sh script: 'pip3 install --user cibuildwheel', label: "Installing cibuildwheel"
                 sh script: 'mkdir wheelhouse', label: "creating wheelhouse"
-                sh script: 'cibuildwheel --platform linux --output-dir wheelhouse; ls -l wheelhouse'
+                // skip pypy builds with CIBW_SKIP=pp*
+                sh script: 'CIBW_SKIP="pp*" cibuildwheel --platform linux --output-dir wheelhouse; ls -l wheelhouse'
               }
               stash allowEmpty: true, name: 'packages', includes: "${BASE_DIR}/wheelhouse/*.whl,${BASE_DIR}/dist/*.tar.gz", useDefaultExcludes: false
             }


### PR DESCRIPTION
## What does this pull request do?

The wrapt c-extension doesn't build with pypy, and our setup.py skips building the extension
when it detects pypy. However, we still mistakenly built pypy-specific binary wheels.

cibuildwheel introduced a check for this in 1.6, alerting us to the problem.