### PR TITLE
Fix test fixtures to uninstrument

### DIFF
--- a/tests/contrib/asyncio/aiohttp_web_tests.py
+++ b/tests/contrib/asyncio/aiohttp_web_tests.py
@@ -35,6 +35,7 @@ aiohttp = pytest.importorskip("aiohttp")  # isort:skip
 import mock
 from multidict import MultiDict
 
+import elasticapm
 from elasticapm import async_capture_span
 from elasticapm.conf import constants
 from elasticapm.contrib.aiohttp import ElasticAPM
@@ -60,6 +61,8 @@ def aioeapm(elasticapm_client):
     app.router.add_route("GET", "/boom", boom)
     apm = ElasticAPM(app, elasticapm_client)
     yield apm
+
+    elasticapm.uninstrument()
 
 
 async def test_get(aiohttp_client, aioeapm):

--- a/tests/contrib/asyncio/tornado/tornado_tests.py
+++ b/tests/contrib/asyncio/tornado/tornado_tests.py
@@ -36,6 +36,7 @@ import os
 
 import mock
 
+import elasticapm
 from elasticapm import async_capture_span
 from elasticapm.conf import constants
 from elasticapm.contrib.tornado import ElasticAPM
@@ -72,7 +73,8 @@ def app(elasticapm_client):
         template_path=os.path.join(os.path.dirname(__file__), "templates"),
     )
     apm = ElasticAPM(app, elasticapm_client)
-    return app
+    yield app
+    elasticapm.uninstrument()
 
 
 @pytest.fixture

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -31,6 +31,7 @@
 import pytest
 from django.apps import apps
 
+import elasticapm
 from elasticapm.conf.constants import SPAN
 from elasticapm.contrib.django.apps import instrument, register_handlers
 from elasticapm.contrib.django.client import DjangoClient
@@ -64,6 +65,7 @@ def django_elasticapm_client(request):
     app.client = client
     yield client
     client.close()
+    elasticapm.uninstrument()
 
     app.client = old_client
 
@@ -90,6 +92,7 @@ def django_sending_elasticapm_client(request, validating_httpserver):
     client.httpserver = validating_httpserver
     yield client
     client.close()
+    elasticapm.uninstrument()
 
     app.client = old_client
 

--- a/tests/contrib/flask/fixtures.py
+++ b/tests/contrib/flask/fixtures.py
@@ -100,6 +100,7 @@ def flask_apm_client(request, flask_app, elasticapm_client):
     try:
         yield client
     finally:
+        elasticapm.uninstrument()
         signals.request_started.disconnect(client.request_started)
         signals.request_finished.disconnect(client.request_finished)
         # remove logging handler if it was added
@@ -118,6 +119,7 @@ def sending_flask_apm_client(request, flask_app, sending_elasticapm_client):
     try:
         yield client
     finally:
+        elasticapm.uninstrument()
         signals.request_started.disconnect(client.request_started)
         signals.request_finished.disconnect(client.request_finished)
         # remove logging handler if it was added

--- a/tests/contrib/opentracing/tests.py
+++ b/tests/contrib/opentracing/tests.py
@@ -37,6 +37,7 @@ import sys
 import mock
 from opentracing import Format
 
+import elasticapm
 from elasticapm.conf import constants
 from elasticapm.contrib.opentracing import Tracer
 from elasticapm.contrib.opentracing.span import OTSpanContext
@@ -55,6 +56,7 @@ except ImportError:
 @pytest.fixture()
 def tracer(elasticapm_client):
     yield Tracer(client_instance=elasticapm_client)
+    elasticapm.uninstrument()
 
 
 def test_tracer_with_instantiated_client(elasticapm_client):


### PR DESCRIPTION
## What does this pull request do?

Found an issue while writing a test for https://github.com/elastic/apm-agent-python/pull/1000 -- the test fixture wasn't calling `uninstrument()`. A brief search revealed that this is the case across all of our framework fixtures. This PR resolves this issue for the remaining framework fixtures.
