### PR TITLE
remove elasticsearch-async instrumentation

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -116,7 +116,6 @@ Instrumented methods:
 
  * `elasticsearch.connection.http_urllib3.Urllib3HttpConnection.perform_request`
  * `elasticsearch.connection.http_requests.RequestsHttpConnection.perform_request`
- * `elasticsearch_async.connection.AIOHttpConnection.perform_request`
 
 Additionally, the instrumentation wraps the following methods of the `Elasticsearch` client class:
 

--- a/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
@@ -36,10 +36,7 @@ from elasticapm.instrumentation.packages.elasticsearch import ElasticSearchConne
 class ElasticSearchAsyncConnection(ElasticSearchConnectionMixin, AsyncAbstractInstrumentedModule):
     name = "elasticsearch_connection"
 
-    instrument_list = [
-        ("elasticsearch_async.connection", "AIOHttpConnection.perform_request"),
-        ("elasticsearch._async.http_aiohttp", "AIOHttpConnection.perform_request"),
-    ]
+    instrument_list = [("elasticsearch._async.http_aiohttp", "AIOHttpConnection.perform_request")]
 
     async def call(self, module, method, wrapped, instance, args, kwargs):
         signature = self.get_signature(args, kwargs)


### PR DESCRIPTION
elasticsearch-async has been deprecated and its functionality brought
into elasticsearch-py proper.

Tests for this module have already been removed in #949

