### PR TITLE
remove certifi dependency, and instead rely on urllib3 to find the OS cert store

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -836,11 +836,12 @@ This disables most of the tracing functionality, but can be useful to debug poss
 | `ELASTIC_APM_VERIFY_SERVER_CERT`  | `VERIFY_SERVER_CERT` | `True`
 |============
 
-By default, the agent verifies the SSL certificate if you use an HTTPS connection to the APM Server.
+By default, the agent verifies the SSL certificate if you use an HTTPS connection to the APM Server,
+using default certificates obtained by calling 
+https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs[`SSLContext.load_default_certs()`].
+
 Verification can be disabled by changing this setting to `False`.
 This setting is ignored when <<config-server-cert,`server_cert`>> is set.
-
-NOTE: SSL certificate verification is only available in Python 2.7.9+ and Python 3.4.3+.
 
 [float]
 [[config-server-cert]]

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -35,7 +35,6 @@ import json
 import re
 import ssl
 
-import certifi
 import urllib3
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
@@ -51,7 +50,7 @@ class Transport(HTTPTransportBase):
     def __init__(self, url, *args, **kwargs):
         super(Transport, self).__init__(url, *args, **kwargs)
         url_parts = compat.urlparse.urlparse(url)
-        pool_kwargs = {"cert_reqs": "CERT_REQUIRED", "ca_certs": certifi.where(), "block": True}
+        pool_kwargs = {"cert_reqs": "CERT_REQUIRED", "ca_certs": None, "block": True}
         if self._server_cert and url_parts.scheme != "http":
             pool_kwargs.update(
                 {"assert_fingerprint": self.cert_fingerprint, "assert_hostname": False, "cert_reqs": ssl.CERT_NONE}

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    urllib3
-    certifi
+    urllib3>=1.25.3
     cachetools;python_version=='2.7'
 test_suite=tests
 tests_require =
@@ -73,8 +72,7 @@ tests_require =
     py-cpuinfo==3.3.0
     statistics==1.0.3.5
 
-    urllib3
-    certifi
+    urllib3>=1.25.3
     Jinja2
     Logbook
     MarkupSafe

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -27,8 +27,7 @@ pathlib==1.0.1
 py-cpuinfo==3.3.0
 statistics==1.0.3.5
 
-urllib3
-certifi
+urllib3>=1.25.3
 Jinja2
 Logbook
 MarkupSafe


### PR DESCRIPTION
This requires at least urllib 1.25.3.

See https://github.com/urllib3/urllib3/blob/master/CHANGES.rst#1253-2019-05-23

## Related issues
fixes #922
