### PR TITLE
Fix for hang on capture_body: error in starlette

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,20 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 5.x" heading
+[float]
+===== Features
+
+
+[float]
+===== Bug fixes
+
+* Fix for potential `capture_body: error` hang in Starlette/FastAPI {pull}1038[#1038]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -121,7 +121,9 @@ async def set_body(request: Request, body: bytes):
 async def get_body(request: Request) -> str:
     """Gets body from the request.
 
-    todo: This is not very pretty however it is not usual to get request body out of the target method (business logic).
+    When we consume the body, we replace the streaming mechanism with
+    a mocked version -- this workaround came from
+    https://github.com/encode/starlette/issues/495#issuecomment-513138055
 
     Args:
         request (Request)


### PR DESCRIPTION
## What does this pull request do?

Because Starlette does not propagate the cached `request._body` properly, we've always had to use a [hack](https://github.com/encode/starlette/issues/495#issuecomment-513138055) in order to make sure we don't hang requests by streaming the body before the request does.

This PR ensures that for any `capture_body` setting that's not `off`, we perform this hack in the pre-request stage so that everyone will have easy access to the body down the line.

Before this fix, if `capture_body` was set to `error`, and an error was thrown after the body was already streamed, we would hang while trying to capture the body. I consider this a [bug in Starlette](https://github.com/encode/starlette/issues/495) but this should let us work around it.

## Related issues
Fixes #1032 
