### PR TITLE
ensure that query string max length is maintained after sanitization

### DIFF
--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -306,6 +306,16 @@ def test_sanitize_http_query_string(elasticapm_client, expected, http_test_data)
     assert result["context"]["request"]["url"]["full"].endswith(expected)
 
 
+def test_sanitize_http_query_string_max_length(elasticapm_client):
+    qs = "api_key=1&v=" + 1020 * "x"
+    data = {"context": {"request": {"url": {"full": "http://example.com/bla?" + qs, "search": qs}}}}
+    result = processors.sanitize_http_request_querystring(elasticapm_client, data)
+    for val in (result["context"]["request"]["url"]["search"], result["context"]["request"]["url"]["full"]):
+        assert "api_key=********" in val
+        assert len(val) == 1024
+        assert val.endswith(u"x…")
+
+
 @pytest.mark.parametrize(
     "elasticapm_client, expected",
     [


### PR DESCRIPTION
if any of the sanitized values is shorter than the replacement string
(`********`), we could potentially end up with the sanitized string that
is longer than the max length for a keyword field (1024). This
would make the event fail the JSONSchema validation.

