### PR TITLE
remove system.process.cgroup.memory.stats.inactive_file.bytes

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -85,6 +85,7 @@ format: bytes
 The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 --
 
+[float]
 [[cpu-memory-cgroup-metricset]]
 ===== Linux’s cgroup metrics
 

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -20,6 +20,9 @@ These metrics will be sent regularly to the APM Server and from there to Elastic
 
 This metric set collects various system metrics and metrics of the current process.
 
+NOTE: if you do *not* use Linux, you need to install https://pypi.org/project/psutil/[`psutil`] for this metric set.
+
+
 *`system.cpu.total.norm.pct`*::
 +
 --
@@ -62,7 +65,6 @@ format: bytes
 Actual free memory in bytes. 
 --
 
-
 *`system.process.memory.size`*::
 +
 --
@@ -73,8 +75,6 @@ format: bytes
 The total virtual memory the process has.
 --
 
-
-
 *`system.process.memory.rss.bytes`*::
 +
 --
@@ -82,10 +82,32 @@ type: long
 
 format: bytes
 
-he Resident Set Size. The amount of memory the process occupied in main memory (RAM).
+The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
 --
 
-NOTE: if you do *not* use Linux, you need to install https://pypi.org/project/psutil/[`psutil`] for this metric set.
+[[cpu-memory-cgroup-metricset]]
+===== Linux’s cgroup metrics
+
+*`system.process.cgroup.memory.mem.limit.bytes`*::
++
+--
+type: long
+
+format: bytes
+
+Memory limit for current cgroup slice.
+--
+
+*`system.process.cgroup.memory.mem.usage.bytes`*::
++
+--
+type: long
+
+format: bytes
+
+Memory usage in current cgroup slice.
+--
+
 
 [float]
 [[transactions-metricset]]

--- a/tests/metrics/cpu_linux_tests.py
+++ b/tests/metrics/cpu_linux_tests.py
@@ -258,8 +258,7 @@ def test_mem_from_cgroup1(elasticapm_client, tmpdir):
     assert data["samples"]["system.process.memory.size"]["value"] == 3686981632
 
     assert data["samples"]["system.process.cgroup.memory.mem.limit.bytes"]["value"] == 7964778496
-    assert data["samples"]["system.process.cgroup.memory.mem.usage.bytes"]["value"] == 954370560
-    assert data["samples"]["system.process.cgroup.memory.stats.inactive_file.bytes"]["value"] == 10407936
+    assert data["samples"]["system.process.cgroup.memory.mem.usage.bytes"]["value"] == 964778496
 
 
 def test_mem_from_cgroup2(elasticapm_client, tmpdir):
@@ -309,8 +308,7 @@ def test_mem_from_cgroup2(elasticapm_client, tmpdir):
     assert data["samples"]["system.process.memory.size"]["value"] == 3686981632
 
     assert data["samples"]["system.process.cgroup.memory.mem.limit.bytes"]["value"] == 7964778496
-    assert data["samples"]["system.process.cgroup.memory.mem.usage.bytes"]["value"] == 954370560
-    assert data["samples"]["system.process.cgroup.memory.stats.inactive_file.bytes"]["value"] == 10407936
+    assert data["samples"]["system.process.cgroup.memory.mem.usage.bytes"]["value"] == 964778496
 
 
 def test_mem_from_cgroup1_max_handling(elasticapm_client, tmpdir):
@@ -354,7 +352,6 @@ def test_mem_from_cgroup1_max_handling(elasticapm_client, tmpdir):
 
     assert "system.process.cgroup.memory.mem.limit.bytes" not in data["samples"]
     assert "system.process.cgroup.memory.mem.usage.bytes" not in data["samples"]
-    assert "system.process.cgroup.memory.stats.inactive_file.bytes" not in data["samples"]
 
 
 def test_mem_from_cgroup2_max_handling(elasticapm_client, tmpdir):
@@ -399,4 +396,3 @@ def test_mem_from_cgroup2_max_handling(elasticapm_client, tmpdir):
 
     assert "system.process.cgroup.memory.mem.limit.bytes" not in data["samples"]
     assert "system.process.cgroup.memory.mem.usage.bytes" not in data["samples"]
-    assert "system.process.cgroup.memory.stats.inactive_file.bytes" not in data["samples"]


### PR DESCRIPTION
this was included by mistake.

Also, add docs for the two remaining cgroup fields

