### PR TITLE
Fix starlette to not instrument when enabled=False

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.5.4
+    rev: 5.7.0
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     -   id: black
         language_version: python3
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
     hooks:
     -   id: flake8
         exclude: elasticapm\/utils\/wrapt|build|src|tests|dist|conftest.py|setup.py

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 * Fix for custom serializers in elasticsearch-py {pull}998[#998]
 * Fix large query truncation in psycopg2 {pull}994[#994]
 * Fix memory metrics reporting when `memory.usage_in_bytes` is unavailable {pull}987[#987]
+* Fix for Starlette/FastAPI integration to properly obey `enabled` config {pull}1000[#1000]
 
 
 [[release-notes-5.x]]

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -115,7 +115,7 @@ class ElasticAPM(BaseHTTPMiddleware):
         """
         self.client = client
 
-        if self.client.config.instrument:
+        if self.client.config.instrument and self.client.config.enabled:
             elasticapm.instrumentation.control.instrument()
 
         super().__init__(app)

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -281,7 +281,11 @@ def test_trailing_slash_redirect_detection(app, elasticapm_client, url, expected
 
 
 @pytest.mark.parametrize(
-    "elasticapm_client", [{"enabled": False},], indirect=True,
+    "elasticapm_client",
+    [
+        {"enabled": False},
+    ],
+    indirect=True,
 )
 def test_enabled_instrumentation(app, elasticapm_client):
     client = TestClient(app)


### PR DESCRIPTION
## What does this pull request do?

Noticed that we were gating instrumentation for starlette only on `config.instrument` -- we need to also gate on `config.enabled` to make sure we don't instrument when we shouldn't.

## Related issues
Ref #993
