### PR TITLE
replace subtype http with host to get unique span values from external calls

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
@@ -47,14 +47,15 @@ class AioHttpClientInstrumentation(AsyncAbstractInstrumentedModule):
         url = str(url)
         destination = url_to_destination(url)
 
-        signature = " ".join([method.upper(), get_host_from_url(url)])
+        host = get_host_from_url(url)
+        signature = " ".join([method.upper(), host])
         url = sanitize_url(url)
         transaction = execution_context.get_transaction()
 
         async with async_capture_span(
             signature,
             span_type="external",
-            span_subtype="http",
+            span_subtype=host,
             extra={"http": {"url": url}, "destination": destination},
             leaf=True,
         ) as span:


### PR DESCRIPTION
## What does this pull request do?
resolves https://github.com/elastic/apm-agent-python/issues/1096


Added details in following issue: https://github.com/elastic/apm-agent-python/issues/1096
