### PR TITLE
added a safeguard for processors that raise exceptions

### DIFF
--- a/docs/sanitizing-data.asciidoc
+++ b/docs/sanitizing-data.asciidoc
@@ -10,6 +10,9 @@ and returns the modified event.
 
 To completely drop an event, your processor should return `False` (or any other "falsy" value) instead of the event.
 
+An event will also be dropped if any processor raises an exception while processing it.
+A log message with level `WARNING` will be issued in this case.
+
 This is an example of a processor that removes the exception stacktrace from an error:
 
 [source,python]
@@ -46,7 +49,7 @@ ELASTIC_APM = {
 }
 ----
 
-NOTE: We recommend to use the above list of processors that sanitize passwords and secrets in different places of the event object.
+NOTE: We recommend using the above list of processors that sanitize passwords and secrets in different places of the event object.
 
 The default set of processors sanitize fields based on a set of defaults defined in `elasticapm.conf.constants`. This set can be configured with the `SANITIZE_FIELD_NAMES` configuration option. For example, if your application produces a sensitive field called `My-Sensitive-Field`, the default processors can be used to automatically sanitize this field. You can specify what fields to santize within default processors like this:
 

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -176,13 +176,23 @@ class Transport(ThreadManager):
         # Run the data through processors
         for processor in self._processors:
             if not hasattr(processor, "event_types") or event_type in processor.event_types:
-                data = processor(self.client, data)
-                if not data:
-                    logger.debug(
-                        "Dropped event of type %s due to processor %s.%s",
+                try:
+                    data = processor(self.client, data)
+                    if not data:
+                        logger.debug(
+                            "Dropped event of type %s due to processor %s.%s",
+                            event_type,
+                            getattr(processor, "__module__"),
+                            getattr(processor, "__name__"),
+                        )
+                        return None
+                except Exception:
+                    logger.warning(
+                        "Dropped event of type %s due to exception in processor %s.%s",
                         event_type,
                         getattr(processor, "__module__"),
                         getattr(processor, "__name__"),
+                        exc_info=True,
                     )
                     return None
         return data
@@ -213,7 +223,6 @@ class Transport(ThreadManager):
     def _flush(self, buffer):
         """
         Flush the queue. This method should only be called from the event processing queue
-        :param sync: if true, flushes the queue synchronously in the current thread
         :return: None
         """
         if not self.state.should_try():

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -182,16 +182,16 @@ class Transport(ThreadManager):
                         logger.debug(
                             "Dropped event of type %s due to processor %s.%s",
                             event_type,
-                            getattr(processor, "__module__"),
-                            getattr(processor, "__name__"),
+                            processor.__module__,
+                            processor.__name__,
                         )
                         return None
                 except Exception:
                     logger.warning(
                         "Dropped event of type %s due to exception in processor %s.%s",
                         event_type,
-                        getattr(processor, "__module__"),
-                        getattr(processor, "__name__"),
+                        processor.__module__,
+                        processor.__name__,
                         exc_info=True,
                     )
                     return None


### PR DESCRIPTION
## What does this pull request do?

Without this safeguard, exceptions in processors would bubble all the way
up, killing the transport thread. This would then result in the agent
stopping to report any data.
