### PR TITLE
Extend asyncpg instrumentation in Elastic APM

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -46,6 +46,9 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
     instrument_list = [
         ("asyncpg.connection", "Connection.execute"),
         ("asyncpg.connection", "Connection.executemany"),
+        ("asyncpg.connection", "Connection.fetch"),
+        ("asyncpg.connection", "Connection.fetchval"),
+        ("asyncpg.connection", "Connection.fetchrow"),
     ]
 
     async def call(self, module, method, wrapped, instance, args, kwargs):


### PR DESCRIPTION
## What does this pull request do?

Issue #889 added instrumentation for asyncpg, though only `execute` and
`executemany` were instrumented. This extends the instrumentation to
include `fetch`, `fetchval` and `fetchrow` methods.
