### PR TITLE
Send request body as a string in Starlette

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix for potential `capture_body: error` hang in Starlette/FastAPI {pull}1038[#1038]
+* Fix for Starlette/FastAPI to correctly capture request bodies as strings {pull}1042[#1041]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -28,8 +28,6 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import json
-
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import Message
@@ -64,10 +62,6 @@ async def get_data_from_request(request: Request, config: Config, event_type: st
             body = None
             try:
                 body = await get_body(request)
-                if request.headers.get("content-type") == "application/x-www-form-urlencoded":
-                    body = await query_params_to_dict(body)
-                else:
-                    body = json.loads(body)
             except Exception:
                 pass
             if body is not None:

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -155,7 +155,7 @@ def test_post(app, elasticapm_client):
     request = transaction["context"]["request"]
     assert request["method"] == "POST"
     assert request["socket"] == {"remote_address": "127.0.0.1", "encrypted": False}
-    assert request["body"]["foo"] == "bar"
+    assert request["body"] == "foo=bar"
 
     assert span["name"] == "test"
 


### PR DESCRIPTION
## What does this pull request do?

I realized while debugging #1032 that we were erroneously sending the request body as a parsed-from-json object, rather than a string as the [spec](https://github.com/elastic/apm-server/blob/af4f9fe07ac714771526ef562e6618c6189e38fd/docs/spec/v2/error.json#L46-L52) requires. This PR fixes that.

## Related issues
Fixes #1032 (again)