### PR TITLE
add database as a dependency in asyncpg instrumentation

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -62,7 +62,7 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
             "port": int(kwargs.get("port", default_ports.get("postgresql"))),
             "service": {"name": "postgres", "resource": "postgres", "type": "db"},
         }
-        context['destination'] = destination_info
+        context["destination"] = destination_info
         async with async_capture_span(
             name, leaf=True, span_type="db", span_subtype="postgres", span_action=action, extra=context
         ):

--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -31,6 +31,7 @@
 from elasticapm.contrib.asyncio.traces import async_capture_span
 from elasticapm.instrumentation.packages.asyncio.base import AsyncAbstractInstrumentedModule
 from elasticapm.instrumentation.packages.dbapi2 import extract_signature
+from elasticapm.utils import default_ports
 
 
 class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
@@ -56,6 +57,12 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
         name = extract_signature(query)
         context = {"db": {"type": "sql", "statement": query}}
         action = "query"
+        destination_info = {
+            "address": kwargs.get("host", "localhost"),
+            "port": int(kwargs.get("port", default_ports.get("postgresql"))),
+            "service": {"name": "postgres", "resource": "postgres", "type": "db"},
+        }
+        context['destination'] = destination_info
         async with async_capture_span(
             name, leaf=True, span_type="db", span_subtype="postgres", span_action=action, extra=context
         ):


### PR DESCRIPTION
Adds database(postgres) as a dependency in python elastic apm for asyncpg instrumentation

I have taken the code from psycopg2 instrumentation which is able to show database as a dependency. Ran these changes locally and I can now see postgres under dependencies.

<img width="1415" alt="116056619-a139e600-a69b-11eb-80ae-58bb164c49ef" src="https://user-images.githubusercontent.com/1856343/116130121-7c1f9480-a6e8-11eb-950b-c5a6a79ab23b.png">


Related issues
closes #1111