### PR TITLE
remove Python 3.5 on Windows testing

### DIFF
--- a/.ci/.jenkins_windows.yml
+++ b/.ci/.jenkins_windows.yml
@@ -15,6 +15,6 @@ windows:
   - VERSION: "3.8"
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"
-  - VERSION: "3.9"  # waiting for https://github.com/giampaolo/psutil/issues/1850
-    WEBFRAMEWORK: "none"
-    ASYNCIO: "true"
+#  - VERSION: "3.9"  # waiting for greenlet to have binary wheels for 3.9
+#    WEBFRAMEWORK: "none"
+#    ASYNCIO: "true"

--- a/.ci/.jenkins_windows.yml
+++ b/.ci/.jenkins_windows.yml
@@ -6,9 +6,6 @@
 #
 
 windows:
-  - VERSION: "3.5"
-    WEBFRAMEWORK: "none"
-    ASYNCIO: "false"
   - VERSION: "3.6"
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"
@@ -18,6 +15,6 @@ windows:
   - VERSION: "3.8"
     WEBFRAMEWORK: "none"
     ASYNCIO: "true"
-#  - VERSION: "3.9"  # waiting for https://github.com/giampaolo/psutil/issues/1850
-#    WEBFRAMEWORK: "none"
-#    ASYNCIO: "true"
+  - VERSION: "3.9"  # waiting for https://github.com/giampaolo/psutil/issues/1850
+    WEBFRAMEWORK: "none"
+    ASYNCIO: "true"

--- a/scripts/install-tools.bat
+++ b/scripts/install-tools.bat
@@ -2,7 +2,7 @@
 : It does require the below list of environment variables:
 :  - PYTHON: the python installation path.
 :  - WEBFRAMEWORK: the framework to be installed.
-@echo off
+@echo on
 
 : Prepare the env context
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\vsdevcmd.bat" -arch=amd64

--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -12,7 +12,6 @@ call .\tests\scripts\download_json_schema.bat
 set COVERAGE_FILE=.coverage.%VERSION%.%WEBFRAMEWORK%
 set IGNORE_PYTHON3_WITH_PYTHON2=
 if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.py"
-call %PYTHON%\python.exe -m pip list
 
 set PYTEST_JUNIT="--junitxml=.\tests\python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (

--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -12,6 +12,7 @@ call .\tests\scripts\download_json_schema.bat
 set COVERAGE_FILE=.coverage.%VERSION%.%WEBFRAMEWORK%
 set IGNORE_PYTHON3_WITH_PYTHON2=
 if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.py"
+call %PYTHON%\python.exe -m pip list
 
 set PYTEST_JUNIT="--junitxml=.\tests\python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (


### PR DESCRIPTION
psutil doesn't provide binary wheels anymore, and we intend to
remove Python 3.5 support soon anyway.

As an added bonus, let's activate Python 3.9 testing on Windows,
since the latest psutil release has binary wheels for 3.9
