### PR TITLE
with Python 2 support gone, we can update a bunch of requirements

### DIFF
--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -1,30 +1,33 @@
-pytest==4.6.9
-py==1.8.1
-more-itertools==4.1.0
-pluggy==0.13.1
-pytest-django==3.8.0
-atomicwrites==1.1.5
-coverage==5.0.3
-pytest-cov==2.8.1
+pytest==6.2.2
+pytest-django==4.1.0
+coverage==5.4
+pytest-cov==2.11.1
 pytest-localserver==0.5.0
-pytest-mock==2.0.0
-pytest-benchmark==3.2.2
-jsonschema==2.6.0
-configparser==4.0.2
+pytest-mock==3.5.1
+pytest-benchmark==3.2.3
+pytest-bdd==3.4.0
+pytest-rerunfailures==9.1.1
+jsonschema==3.2.0
+
+
+py==1.10.0
+more-itertools==8.6.0
+pluggy==0.13.1
+atomicwrites==1.4.0
+pyrsistent==0.17.3
+configparser==5.0.1
 contextlib2==0.6.0
-importlib-metadata==1.5.0
-packaging==20.1
-Mako==1.1.0
+importlib-metadata==3.4.0
+packaging==20.9
+Mako==1.1.4
 glob2==0.7
-parse==1.15.0
+parse==1.19.0
 parse-type==0.5.2
-pytest-bdd==3.2.1
-pytest-rerunfailures==8.0
-
-
-docutils==0.14
+toml==0.10.2
+iniconfig==1.1.1
+docutils==0.16
 pathlib==1.0.1
-py-cpuinfo==3.3.0
+py-cpuinfo==7.0.0
 statistics==1.0.3.5
 
 urllib3
@@ -45,7 +48,5 @@ pep8
 pytz
 
 
-pytest-asyncio==0.10.0 ; python_version >= '3.7'
-asynctest==0.12.2 ; python_version >= '3.7'
-
-cachetools==2.0.1 ; python_version == '2.7'
+pytest-asyncio==0.14.0 ; python_version >= '3.7'
+asynctest==0.13.0 ; python_version >= '3.7'

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -168,7 +168,7 @@ def test_ssl_verify_fails(waiting_httpsserver, elasticapm_client):
     try:
         with pytest.raises(TransportException) as exc_info:
             url = transport.send(compat.b("x"))
-        assert "CERTIFICATE_VERIFY_FAILED" in str(exc_info)
+        assert "certificate verify failed" in str(exc_info)
     finally:
         transport.close()
 


### PR DESCRIPTION
pytest-bdd isn't updated all the way, as it introduced a few
backwards incompatibilities that need to be fixed first

A test of urllib3 had to be modified slightly, as some
requirement update seems to truncate the error message we
are looking for. It's not quite clear where this happens.
