### PR TITLE
Fix python-memcached package name

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -360,7 +360,7 @@ Collected trace data:
 [[automatic-instrumentation-db-python-memcache]]
 ==== Python Memcache
 
-Library: `memcache` (`>=1.51`)
+Library: `python-memcached` (`>=1.51`)
 
 Instrumented methods:
 


### PR DESCRIPTION
## What does this pull request do?

This PR makes a small change in python-memacached library name.

I think that the package name should be used instead of the imported library name for clarity (or at least referenced alongside).

Until I looked at the code, I thought that python-memcached was not supported based on the documentation, so hopefully this may save a little time for someone.