### PR TITLE
Add defaults for all required config values

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -77,8 +77,8 @@ apm = ElasticAPM(app)
 ----
 
 [float]
-[[required-options]]
-=== Required options
+[[core-options]]
+=== Core options
 
 [float]
 [[config-service-name]]
@@ -86,14 +86,17 @@ apm = ElasticAPM(app)
 
 [options="header"]
 |============
-| Environment                | Django/Flask      | Default    | Example
-| `ELASTIC_APM_SERVICE_NAME` | `SERVICE_NAME`    | `None`     | `my-app`
+| Environment                | Django/Flask      | Default           | Example
+| `ELASTIC_APM_SERVICE_NAME` | `SERVICE_NAME`    | `python_service`  | `my-app`
 |============
 
 
 The name of your service.
 This is used to keep all the errors and transactions of your service together
 and is the primary filter in the Elastic APM user interface.
+
+While a default is provided, it is essential that you override this default
+with something more descriptive and unique across your infrastructure.
 
 NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 In less regexy terms:
@@ -143,19 +146,6 @@ If set to false, then the Python agent does not send any events to the Elastic A
 and instrumentation overhead is minimized,
 but the agent will continue to poll the server for configuration changes.
 
-
-[float]
-[[config-transport-class]]
-==== `transport_class`
-
-[options="header"]
-|============
-| Environment                   | Django/Flask      | Default
-| `ELASTIC_APM_TRANSPORT_CLASS` | `TRANSPORT_CLASS` | `elasticapm.transport.http.Transport`
-|============
-
-
-The transport class to use when sending events to the APM Server.
 
 [float]
 [[logging-options]]
@@ -228,6 +218,19 @@ the log files will consume is twice the value of this setting.
 [float]
 [[other-options]]
 === Other options
+
+[float]
+[[config-transport-class]]
+==== `transport_class`
+
+[options="header"]
+|============
+| Environment                   | Django/Flask      | Default
+| `ELASTIC_APM_TRANSPORT_CLASS` | `TRANSPORT_CLASS` | `elasticapm.transport.http.Transport`
+|============
+
+
+The transport class to use when sending events to the APM Server.
 
 [float]
 [[config-service-node-name]]

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -108,6 +108,8 @@ class Client(object):
             for msg in config.errors.values():
                 self.error_logger.error(msg)
             config.disable_send = True
+        if config.service_name == "python_service":
+            self.logger.warning("No custom SERVICE_NAME was set -- using non-descript default 'python_service'")
         self.config = VersionedConfig(config, version=None)
 
         # Insert the log_record_factory into the logging library

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -472,7 +472,9 @@ class _ConfigBase(object):
 
 
 class Config(_ConfigBase):
-    service_name = _ConfigValue("SERVICE_NAME", validators=[RegexValidator("^[a-zA-Z0-9 _-]+$")], required=True)
+    service_name = _ConfigValue(
+        "SERVICE_NAME", validators=[RegexValidator("^[a-zA-Z0-9 _-]+$")], default="python_service", required=True
+    )
     service_node_name = _ConfigValue("SERVICE_NODE_NAME")
     environment = _ConfigValue("ENVIRONMENT")
     secret_token = _ConfigValue("SECRET_TOKEN")

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1181,16 +1181,6 @@ def test_subcommand_not_known(argv_mock):
     assert 'No such command "foo"' in output
 
 
-def test_settings_missing():
-    stdout = compat.StringIO()
-    with override_settings(ELASTIC_APM={}):
-        call_command("elasticapm", "check", stdout=stdout)
-    output = stdout.getvalue()
-    assert "Configuration errors detected" in output
-    assert "SERVICE_NAME not set" in output
-    assert "optional SECRET_TOKEN not set" in output
-
-
 def test_settings_missing_secret_token_no_https():
     stdout = compat.StringIO()
     with override_settings(ELASTIC_APM={"SERVER_URL": "http://foo"}):
@@ -1255,7 +1245,6 @@ def test_settings_server_url_not_http_nor_https():
     with override_settings(ELASTIC_APM={"SERVER_URL": "xhttp://dev.brwnppr.com:8000/"}):
         call_command("elasticapm", "check", stdout=stdout)
     output = stdout.getvalue()
-    assert "Configuration errors detected" in output
     assert "SERVER_URL has scheme xhttp and we require http or https" in output
 
 


### PR DESCRIPTION
## What does this pull request do?

Adds a default for all required configuration values. This allows the agent to be used with zero configuration alongside something like the Fleet Agent. We don't do any fancy detection around the `SERVICE_NAME`, it just defaults to `python_service` (and logs a warning if it's not overridden by the user).

"Zero-configuration" is actually pretty worthless by itself, but the hope is that along with #1019 we should be able to allow the user to onboard with no code changes and just an invocation change.

## Related issues
Fixes #1008 
