### PR TITLE
Avoid the slow pkg_resources package on modern python versions

### DIFF
--- a/elasticapm/__init__.py
+++ b/elasticapm/__init__.py
@@ -52,7 +52,10 @@ from elasticapm.utils.disttracing import trace_parent_from_headers, trace_parent
 __all__ = ("VERSION", "Client")
 
 try:
-    VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
+    try:
+        VERSION = __import__("importlib.metadata").metadata.version("elastic-apm")
+    except ImportError:
+        VERSION = __import__("pkg_resources").get_distribution("elastic-apm").version
 except Exception:
     VERSION = "unknown"
 


### PR DESCRIPTION
pkg_resources is very slow as can be seen in this simple test:

```
> time python -c "print( __import__('pkg_resources').get_distribution('elastic-apm').version)"
4.2.2
        0.33 real         0.24 user         0.08 sys
        
> time python -c "from importlib.metadata import version; print(version('elastic-apm'))"
4.2.2
        0.08 real         0.05 user         0.02 sys

> time python -c ""                   Wed Dec  2 09:36:26 2020
        0.03 real         0.02 user         0.01 sys
```