### PR TITLE
Refactor auto_ecs_logging to log_ecs_formatting

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,7 @@ endif::[]
 ===== Features
 
 * Add global access to Client singleton object at `elasticapm.get_client()` {pull}1043[#1043]
-* Add `auto_ecs_logging` config option {pull}1058[#1058]
+* Add `log_ecs_formatting` config option {pull}1058[#1058] {pull}1063[#1063]
 
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -231,10 +231,10 @@ the log files will consume is twice the value of this setting.
 Valid options:
 
 * `"off"`
-* `"on"`
+* `"override"`
 
 If https://github.com/elastic/ecs-logging-python[`ecs_logging`] is installed,
-setting this to `"on"` will cause the agent to automatically attempt to enable
+setting this to `"override"` will cause the agent to automatically attempt to enable
 ecs-formatted logging.
 
 For base `logging` from the standard library, the agent will get the root

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -219,17 +219,22 @@ The agent always keeps one backup file when rotating, so the max space that
 the log files will consume is twice the value of this setting.
 
 [float]
-[[config-auto_ecs_logging]]
-==== `auto_ecs_logging`
+[[config-log_ecs_formatting]]
+==== `log_ecs_formatting`
 
 [options="header"]
 |============
-| Environment                    | Django/Flask       | Default
-| `ELASTIC_APM_AUTO_ECS_LOGGING` | `AUTO_ECS_LOGGING` | `False`
+| Environment                      | Django/Flask         | Default
+| `ELASTIC_APM_LOG_ECS_FORMATTING` | `LOG_ECS_FORMATTING` | `"off"`
 |============
 
+Valid options:
+
+* `"off"`
+* `"on"`
+
 If https://github.com/elastic/ecs-logging-python[`ecs_logging`] is installed,
-setting this to `True` will cause the agent to automatically attempt to enable
+setting this to `"on"` will cause the agent to automatically attempt to enable
 ecs-formatted logging.
 
 For base `logging` from the standard library, the agent will get the root
@@ -241,7 +246,7 @@ with `ecs_logging.StructlogFormatter()`.
 
 Note that this is a very blunt instrument that could have unintended side effects.
 If problems arise, please apply these formatters manually and leave this setting
-as `False`. See the
+as `"off"`. See the
 https://www.elastic.co/guide/en/ecs-logging/python/current/installation.html[`ecs_logging` docs]
 for more information about using these formatters.
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -378,12 +378,12 @@ def _log_level_callback(dict_key, old_value, new_value, config_instance):
 
 def _log_ecs_formatting_callback(dict_key, old_value, new_value, config_instance):
     """
-    If ecs_logging is installed and log_ecs_formatting is set to "on", we should
+    If ecs_logging is installed and log_ecs_formatting is set to "override", we should
     set the ecs_logging.StdlibFormatter as the formatted for every handler in
     the root logger, and set the default processor for structlog to the
     ecs_logging.StructlogFormatter.
     """
-    if new_value.lower() == "on":
+    if new_value.lower() == "override":
         try:
             import ecs_logging
         except ImportError:
@@ -618,7 +618,7 @@ class Config(_ConfigBase):
     log_file_size = _ConfigValue("LOG_FILE_SIZE", validators=[size_validator], type=int, default=50 * 1024 * 1024)
     log_ecs_formatting = _ConfigValue(
         "LOG_ECS_FORMATTING",
-        validators=[EnumerationValidator(["off", "on"])],
+        validators=[EnumerationValidator(["off", "override"])],
         callbacks=[_log_ecs_formatting_callback],
         default="off",
     )

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -376,14 +376,14 @@ def _log_level_callback(dict_key, old_value, new_value, config_instance):
         elasticapm_logger.addHandler(filehandler)
 
 
-def _auto_ecs_logging_callback(dict_key, old_value, new_value, config_instance):
+def _log_ecs_formatting_callback(dict_key, old_value, new_value, config_instance):
     """
-    If ecs_logging is installed and auto_ecs_logging is set to True, we should
+    If ecs_logging is installed and log_ecs_formatting is set to "on", we should
     set the ecs_logging.StdlibFormatter as the formatted for every handler in
     the root logger, and set the default processor for structlog to the
     ecs_logging.StructlogFormatter.
     """
-    if new_value:
+    if new_value.lower() == "on":
         try:
             import ecs_logging
         except ImportError:
@@ -616,7 +616,12 @@ class Config(_ConfigBase):
     )
     log_file = _ConfigValue("LOG_FILE", default="")
     log_file_size = _ConfigValue("LOG_FILE_SIZE", validators=[size_validator], type=int, default=50 * 1024 * 1024)
-    auto_ecs_logging = _BoolConfigValue("AUTO_ECS_LOGGING", callbacks=[_auto_ecs_logging_callback], default=False)
+    log_ecs_formatting = _ConfigValue(
+        "LOG_ECS_FORMATTING",
+        validators=[EnumerationValidator(["off", "on"])],
+        callbacks=[_log_ecs_formatting_callback],
+        default="off",
+    )
 
     @property
     def is_recording(self):

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -398,8 +398,8 @@ def test_log_file(elasticapm_client_log_file):
     assert found
 
 
-@pytest.mark.parametrize("elasticapm_client_log_file", [{"auto_ecs_logging": True}], indirect=True)
-def test_auto_ecs_logging(elasticapm_client_log_file):
+@pytest.mark.parametrize("elasticapm_client_log_file", [{"log_ecs_formatting": "on"}], indirect=True)
+def test_log_ecs_formatting(elasticapm_client_log_file):
     logger = logging.getLogger()
     assert isinstance(logger.handlers[0].formatter, ecs_logging.StdlibFormatter)
     assert isinstance(structlog.get_config()["processors"][-1], ecs_logging.StructlogFormatter)

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -398,7 +398,7 @@ def test_log_file(elasticapm_client_log_file):
     assert found
 
 
-@pytest.mark.parametrize("elasticapm_client_log_file", [{"log_ecs_formatting": "on"}], indirect=True)
+@pytest.mark.parametrize("elasticapm_client_log_file", [{"log_ecs_formatting": "override"}], indirect=True)
 def test_log_ecs_formatting(elasticapm_client_log_file):
     logger = logging.getLogger()
     assert isinstance(logger.handlers[0].formatter, ecs_logging.StdlibFormatter)


### PR DESCRIPTION
This matches the Java implementation which is more flexible (due
to using an enum instead of a bool) and will match the upcoming
ecs log formatting [spec](https://github.com/elastic/apm/pull/423)

Ref #1058 and #1006 