### PR TITLE
Starlette: use route name as transaction name if available

### DIFF
--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -213,10 +213,15 @@ class ElasticAPM(BaseHTTPMiddleware):
         # redirects all in the same "redirect trailing slashes" transaction name
         if not route_name and app.router.redirect_slashes and scope["path"] != "/":
             redirect_scope = dict(scope)
-            redirect_scope["path"] = scope["path"][:-1] if scope["path"].endswith("/") else scope["path"] + "/"
+            if scope["path"].endswith("/"):
+                redirect_scope["path"] = scope["path"][:-1]
+                trim = True
+            else:
+                redirect_scope["path"] = scope["path"] + "/"
+                trim = False
             for route in routes:
                 match, _ = route.matches(redirect_scope)
                 if match != Match.NONE:
-                    route_name = "redirect trailing slashes"
+                    route_name = route.path + "/" if trim else route.path[:-1]
                     break
         return route_name


### PR DESCRIPTION
Unfortunately, we need to do some matching here that Starlette does
too, but currently isn't exposed. If/when https://github.com/encode/starlette/pull/804
is merged, we can re-use the route from there.

closes #833