### PR TITLE
Fix httpx 0.18.0

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/httpcore.py
+++ b/elasticapm/instrumentation/packages/asyncio/httpcore.py
@@ -48,8 +48,9 @@ class HTTPCoreAsyncInstrumentation(AsyncAbstractInstrumentedModule):
     name = "httpcore"
 
     instrument_list = [
-        ("httpcore._async.connection", "AsyncHTTPConnection.request"),
-        ("httpcore._async.connection", "AsyncHTTPConnection.arequest"),
+        ("httpcore._async.connection", "AsyncHTTPConnection.request"),  # < httpcore 0.11
+        ("httpcore._async.connection", "AsyncHTTPConnection.arequest"),  # httcore 0.11 - 0.12
+        ("httpcore._async.connection", "AsyncHTTPConnection.handle_async_request"),  # >= httpcore 0.13
     ]
 
     async def call(self, module, method, wrapped, instance, args, kwargs):

--- a/elasticapm/instrumentation/packages/httpcore.py
+++ b/elasticapm/instrumentation/packages/httpcore.py
@@ -39,7 +39,8 @@ class HTTPCoreInstrumentation(AbstractInstrumentedModule):
     name = "httpcore"
 
     instrument_list = [
-        ("httpcore._sync.connection", "SyncHTTPConnection.request"),
+        ("httpcore._sync.connection", "SyncHTTPConnection.request"),  # < httpcore 0.13
+        ("httpcore._sync.connection", "SyncHTTPConnection.handle_request"),  # >= httpcore 0.13
     ]
 
     def call(self, module, method, wrapped, instance, args, kwargs):

--- a/tests/instrumentation/httpx_tests.py
+++ b/tests/instrumentation/httpx_tests.py
@@ -120,12 +120,13 @@ def test_httpx_instrumentation_malformed_empty(instrument, elasticapm_client):
 
 def test_httpx_instrumentation_malformed_path(instrument, elasticapm_client):
     try:
-        from httpx._exceptions import LocalProtocolError
+        from httpx._exceptions import LocalProtocolError, UnsupportedProtocol
     except ImportError:
         pytest.skip("Test requires HTTPX 0.14+")
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
-        with pytest.raises(LocalProtocolError):
+        # raises UnsupportedProtocol since 0.18.0
+        with pytest.raises((LocalProtocolError, UnsupportedProtocol)):
             httpx.get("http://")
 
 


### PR DESCRIPTION
The newly released httpx 0.18.0 and its dependency httpcore 0.13 changed some internals that affect us.
