### PR TITLE
Upgrade to isort v5.5.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 repos:
-# seed-isort-config disabled for now, see https://github.com/asottile/seed-isort-config/issues/10
-#-   repo: https://github.com/asottile/seed-isort-config
-#    rev: v1.1.0
-#    hooks:
-#    -   id: seed-isort-config
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+-   repo: https://github.com/pycqa/isort
+    rev: 5.5.4
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILD_DIR?=build
 SHELL := /bin/bash
 
 isort:
-	isort -rc -vb .
+	isort --vb .
 
 flake8:
 	flake8

--- a/elasticapm/contrib/django/apps.py
+++ b/elasticapm/contrib/django/apps.py
@@ -97,7 +97,8 @@ class ElasticAPMConfig(AppConfig):
 
 
 def register_handlers(client):
-    from django.core.signals import got_request_exception, request_started, request_finished
+    from django.core.signals import got_request_exception, request_finished, request_started
+
     from elasticapm.contrib.django.handlers import exception_handler
 
     # Connect to Django's internal signal handlers
@@ -119,6 +120,7 @@ def register_handlers(client):
     # If we can import celery, register ourselves as exception handler
     try:
         import celery  # noqa F401
+
         from elasticapm.contrib.celery import register_exception_tracking
 
         try:
@@ -156,6 +158,7 @@ def instrument(client):
     instrument()
     try:
         import celery  # noqa F401
+
         from elasticapm.contrib.celery import register_instrumentation
 
         register_instrumentation(client)

--- a/elasticapm/contrib/opentracing/span.py
+++ b/elasticapm/contrib/opentracing/span.py
@@ -37,8 +37,8 @@ from elasticapm.utils.logging import get_logger
 
 try:
     # opentracing-python 2.1+
-    from opentracing import tags
     from opentracing import logs as ot_logs
+    from opentracing import tags
 except ImportError:
     # opentracing-python <2.1
     from opentracing.ext import tags

--- a/elasticapm/instrumentation/packages/tornado.py
+++ b/elasticapm/instrumentation/packages/tornado.py
@@ -88,6 +88,7 @@ class TornadoHandleRequestExceptionInstrumentation(AbstractInstrumentedModule):
 
         # Late import to avoid ImportErrors
         from tornado.web import Finish, HTTPError
+
         from elasticapm.contrib.tornado.utils import get_data_from_request
 
         e = args[0]

--- a/elasticapm/utils/compat.py
+++ b/elasticapm/utils/compat.py
@@ -77,11 +77,12 @@ PY3 = sys.version_info[0] == 3
 
 
 if PY2:
-    import StringIO
+    from urllib import getproxies_environment, proxy_bypass_environment  # noqa F401
+
     import Queue as queue  # noqa F401
+    import StringIO
     import urlparse  # noqa F401
     from urllib2 import HTTPError  # noqa F401
-    from urllib import proxy_bypass_environment, getproxies_environment  # noqa F401
 
     StringIO = BytesIO = StringIO.StringIO
 
@@ -113,7 +114,7 @@ else:
     import queue  # noqa F401
     from urllib import parse as urlparse  # noqa F401
     from urllib.error import HTTPError  # noqa F401
-    from urllib.request import proxy_bypass_environment, getproxies_environment  # noqa F401
+    from urllib.request import getproxies_environment, proxy_bypass_environment  # noqa F401
 
     StringIO = io.StringIO
     BytesIO = io.BytesIO

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,9 +120,6 @@ exclude =
 
 [tool:pytest]
 python_files=tests.py test_*.py *_tests.py
-isort_ignore=
-    elasticapm/transport/asyncio.py
-    elasticapm/contrib/asyncio/client.py
 markers =
     integrationtest: mark a test as integration test that accesses a service (like postgres, mongodb etc.)
     bdd: mark a test as behavioral test
@@ -157,17 +154,9 @@ markers =
 
 [isort]
 line_length=120
-indent='    '
-not_skip=__init__.py
 skip=wrapt,setup.py,build,src,elasticapm/__init__.py
 multi_line_output=3
 include_trailing_comma=true
-known_standard_library=importlib,types,asyncio,contextvars
-known_django=django
-known_first_party=elasticapm,tests
-known_third_party=StringIO,__pypy__,aiohttp,async_timeout,boto3,cachetools,cassandra,celery,certifi,elasticsearch,flask,jinja2,jsonschema,logbook,memcache,mock,pkg_resources,psycopg2,psycopg2cffi,pymongo,pytest,pytest_localserver,redis,requests,setuptools,simplejson,twisted,urllib2,urllib3,urllib3_mock,urlparse,uwsgi,webob,werkzeug,zope,asynctest,opentracing,eventlet,tornado,starlette,multidict,pytest_bdd,pymemcache,graphene,httpx
-default_section=FIRSTPARTY
-sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [coverage:run]
 include =

--- a/tests/client/exception_tests.py
+++ b/tests/client/exception_tests.py
@@ -196,7 +196,8 @@ def test_collect_source_errors(elasticapm_client):
     library_frame_context = elasticapm_client.config.source_lines_error_library_frames
     in_app_frame_context = elasticapm_client.config.source_lines_error_app_frames
     try:
-        import json, datetime
+        import datetime
+        import json
 
         json.dumps(datetime.datetime.now())
     except TypeError:

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -40,6 +40,7 @@ import logging
 import os
 from copy import deepcopy
 
+import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.redirects.models import Redirect
@@ -53,8 +54,6 @@ from django.http.cookie import SimpleCookie
 from django.test.client import Client as _TestClient
 from django.test.client import ClientHandler as _TestClientHandler
 from django.test.utils import override_settings
-
-import mock
 
 from elasticapm.base import Client
 from elasticapm.conf import constants

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -28,9 +28,8 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from django.apps import apps
-
 import pytest
+from django.apps import apps
 
 from elasticapm.conf.constants import SPAN
 from elasticapm.contrib.django.apps import instrument, register_handlers

--- a/tests/contrib/django/testapp/celery.py
+++ b/tests/contrib/django/testapp/celery.py
@@ -30,9 +30,8 @@
 
 from __future__ import absolute_import
 
-from django.conf import settings
-
 from celery import Celery
+from django.conf import settings
 
 app = Celery("testapp")
 

--- a/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
@@ -35,9 +35,9 @@ pytest.importorskip("elasticsearch_async")  # isort:skip
 import os
 
 from elasticsearch import VERSION as ES_VERSION
+from elasticsearch_async import AsyncElasticsearch
 
 from elasticapm.conf.constants import TRANSACTION
-from elasticsearch_async import AsyncElasticsearch
 
 pytestmark = [pytest.mark.elasticsearch, pytest.mark.asyncio, pytest.mark.integrationtest]
 

--- a/tests/instrumentation/django_tests/template_tests.py
+++ b/tests/instrumentation/django_tests/template_tests.py
@@ -35,9 +35,8 @@ pytest.importorskip("django")  # isort:skip
 from os.path import join
 
 import django
-from django.test.utils import override_settings
-
 import pytest
+from django.test.utils import override_settings
 
 from elasticapm.conf.constants import TRANSACTION
 from tests.contrib.django.conftest import BASE_TEMPLATE_DIR

--- a/tests/instrumentation/urllib_tests.py
+++ b/tests/instrumentation/urllib_tests.py
@@ -38,14 +38,13 @@ from elasticapm.utils.compat import urlparse
 from elasticapm.utils.disttracing import TraceParent
 
 try:
+    from urllib.error import HTTPError, URLError
     from urllib.request import urlopen
-    from urllib.error import URLError, HTTPError
 
     request_method = "http.client.HTTPConnection.request"
     getresponse_method = "http.client.HTTPConnection.getresponse"
 except ImportError:
-    from urllib2 import urlopen
-    from urllib2 import URLError, HTTPError
+    from urllib2 import HTTPError, URLError, urlopen
 
     request_method = "httplib.HTTPConnection.request"
     getresponse_method = "httplib.HTTPConnection.getresponse"


### PR DESCRIPTION
While I was fixing `isort` behavior in my IDE for the umpteenth time, I noticed that we're running a fairly old version of isort. After reading the [guide to upgrading to 5.x](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/) I realized we were missing out on some real goodness in terms of `isort`'s ability to automatically categorize imports and the like.

You'll note that the changes in actual behavior were pretty minimal, despite removing most of our isort config.

The biggest change to moving to a largely default config was that django is now not its own section. You'll see from the diff that that's actually not a very big deal, but I'm open to reintroducing that as a section if we want to.

@beniwohli Thoughts?