### PR TITLE
Include whole body for elasticsearch-py queries

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,8 @@ endif::[]
 [float]
 ===== Bug fixes
 
+* Fix to collect the whole query body in `elasticsearch-py` {pull}940[#940]
+
 
 [[release-notes-5.x]]
 === Python Agent version 5.x

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -70,8 +70,8 @@ class ElasticSearchConnectionMixin(object):
                 # 'q' is already encoded to a byte string at this point
                 # we assume utf8, which is the default
                 query.append("q=" + params["q"].decode("utf-8", errors="replace"))
-            if isinstance(body, dict) and "query" in body:
-                query.append(json.dumps(body["query"], default=compat.text_type))
+            if body and isinstance(body, dict):
+                query.append(json.dumps(body, default=compat.text_type))
             if query:
                 context["db"]["statement"] = "\n\n".join(query)
         elif api_method == "update":

--- a/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
@@ -127,15 +127,15 @@ async def test_create(instrument, elasticapm_client, async_elasticsearch):
 
 async def test_search_body(instrument, elasticapm_client, async_elasticsearch):
     await async_elasticsearch.create(
-        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
+        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola", "userid": 1}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    search_query = {"query": {"term": {"user": "kimchy"}}}
+    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}
     result = await async_elasticsearch.search(body=search_query, params=None)
     elasticapm_client.end_transaction("test", "OK")
 
     transaction = elasticapm_client.events[TRANSACTION][0]
-    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola"}
+    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola", "userid": 1}
     spans = elasticapm_client.spans_for_transaction(transaction)
     assert len(spans) == 1
     span = spans[0]
@@ -145,7 +145,7 @@ async def test_search_body(instrument, elasticapm_client, async_elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
     assert span["sync"] is False
 
 
@@ -168,7 +168,7 @@ async def test_count_body(instrument, elasticapm_client, async_elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
     assert span["sync"] is False
 
 
@@ -189,5 +189,5 @@ async def test_delete_by_query_body(instrument, elasticapm_client, async_elastic
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
     assert span["sync"] is False

--- a/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
@@ -145,7 +145,10 @@ async def test_search_body(instrument, elasticapm_client, async_elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+    assert (
+        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
+    )
     assert span["sync"] is False
 
 

--- a/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/async_elasticsearch_client_tests.py
@@ -146,7 +146,7 @@ async def test_search_body(instrument, elasticapm_client, async_elasticsearch):
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
     assert (
-        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        span["context"]["db"]["statement"] == '{"sort": ["userid"], "query": {"term": {"user": "kimchy"}}}'
         or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
     )
     assert span["sync"] is False

--- a/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
@@ -145,7 +145,7 @@ async def test_search_body(instrument, elasticapm_client, elasticsearch_async):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
+    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
     assert span["sync"] is False
 
 

--- a/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
@@ -146,7 +146,7 @@ async def test_search_body(instrument, elasticapm_client, elasticsearch_async):
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
     assert (
-        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        span["context"]["db"]["statement"] == '{"sort": ["userid"], "query": {"term": {"user": "kimchy"}}}'
         or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
     )
     assert span["sync"] is False

--- a/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
@@ -145,7 +145,10 @@ async def test_search_body(instrument, elasticapm_client, elasticsearch_async):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+    assert (
+        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
+    )
     assert span["sync"] is False
 
 

--- a/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
+++ b/tests/instrumentation/asyncio_tests/elasticsearch_async_client_tests.py
@@ -127,15 +127,15 @@ async def test_create(instrument, elasticapm_client, elasticsearch_async):
 
 async def test_search_body(instrument, elasticapm_client, elasticsearch_async):
     await elasticsearch_async.create(
-        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
+        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola", "userid": 1}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    search_query = {"query": {"term": {"user": "kimchy"}}}
+    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}
     result = await elasticsearch_async.search(body=search_query, params=None)
     elasticapm_client.end_transaction("test", "OK")
 
     transaction = elasticapm_client.events[TRANSACTION][0]
-    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola"}
+    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola", "userid": 1}
     spans = elasticapm_client.spans_for_transaction(transaction)
     assert len(spans) == 1
     span = spans[0]
@@ -145,7 +145,7 @@ async def test_search_body(instrument, elasticapm_client, elasticsearch_async):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
     assert span["sync"] is False
 
 
@@ -168,7 +168,7 @@ async def test_count_body(instrument, elasticapm_client, elasticsearch_async):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
     assert span["sync"] is False
 
 
@@ -190,5 +190,5 @@ async def test_delete_by_query_body(instrument, elasticapm_client, elasticsearch
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
     assert span["sync"] is False

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -338,7 +338,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
+    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
 
 
 @pytest.mark.integrationtest

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -323,7 +323,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
         index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["text"]}
+    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["text.keyword"]}
     result = elasticsearch.search(body=search_query, params=None)
     elasticapm_client.end_transaction("test", "OK")
 
@@ -338,7 +338,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["text"]}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["text.keyword"]}'
 
 
 @pytest.mark.integrationtest

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -323,7 +323,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
         index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    search_query = {"query": {"term": {"user": "kimchy"}}}
+    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["text"]}
     result = elasticsearch.search(body=search_query, params=None)
     elasticapm_client.end_transaction("test", "OK")
 
@@ -338,7 +338,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["text"]}'
 
 
 @pytest.mark.integrationtest
@@ -390,7 +390,7 @@ def test_search_both(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == 'q=text:hola\n\n{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == 'q=text:hola\n\n{"query": {"term": {"user": "kimchy"}}}'
 
 
 @pytest.mark.integrationtest
@@ -416,7 +416,7 @@ def test_count_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
 
 
 @pytest.mark.integrationtest
@@ -483,7 +483,7 @@ def test_delete_by_query_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"term": {"user": "kimchy"}}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}}'
 
 
 @pytest.mark.integrationtest

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -320,10 +320,10 @@ def test_update_document(instrument, elasticapm_client, elasticsearch):
 @pytest.mark.integrationtest
 def test_search_body(instrument, elasticapm_client, elasticsearch):
     elasticsearch.create(
-        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola"}, refresh=True
+        index="tweets", doc_type=document_type, id=1, body={"user": "kimchy", "text": "hola", "userid": 1}, refresh=True
     )
     elasticapm_client.begin_transaction("test")
-    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["text.keyword"]}
+    search_query = {"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}
     result = elasticsearch.search(body=search_query, params=None)
     elasticapm_client.end_transaction("test", "OK")
 
@@ -338,7 +338,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["text.keyword"]}'
+    assert span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
 
 
 @pytest.mark.integrationtest

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -339,7 +339,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
     assert (
-        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        span["context"]["db"]["statement"] == '{"sort": ["userid"], "query": {"term": {"user": "kimchy"}}}'
         or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
     )
 

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -328,7 +328,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     elasticapm_client.end_transaction("test", "OK")
 
     transaction = elasticapm_client.events[TRANSACTION][0]
-    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola"}
+    assert result["hits"]["hits"][0]["_source"] == {"user": "kimchy", "text": "hola", "userid": 1}
     spans = elasticapm_client.spans_for_transaction(transaction)
     assert len(spans) == 1
     span = spans[0]

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -338,7 +338,10 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+    assert (
+        span["context"]["db"]["statement"] == '"sort": ["userid"]}, {"query": {"term": {"user": "kimchy"}}'
+        or span["context"]["db"]["statement"] == '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
+    )
 
 
 @pytest.mark.integrationtest


### PR DESCRIPTION
See https://discuss.elastic.co/t/apm-not-showing-aggregation/250762
for context.

Basically, by only including the query, we risk missing very useful
pieces of the query for diagnosing issues -- `aggs` is the big problem
here but I don't see why the user wouldn't want the entire query every
time.