### PR TITLE
Update httpcore instrumentation for 0.11.0 compatibility

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -287,16 +287,22 @@ exclude:
   - PYTHON_VERSION: pypy-2
     FRAMEWORK: httpx-0.13
   - PYTHON_VERSION: pypy-2
+    FRAMEWORK: httpx-0.14
+  - PYTHON_VERSION: pypy-2
     FRAMEWORK: httpx-newest
   - PYTHON_VERSION: python-2.7
     FRAMEWORK: httpx-0.12
   - PYTHON_VERSION: python-2.7
     FRAMEWORK: httpx-0.13
   - PYTHON_VERSION: python-2.7
+    FRAMEWORK: httpx-0.14
+  - PYTHON_VERSION: python-2.7
     FRAMEWORK: httpx-newest
   - PYTHON_VERSION: python-3.5
     FRAMEWORK: httpx-0.12
   - PYTHON_VERSION: python-3.5
     FRAMEWORK: httpx-0.13
+  - PYTHON_VERSION: python-3.5
+    FRAMEWORK: httpx-0.14
   - PYTHON_VERSION: python-3.5
     FRAMEWORK: httpx-newest

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -74,4 +74,5 @@ FRAMEWORK:
   - graphene-2
   - httpx-0.12
   - httpx-0.13
+  - httpx-0.14
   - httpx-newest

--- a/elasticapm/instrumentation/packages/httpcore.py
+++ b/elasticapm/instrumentation/packages/httpcore.py
@@ -96,8 +96,14 @@ class HTTPCoreInstrumentation(AbstractInstrumentedModule):
                 )
                 self._set_disttracing_headers(headers, trace_parent, transaction)
             response = wrapped(*args, **kwargs)
-            # response = (http_version, status_code, reason_phrase, headers, stream)
-            status_code = response[1]
+            if len(response) > 4:
+                # httpcore < 0.11.0
+                # response = (http_version, status_code, reason_phrase, headers, stream)
+                status_code = response[1]
+            else:
+                # httpcore >= 0.11.0
+                # response = (status_code, headers, stream, ext)
+                status_code = response[0]
             if status_code:
                 if span.context:
                     span.context["http"]["status_code"] = status_code

--- a/tests/requirements/reqs-httpx-0.14.txt
+++ b/tests/requirements/reqs-httpx-0.14.txt
@@ -1,2 +1,2 @@
-httpx>=0.15.0
+httpx==0.14.*
 -r reqs-base.txt


### PR DESCRIPTION
This fixes the httpx tests that are failing since the 0.11.0 release of httpcore (and the 0.15.0 release of httpx).

Just a small API change for retrieving the status code, and the async version of requests in httpcore is now `arequest` instead of `request` for namespacing.