### PR TITLE
Add log_level config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
  * Implement "sample_rate" property for transactions and spans, and propagate through tracestate {pull}891[#891]
  * Add support for callbacks on config changes {pull}912[#912]
  * Override `sys.excepthook` to catch all exceptions {pull}943[#943]
+ * Implement `log_level` config (supports central config) {pull}946[#946]
 
 [float]
 ===== Bug fixes

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -170,7 +170,7 @@ The transport class to use when sending events to the APM Server.
 [options="header"]
 |============
 | Environment             | Django/Flask | Default
-| `ELASTIC_APM_LOG_LEVEL` | `LOG_LEVEL`  | `"info"`
+| `ELASTIC_APM_LOG_LEVEL` | `LOG_LEVEL`  |
 |============
 
 The `logging.logLevel` at which the `elasticapm` logger will log. Available
@@ -189,7 +189,8 @@ Options are case-insensitive.
 Note that this option doesn't do anything with logging handlers. In order
 for any logs to be visible, you must either configure a handler
 (https://docs.python.org/3/library/logging.html#logging.basicConfig[`logging.basicConfig`]
-will do this for you) or set <<config-log_file>>.
+will do this for you) or set <<config-log_file>>. This will also override
+any log level your app has set for the `elasticapm` logger.
 
 [float]
 [[config-log_file]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -157,6 +157,69 @@ but the agent will continue to poll the server for configuration changes.
 
 The transport class to use when sending events to the APM Server.
 
+[float]
+[[logging-options]]
+=== Logging Options
+
+[float]
+[[config-log_level]]
+==== `log_level`
+
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+
+[options="header"]
+|============
+| Environment             | Django/Flask | Default
+| `ELASTIC_APM_LOG_LEVEL` | `LOG_LEVEL`  | `"info"`
+|============
+
+The `logging.logLevel` at which the `elasticapm` logger will log. Available
+options are:
+
+* `"off"` (sets `logging.logLevel` to 1000)
+* `"critical"`
+* `"error"`
+* `"warning"`
+* `"info"`
+* `"debug"`
+* `"trace"` (sets `logging.log_level` to 5)
+
+Options are case-insensitive.
+
+Note that this option doesn't do anything with logging handlers. In order
+for any logs to be visible, you must either configure a handler
+(https://docs.python.org/3/library/logging.html#logging.basicConfig[`logging.basicConfig`]
+will do this for you) or set <<config-log_file>>.
+
+[float]
+[[config-log_file]]
+==== `log_file`
+
+[options="header"]
+|============
+| Environment             | Django/Flask | Default | Example
+| `ELASTIC_APM_LOG_FILE` | `LOG_FILE`    | `""`    | `"/var/log/elasticapm/log.txt"`
+|============
+
+Enables the agent to log to a file. Disabled by default. The agent will log
+at the `logging.logLevel` configured with <<config-log_level>>. Use
+<<config-log_level_size>> to configure the max size of the log file. This log
+file will automatically rotate.
+
+[float]
+[[config-log_file_size]]
+==== `log_file_size`
+
+[options="header"]
+|============
+| Environment                 | Django/Flask    | Default     | Example
+| `ELASTIC_APM_LOG_FILE_SIZE` | `LOG_FILE_SIZE` | `"50mb"`    | `"100mb"`
+|============
+
+The size of the log file, if <<config-log_file>> is set.
+
+The agent always keeps one backup file when rotating, so the max space that
+the log files will consume is twice the value of this setting.
 
 [float]
 [[other-options]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -207,6 +207,9 @@ at the `logging.logLevel` configured with <<config-log_level>>. Use
 <<config-log_file_size>> to configure the max size of the log file. This log
 file will automatically rotate.
 
+Note that setting <<config-log_level>> is required for this setting to do
+anything.
+
 [float]
 [[config-log_file_size]]
 ==== `log_file_size`

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -203,7 +203,7 @@ will do this for you) or set <<config-log_file>>.
 
 Enables the agent to log to a file. Disabled by default. The agent will log
 at the `logging.logLevel` configured with <<config-log_level>>. Use
-<<config-log_level_size>> to configure the max size of the log file. This log
+<<config-log_file_size>> to configure the max size of the log file. This log
 file will automatically rotate.
 
 [float]

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -539,7 +539,7 @@ class Client(object):
                     exc_name = "%s.%s" % (exc_module, exc_type)
                 else:
                     exc_name = exc_type
-                self.logger.info("Ignored %s exception due to exception type filter", exc_name)
+                self.logger.debug("Ignored %s exception due to exception type filter", exc_name)
                 return True
         return False
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -358,7 +358,8 @@ class EnumerationValidator(object):
 
 def _log_level_callback(dict_key, old_value, new_value, config_instance):
     elasticapm_logger = logging.getLogger("elasticapm")
-    elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
+    if new_value:
+        elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
 
     global logfile_set_up
     if not logfile_set_up and config_instance.log_file:
@@ -569,7 +570,7 @@ class Config(_ConfigBase):
         "LOG_LEVEL",
         validators=[EnumerationValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
         callbacks=[_log_level_callback],
-        default="info",
+        default=None,
     )
     log_file = _ConfigValue("LOG_FILE", default="")
     log_file_size = _ConfigValue("LOG_FILE_SIZE", validators=[size_validator], type=int, default=50 * 1024 * 1024)

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -604,11 +604,9 @@ class VersionedConfig(ThreadManager):
             self._update_thread = None
 
 
-def setup_logging(handler, exclude=("gunicorn", "south", "elasticapm.errors")):
+def setup_logging(handler):
     """
     Configures logging to pipe to Elastic APM.
-
-    - ``exclude`` is a list of loggers that shouldn't go to ElasticAPM.
 
     For a typical Python install:
 
@@ -623,6 +621,9 @@ def setup_logging(handler, exclude=("gunicorn", "south", "elasticapm.errors")):
 
     Returns a boolean based on if logging was configured or not.
     """
+    # TODO We should probably revisit this. Does it make more sense as
+    # a method within the Client class? The Client object could easily
+    # pass itself into LoggingHandler and we could eliminate args altogether.
     logger = logging.getLogger()
     if handler.__class__ in map(type, logger.handlers):
         return False

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -52,6 +52,7 @@ log_levels_map = {
     "debug": logging.DEBUG,
     "info": logging.INFO,
     "warning": logging.WARNING,
+    "warn": logging.WARNING,
     "error": logging.ERROR,
     "critical": logging.CRITICAL,
     "off": 1000,
@@ -572,7 +573,7 @@ class Config(_ConfigBase):
     cloud_provider = _ConfigValue("CLOUD_PROVIDER", default=True)
     log_level = _ConfigValue(
         "LOG_LEVEL",
-        validators=[EnumerationValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
+        validators=[EnumerationValidator(["trace", "debug", "info", "warning", "warn", "error", "critical", "off"])],
         callbacks=[_log_level_callback],
     )
     log_file = _ConfigValue("LOG_FILE", default="")

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -46,10 +46,8 @@ __all__ = ("setup_logging", "Config")
 
 logger = get_logger("elasticapm.conf")
 
-logging.addLevelName(5, "TRACE")
-logging.TRACE = 5
 log_levels_map = {
-    "trace": logging.TRACE,
+    "trace": 5,
     "debug": logging.DEBUG,
     "info": logging.INFO,
     "warning": logging.WARNING,

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -324,7 +324,7 @@ class ValidValuesValidator(object):
             ret = self.valid_values.get(value.lower())
         if ret is None:
             raise ConfigurationError(
-                "{} is not in the list of valid values: {}".format(value, list(self.valid_values.values()))
+                "{} is not in the list of valid values: {}".format(value, list(self.valid_values.values())), field_name
             )
         return ret
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -297,6 +297,38 @@ class FileIsReadableValidator(object):
         return value
 
 
+class ValidValuesValidator(object):
+    """
+    Validator which ensures that a given config value is chosen from a list
+    of valid options.
+    """
+
+    def __init__(self, valid_values, case_sensitive=False):
+        """
+        valid_values
+            List of valid values for the config value
+        case_sensitive
+            Whether to compare case when comparing a value to the valid list.
+            Defaults to False (case-insensitive)
+        """
+        self.case_sensitive = case_sensitive
+        if case_sensitive:
+            self.valid_values = {s: s for s in valid_values}
+        else:
+            self.valid_values = {s.lower(): s for s in valid_values}
+
+    def __call__(self, value, field_name):
+        if self.case_sensitive:
+            ret = self.valid_values.get(value)
+        else:
+            ret = self.valid_values.get(value.lower())
+        if ret is None:
+            raise ConfigurationError(
+                "{} is not in the list of valid values: {}".format(value, list(self.valid_values.values()))
+            )
+        return ret
+
+
 class _ConfigBase(object):
     _NO_VALUE = object()  # sentinel object
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -176,7 +176,8 @@ class _ConfigValue(object):
                 raise ConfigurationError(
                     "Callback {} raised an exception when setting {} to {}: {}".format(
                         callback, self.dict_key, new_value, e
-                    )
+                    ),
+                    self.dict_key,
                 )
 
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -55,7 +55,7 @@ log_levels_map = {
     "critical": logging.CRITICAL,
     "off": 1000,
 }
-logging_set_up = False
+logfile_set_up = False
 
 
 class ConfigurationError(ValueError):
@@ -358,9 +358,9 @@ def _log_level_callback(dict_key, old_value, new_value, config_instance):
     elasticapm_logger = logging.getLogger("elasticapm")
     elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
 
-    global logging_set_up
-    if not logging_set_up and config_instance.log_file:
-        logging_set_up = True
+    global logfile_set_up
+    if not logfile_set_up and config_instance.log_file:
+        logfile_set_up = True
         filehandler = logging.handlers.RotatingFileHandler(
             config_instance.log_file, maxBytes=config_instance.log_file_size, backupCount=1
         )

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -358,8 +358,7 @@ class EnumerationValidator(object):
 
 def _log_level_callback(dict_key, old_value, new_value, config_instance):
     elasticapm_logger = logging.getLogger("elasticapm")
-    if new_value:
-        elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
+    elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
 
     global logfile_set_up
     if not logfile_set_up and config_instance.log_file:

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -324,16 +324,16 @@ class FileIsReadableValidator(object):
         return value
 
 
-class ValidValuesValidator(object):
+class EnumerationValidator(object):
     """
     Validator which ensures that a given config value is chosen from a list
-    of valid options.
+    of valid string options.
     """
 
     def __init__(self, valid_values, case_sensitive=False):
         """
         valid_values
-            List of valid values for the config value
+            List of valid string values for the config value
         case_sensitive
             Whether to compare case when comparing a value to the valid list.
             Defaults to False (case-insensitive)
@@ -567,7 +567,7 @@ class Config(_ConfigBase):
     cloud_provider = _ConfigValue("CLOUD_PROVIDER", default=True)
     log_level = _ConfigValue(
         "LOG_LEVEL",
-        validators=[ValidValuesValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
+        validators=[EnumerationValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
         callbacks=[_log_level_callback],
         default="info",
     )

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -428,7 +428,12 @@ class _ConfigBase(object):
                 except ConfigurationError as e:
                     self._errors[e.field_name] = str(e)
             # handle initial callbacks
-            if initial and config_value.callbacks_on_default and getattr(self, field) == config_value.default:
+            if (
+                initial
+                and config_value.callbacks_on_default
+                and getattr(self, field) is not None
+                and getattr(self, field) == config_value.default
+            ):
                 self.callbacks_queue.append((config_value.dict_key, self._NO_VALUE, config_value.default))
             # if a field has not been provided by any config source, we have to check separately if it is required
             if config_value.required and getattr(self, field) is None:
@@ -468,13 +473,13 @@ class _ConfigBase(object):
 
 class Config(_ConfigBase):
     service_name = _ConfigValue("SERVICE_NAME", validators=[RegexValidator("^[a-zA-Z0-9 _-]+$")], required=True)
-    service_node_name = _ConfigValue("SERVICE_NODE_NAME", default=None)
-    environment = _ConfigValue("ENVIRONMENT", default=None)
+    service_node_name = _ConfigValue("SERVICE_NODE_NAME")
+    environment = _ConfigValue("ENVIRONMENT")
     secret_token = _ConfigValue("SECRET_TOKEN")
     api_key = _ConfigValue("API_KEY")
     debug = _BoolConfigValue("DEBUG", default=False)
     server_url = _ConfigValue("SERVER_URL", default="http://localhost:8200", required=True)
-    server_cert = _ConfigValue("SERVER_CERT", default=None, validators=[FileIsReadableValidator()])
+    server_cert = _ConfigValue("SERVER_CERT", validators=[FileIsReadableValidator()])
     verify_server_cert = _BoolConfigValue("VERIFY_SERVER_CERT", default=True)
     include_paths = _ListConfigValue("INCLUDE_PATHS")
     exclude_paths = _ListConfigValue("EXCLUDE_PATHS", default=compat.get_default_library_patters())
@@ -552,9 +557,9 @@ class Config(_ConfigBase):
     autoinsert_django_middleware = _BoolConfigValue("AUTOINSERT_DJANGO_MIDDLEWARE", default=True)
     transactions_ignore_patterns = _ListConfigValue("TRANSACTIONS_IGNORE_PATTERNS", default=[])
     service_version = _ConfigValue("SERVICE_VERSION")
-    framework_name = _ConfigValue("FRAMEWORK_NAME", default=None)
-    framework_version = _ConfigValue("FRAMEWORK_VERSION", default=None)
-    global_labels = _DictConfigValue("GLOBAL_LABELS", default=None)
+    framework_name = _ConfigValue("FRAMEWORK_NAME")
+    framework_version = _ConfigValue("FRAMEWORK_VERSION")
+    global_labels = _DictConfigValue("GLOBAL_LABELS")
     disable_send = _BoolConfigValue("DISABLE_SEND", default=False)
     enabled = _BoolConfigValue("ENABLED", default=True)
     recording = _BoolConfigValue("RECORDING", default=True)
@@ -570,7 +575,6 @@ class Config(_ConfigBase):
         "LOG_LEVEL",
         validators=[EnumerationValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
         callbacks=[_log_level_callback],
-        default=None,
     )
     log_file = _ConfigValue("LOG_FILE", default="")
     log_file_size = _ConfigValue("LOG_FILE_SIZE", validators=[size_validator], type=int, default=50 * 1024 * 1024)

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -334,6 +334,11 @@ class ValidValuesValidator(object):
         return ret
 
 
+def _log_level_callback(dict_key, old_value, new_value):
+    # TODO setup logging!
+    pass
+
+
 class _ConfigBase(object):
     _NO_VALUE = object()  # sentinel object
 
@@ -510,6 +515,12 @@ class Config(_ConfigBase):
     use_elastic_traceparent_header = _BoolConfigValue("USE_ELASTIC_TRACEPARENT_HEADER", default=True)
     use_elastic_excepthook = _BoolConfigValue("USE_ELASTIC_EXCEPTHOOK", default=False)
     cloud_provider = _ConfigValue("CLOUD_PROVIDER", default=True)
+    log_level = _ConfigValue(
+        "LOG_LEVEL",
+        validators=[ValidValuesValidator(["trace", "debug", "info", "warning", "error", "critical", "off"])],
+        callbacks=[_log_level_callback],
+        default="info",
+    )
 
     @property
     def is_recording(self):

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -682,7 +682,7 @@ class VersionedConfig(ThreadManager):
                 logger.error("Error applying new configuration: %s", repr(errors))
             else:
                 logger.info(
-                    "Applied new configuration: %s",
+                    "Applied new remote configuration: %s",
                     "; ".join(
                         "%s=%s" % (compat.text_type(k), compat.text_type(v)) for k, v in compat.iteritems(new_config)
                     ),

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -30,6 +30,7 @@
 
 
 import logging
+import logging.handlers
 import math
 import os
 import re

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -73,7 +73,7 @@ class async_capture_span(capture_span):
                         # could happen if the exception has __slots__
                         pass
             except LookupError:
-                error_logger.info("ended non-existing span %s of type %s", self.name, self.type)
+                error_logger.debug("ended non-existing span %s of type %s", self.name, self.type)
 
 
 async def set_context(data, key="custom"):

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -157,7 +157,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
                     if hasattr(middleware_class, "process_response"):
                         wrapt.wrap_function_wrapper(middleware_class, "process_response", process_response_wrapper)
                 except ImportError:
-                    client.logger.info("Can't instrument middleware %s", middleware_path)
+                    client.logger.warning("Can't instrument middleware %s", middleware_path)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         request._elasticapm_view_func = view_func

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -733,7 +733,7 @@ class capture_span(object):
                         # could happen if the exception has __slots__
                         pass
             except LookupError:
-                logger.info("ended non-existing span %s of type %s", self.name, self.type)
+                logger.debug("ended non-existing span %s of type %s", self.name, self.type)
 
 
 def label(**labels):

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -333,7 +333,7 @@ def test_required_is_checked_if_field_not_provided():
 def test_callback():
     test_var = {"foo": 0}
 
-    def set_global(dict_key, old_value, new_value):
+    def set_global(dict_key, old_value, new_value, config_instance):
         # TODO make test_var `nonlocal` once we drop py2 -- it can just be a
         # basic variable then instead of a dictionary
         test_var[dict_key] += 1
@@ -350,7 +350,7 @@ def test_callback():
 def test_callbacks_on_default():
     test_var = {"foo": 0}
 
-    def set_global(dict_key, old_value, new_value):
+    def set_global(dict_key, old_value, new_value, config_instance):
         # TODO make test_var `nonlocal` once we drop py2 -- it can just be a
         # basic variable then instead of a dictionary
         test_var[dict_key] += 1
@@ -380,7 +380,7 @@ def test_callbacks_on_default():
 def test_callback_reset():
     test_var = {"foo": 0}
 
-    def set_global(dict_key, old_value, new_value):
+    def set_global(dict_key, old_value, new_value, config_instance):
         # TODO make test_var `nonlocal` once we drop py2 -- it can just be a
         # basic variable then instead of a dictionary
         test_var[dict_key] += 1

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -44,6 +44,7 @@ from elasticapm.conf import (
     FileIsReadableValidator,
     PrecisionValidator,
     RegexValidator,
+    ValidValuesValidator,
     VersionedConfig,
     _BoolConfigValue,
     _ConfigBase,
@@ -363,3 +364,24 @@ def test_callback_reset():
     assert test_var["foo"] == 2
     c.reset()
     assert test_var["foo"] == 3
+
+
+def test_valid_values_validator():
+    # Case sensitive
+    v = ValidValuesValidator(["foo", "Bar", "baz"], case_sensitive=False)
+    assert v("foo", "foo") == "foo"
+    assert v("bar", "foo") == "Bar"
+    assert v("BAZ", "foo") == "baz"
+    with pytest.raises(ConfigurationError):
+        v("foobar", "foo")
+
+    # Case insensitive
+    v = ValidValuesValidator(["foo", "Bar", "baz"], case_sensitive=True)
+    assert v("foo", "foo") == "foo"
+    with pytest.raises(ConfigurationError):
+        v("bar", "foo")
+    with pytest.raises(ConfigurationError):
+        v("BAZ", "foo")
+    assert v("Bar", "foo") == "Bar"
+    with pytest.raises(ConfigurationError):
+        v("foobar", "foo")

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -41,10 +41,10 @@ import pytest
 from elasticapm.conf import (
     Config,
     ConfigurationError,
+    EnumerationValidator,
     FileIsReadableValidator,
     PrecisionValidator,
     RegexValidator,
-    ValidValuesValidator,
     VersionedConfig,
     _BoolConfigValue,
     _ConfigBase,
@@ -398,7 +398,7 @@ def test_callback_reset():
 
 def test_valid_values_validator():
     # Case sensitive
-    v = ValidValuesValidator(["foo", "Bar", "baz"], case_sensitive=False)
+    v = EnumerationValidator(["foo", "Bar", "baz"], case_sensitive=False)
     assert v("foo", "foo") == "foo"
     assert v("bar", "foo") == "Bar"
     assert v("BAZ", "foo") == "baz"
@@ -406,7 +406,7 @@ def test_valid_values_validator():
         v("foobar", "foo")
 
     # Case insensitive
-    v = ValidValuesValidator(["foo", "Bar", "baz"], case_sensitive=True)
+    v = EnumerationValidator(["foo", "Bar", "baz"], case_sensitive=True)
     assert v("foo", "foo") == "foo"
     with pytest.raises(ConfigurationError):
         v("bar", "foo")

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -347,6 +347,36 @@ def test_callback():
     assert test_var["foo"] == 2
 
 
+def test_callbacks_on_default():
+    test_var = {"foo": 0}
+
+    def set_global(dict_key, old_value, new_value):
+        # TODO make test_var `nonlocal` once we drop py2 -- it can just be a
+        # basic variable then instead of a dictionary
+        test_var[dict_key] += 1
+
+    class MyConfig(_ConfigBase):
+        foo = _ConfigValue("foo", callbacks=[set_global], default="foobar")
+
+    c = MyConfig()
+    assert test_var["foo"] == 1
+    c = MyConfig({"foo": "bar"})
+    assert test_var["foo"] == 2
+    c.update({"foo": "baz"})
+    assert test_var["foo"] == 3
+
+    # Test without callback on default
+    class MyConfig(_ConfigBase):
+        foo = _ConfigValue("foo", callbacks=[set_global], callbacks_on_default=False, default="foobar")
+
+    c = MyConfig()
+    assert test_var["foo"] == 3
+    c = MyConfig({"foo": "bar"})
+    assert test_var["foo"] == 4
+    c.update({"foo": "baz"})
+    assert test_var["foo"] == 5
+
+
 def test_callback_reset():
     test_var = {"foo": 0}
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -35,6 +35,7 @@ import os
 import random
 import socket
 import sys
+import tempfile
 import time
 import zlib
 from collections import defaultdict
@@ -181,6 +182,31 @@ def elasticapm_client(request):
     client_config.setdefault("span_frames_min_duration", -1)
     client_config.setdefault("metrics_interval", "0ms")
     client_config.setdefault("cloud_provider", False)
+    client = TempStoreClient(**client_config)
+    yield client
+    client.close()
+    # clear any execution context that might linger around
+    sys.excepthook = original_exceptionhook
+    execution_context.set_transaction(None)
+    execution_context.set_span(None)
+
+
+@pytest.fixture()
+def elasticapm_client_log_file(request):
+    original_exceptionhook = sys.excepthook
+    client_config = getattr(request, "param", {})
+    client_config.setdefault("service_name", "myapp")
+    client_config.setdefault("secret_token", "test_key")
+    client_config.setdefault("central_config", "false")
+    client_config.setdefault("include_paths", ("*/tests/*",))
+    client_config.setdefault("span_frames_min_duration", -1)
+    client_config.setdefault("metrics_interval", "0ms")
+    client_config.setdefault("cloud_provider", False)
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.close()
+    client_config["log_file"] = tmp.name
+
     client = TempStoreClient(**client_config)
     yield client
     client.close()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -204,6 +204,7 @@ def elasticapm_client_log_file(request):
     client_config.setdefault("span_frames_min_duration", -1)
     client_config.setdefault("metrics_interval", "0ms")
     client_config.setdefault("cloud_provider", False)
+    client_config.setdefault("log_level", "warning")
 
     tmp = tempfile.NamedTemporaryFile(delete=False)
     tmp.close()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -31,6 +31,8 @@
 import codecs
 import gzip
 import json
+import logging
+import logging.handlers
 import os
 import random
 import socket
@@ -212,6 +214,10 @@ def elasticapm_client_log_file(request):
     client.close()
 
     # delete our tmpfile
+    logger = logging.getLogger("elasticapm")
+    for handler in logger.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            handler.close()
     os.unlink(tmp.name)
 
     # clear any execution context that might linger around

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -210,6 +210,10 @@ def elasticapm_client_log_file(request):
     client = TempStoreClient(**client_config)
     yield client
     client.close()
+
+    # delete our tmpfile
+    os.unlink(tmp.name)
+
     # clear any execution context that might linger around
     sys.excepthook = original_exceptionhook
     execution_context.set_transaction(None)

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -29,6 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import logging.handlers
 import sys
 import warnings
 from logging import LogRecord

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -357,3 +357,31 @@ def test_logging_handler_no_client(recwarn):
         w = recwarn.pop(PendingDeprecationWarning)
         if "LoggingHandler requires a Client instance" in w.message.args[0]:
             return True
+
+
+@pytest.mark.parametrize(
+    "elasticapm_client,expected",
+    [
+        ({}, logging.INFO),
+        ({"log_level": "off"}, 1000),
+        ({"log_level": "trace"}, 5),
+        ({"log_level": "debug"}, logging.DEBUG),
+        ({"log_level": "info"}, logging.INFO),
+        ({"log_level": "WARNING"}, logging.WARNING),
+        ({"log_level": "errOr"}, logging.ERROR),
+        ({"log_level": "CRITICAL"}, logging.CRITICAL),
+    ],
+    indirect=["elasticapm_client"],
+)
+def test_log_level_config(elasticapm_client, expected):
+    logger = logging.getLogger("elasticapm")
+    assert logger.level == expected
+
+
+def test_log_file(elasticapm_client_log_file):
+    logger = logging.getLogger("elasticapm")
+    found = False
+    for handler in logger.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            found = True
+    assert found

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -363,7 +363,7 @@ def test_logging_handler_no_client(recwarn):
 @pytest.mark.parametrize(
     "elasticapm_client,expected",
     [
-        ({}, logging.INFO),
+        ({}, logging.NOTSET),
         ({"log_level": "off"}, 1000),
         ({"log_level": "trace"}, 5),
         ({"log_level": "debug"}, logging.DEBUG),

--- a/tests/instrumentation/base_tests.py
+++ b/tests/instrumentation/base_tests.py
@@ -183,7 +183,7 @@ def test_skip_ignored_frames(elasticapm_client):
 
 
 def test_end_nonexisting_span(caplog, elasticapm_client):
-    with caplog.at_level(logging.INFO, "elasticapm.traces"):
+    with caplog.at_level(logging.DEBUG, "elasticapm.traces"):
         t = elasticapm_client.begin_transaction("test")
         # we're purposefully creating a case where we don't begin a span
         # and then try to end the non-existing span


### PR DESCRIPTION
Adds support for configurable `log_level`.

[Spec](https://github.com/elastic/apm/blob/master/specs/agents/logging.md)

## Related issues
Closes #941 