### PR TITLE
Fix transaction names for starlette Mount routes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 * Fix for potential `capture_body: error` hang in Starlette/FastAPI {pull}1038[#1038]
 * Fix a rare error around processing stack frames {pull}1012[#1012]
 * Fix for Starlette/FastAPI to correctly capture request bodies as strings {pull}1042[#1041]
+* Fix transaction names for Starlette Mount routes {pull}1037[#1037]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -211,7 +211,9 @@ class ElasticAPM(BaseHTTPMiddleware):
                     child_scope = {**scope, **child_scope}
                     if isinstance(route, Mount):
                         child_route_name = _get_route_name(child_scope, route.routes, route_name)
-                        if child_route_name:
+                        if child_route_name is None:
+                            route_name = None
+                        else:
                             route_name += child_route_name
                     return route_name
                 elif match == Match.PARTIAL and route_name is None:
@@ -230,9 +232,7 @@ class ElasticAPM(BaseHTTPMiddleware):
             else:
                 redirect_scope["path"] = scope["path"] + "/"
                 trim = False
-            for route in routes:
-                match, _ = route.matches(redirect_scope)
-                if match != Match.NONE:
-                    route_name = route.path + "/" if trim else route.path[:-1]
-                    break
+
+            route_name = _get_route_name(redirect_scope, routes)
+            route_name = route_name + "/" if trim else route_name[:-1]
         return route_name

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -217,7 +217,6 @@ class ElasticAPM(BaseHTTPMiddleware):
                 elif match == Match.PARTIAL and route_name is None:
                     route_name = route.path
 
-
         route_name = _get_route_name(scope, routes)
 
         # Starlette magically redirects requests if the path matches a route name with a trailing slash

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -35,7 +35,7 @@ import starlette
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Match
+from starlette.routing import Match, Mount
 from starlette.types import ASGIApp
 
 import elasticapm
@@ -199,18 +199,27 @@ class ElasticAPM(BaseHTTPMiddleware):
         elasticapm.set_transaction_result(result, override=False)
 
     def get_route_name(self, request: Request) -> str:
-        route_name = None
         app = request.app
         scope = request.scope
         routes = app.routes
 
-        for route in routes:
-            match, _ = route.matches(scope)
-            if match == Match.FULL:
-                route_name = route.path
-                break
-            elif match == Match.PARTIAL and route_name is None:
-                route_name = route.path
+        def _get_route_name(scope, routes, route_name=None):
+            for route in routes:
+                match, child_scope = route.matches(scope)
+                if match == Match.FULL:
+                    route_name = route.path
+                    child_scope = {**scope, **child_scope}
+                    if isinstance(route, Mount):
+                        child_route_name = _get_route_name(child_scope, route.routes, route_name)
+                        if child_route_name:
+                            route_name += child_route_name
+                    return route_name
+                elif match == Match.PARTIAL and route_name is None:
+                    route_name = route.path
+
+
+        route_name = _get_route_name(scope, routes)
+
         # Starlette magically redirects requests if the path matches a route name with a trailing slash
         # appended or removed. To not spam the transaction names list, we do the same here and put these
         # redirects all in the same "redirect trailing slashes" transaction name

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -281,6 +281,7 @@ def test_transaction_name_is_route(app, elasticapm_client):
     (
         ("/hi/shay/with/slash", "GET /hi/{name}/with/slash"),
         ("/hi/shay/without/slash/", "GET /hi/{name}/without/slash/"),
+        ("/sub/subsub/hihi/shay/", "GET /sub/subsub/hihi/{name}/"),
     ),
 )
 def test_trailing_slash_redirect_detection(app, elasticapm_client, url, expected):


### PR DESCRIPTION
## What does this pull request do?
Fix transaction names for starlette [Mount](https://www.starlette.io/routing/#submounting-routes) routes. 
Recursively build route names for mounted sub-applications.

## Related issues
closes #1036 

*Note: Opened it as a draft pull request because I couldn't write tests yet, but I still wanted to give you an idea of a potential fix.*