### PR TITLE
remove Python 2.7 testing on Windows

### DIFF
--- a/.ci/.jenkins_windows.yml
+++ b/.ci/.jenkins_windows.yml
@@ -6,9 +6,6 @@
 #
 
 windows:
-  - VERSION: "2.7"
-    WEBFRAMEWORK: "none"
-    ASYNCIO: "false"
   - VERSION: "3.5"
     WEBFRAMEWORK: "none"
     ASYNCIO: "false"
@@ -19,5 +16,8 @@ windows:
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"
   - VERSION: "3.8"
+    WEBFRAMEWORK: "none"
+    ASYNCIO: "true"
+  - VERSION: "3.9"
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"

--- a/.ci/.jenkins_windows.yml
+++ b/.ci/.jenkins_windows.yml
@@ -18,6 +18,6 @@ windows:
   - VERSION: "3.8"
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"
-  - VERSION: "3.9"
-    WEBFRAMEWORK: "none"
-    ASYNCIO: "true"
+#  - VERSION: "3.9"  # waiting for https://github.com/giampaolo/psutil/issues/1850
+#    WEBFRAMEWORK: "none"
+#    ASYNCIO: "true"


### PR DESCRIPTION
we experience a lot of failed test runs on Windows/Python2.7 due to
a race condition happening in the coverage library.

We will drop support for Python 2.7 soon anyway, so it's not worth
investigating this further.
