### PR TITLE
Add public API to retrieve trace parent header.

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -174,6 +174,16 @@ client.begin_transaction('processors', trace_parent=parent)
 
  * `headers`: (*required*) HTTP headers formed as a dictionary.
 
+[float]
+[[api-traceparent-from-headers]]
+===== `elasticapm.get_trace_parent_header()`
+
+Return the string representation of the current transaction TraceParent object:
+
+[source,python]
+----
+elasticapm.get_trace_parent_header()
+----
 
 [float]
 [[api-other]]

--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -37,6 +37,7 @@ from elasticapm.traces import (  # noqa: F401
     get_span_id,
     get_trace_id,
     get_transaction_id,
+    get_trace_parent_header,
     label,
     set_context,
     set_custom_context,

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -837,6 +837,16 @@ def get_transaction_id():
     return transaction.id
 
 
+def get_trace_parent_header():
+    """
+    Return the trace parent header for the current transaction.
+    """
+    transaction = execution_context.get_transaction()
+    if not transaction or not transaction.trace_parent:
+        return
+    return transaction.trace_parent.to_string()
+
+
 def get_trace_id():
     """
     Returns the current trace ID


### PR DESCRIPTION
## What does this pull request do?

Add a new public API to easily return the trace parent header of the current transaction, currently it's necessary to dig into the project and understand how it works.

Code necessary to get the current trace parent header without the new function.

```
from elasticapm.traces import execution_context

transaction = execution_context.get_transaction().
trace_parent_header = transaction .trace_parent.to_string() if transaction and transaction.trace_parent else None
```

## Related issues

https://github.com/elastic/apm-agent-python/issues/954
