### PR TITLE
fix test result output on Windows

### DIFF
--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -15,9 +15,9 @@ if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.p
 
 set PYTEST_JUNIT="--junitxml=.\tests\python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (
-    call %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
 )
 if "%ASYNCIO%" == "false" (
-    call %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
 )
 call %PYTHON%\python.exe setup.py bdist_wheel

--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -15,9 +15,9 @@ if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.p
 
 set PYTEST_JUNIT="--junitxml=.\tests\python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (
-    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b
 )
 if "%ASYNCIO%" == "false" (
-    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest"
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b
 )
 call %PYTHON%\python.exe setup.py bdist_wheel

--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -15,9 +15,9 @@ if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.p
 
 set PYTEST_JUNIT="--junitxml=.\tests\python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (
-    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
 )
 if "%ASYNCIO%" == "false" (
-    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b
+    %PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
 )
 call %PYTHON%\python.exe setup.py bdist_wheel

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -239,3 +239,10 @@ def test_read_pem_file_chain():
     with open(os.path.join(os.path.dirname(__file__), "..", "ca", "chain.crt"), mode="rb") as f:
         result = read_pem_file(f)
         assert result.endswith(b"\xc8\xae")
+
+
+def test_fails_on_windows_python_37():
+    import platform
+    import sys
+
+    assert not (platform.system() == "Windows" and sys.version_info[:2] == (3, 7))

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -239,10 +239,3 @@ def test_read_pem_file_chain():
     with open(os.path.join(os.path.dirname(__file__), "..", "ca", "chain.crt"), mode="rb") as f:
         result = read_pem_file(f)
         assert result.endswith(b"\xc8\xae")
-
-
-def test_fails_on_windows_python_37():
-    import platform
-    import sys
-
-    assert not (platform.system() == "Windows" and sys.version_info[:2] == (3, 7))


### PR DESCRIPTION
Using `call` swallows the exit code of the test runner, making
Jenkins mark failed test runs as unstable instead of failed.
