### PR TITLE
Only process frames if they exist

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix for potential `capture_body: error` hang in Starlette/FastAPI {pull}1038[#1038]
+* Fix a rare error around processing stack frames {pull}1012[#1012]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -467,7 +467,7 @@ class Span(BaseSpan):
         tracer = self.transaction.tracer
         timestamp = _time_func()
         self.duration = duration if duration is not None else (timestamp - self.start_time)
-        if not tracer.span_frames_min_duration or self.duration >= tracer.span_frames_min_duration:
+        if not tracer.span_frames_min_duration or self.duration >= tracer.span_frames_min_duration and self.frames:
             self.frames = tracer.frames_processing_func(self.frames)[skip_frames:]
         else:
             self.frames = None


### PR DESCRIPTION
## What does this pull request do?

- [x] Fix for `frames=None`
- [ ] ~Fix for frames as a list of dicts (waiting on more info from the user)~ (no user response)

## Related issues
Fixes #986 
