### PR TITLE
exclude pypy-3/psycopg-2.7

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -130,6 +130,8 @@ exclude:
     FRAMEWORK: psycopg2-2.7
   - PYTHON_VERSION: python-3.10-rc # see https://github.com/psycopg/psycopg2/issues/858
     FRAMEWORK: psycopg2-2.7
+  - PYTHON_VERSION: pypy-3  # async keyword clash in old version of psycopg2cffi
+    FRAMEWORK: psycopg2-2.7
   # pyodbc
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: pyodbc-newest


### PR DESCRIPTION
pypy-3 gained support for the `async` keyword, making code fail that uses
`async` as an identifier. Such as old versions of pyscopg2cffi.


