### PR TITLE
Ensure that metrics are flushed before shutting down

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -213,11 +213,11 @@ class Client(object):
         set_client(self)
 
     def start_threads(self):
-        with self._thread_starter_lock:
-            current_pid = os.getpid()
-            if self._pid != current_pid:
+        current_pid = os.getpid()
+        if self._pid != current_pid:
+            with self._thread_starter_lock:
                 self.logger.debug("Detected PID change from %r to %r, starting threads", self._pid, current_pid)
-                for manager_type, manager in self._thread_managers.items():
+                for manager_type, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].priority):
                     self.logger.debug("Starting %s thread", manager_type)
                     manager.start_thread(pid=current_pid)
                 self._pid = current_pid
@@ -303,7 +303,7 @@ class Client(object):
     def close(self):
         if self.config.enabled:
             with self._thread_starter_lock:
-                for _, manager in self._thread_managers.items():
+                for _, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].priority):
                     manager.stop_thread()
         global CLIENT_SINGLETON
         CLIENT_SINGLETON = None

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -217,7 +217,9 @@ class Client(object):
         if self._pid != current_pid:
             with self._thread_starter_lock:
                 self.logger.debug("Detected PID change from %r to %r, starting threads", self._pid, current_pid)
-                for manager_type, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].priority):
+                for manager_type, manager in sorted(
+                    self._thread_managers.items(), key=lambda item: item[1].start_stop_order
+                ):
                     self.logger.debug("Starting %s thread", manager_type)
                     manager.start_thread(pid=current_pid)
                 self._pid = current_pid
@@ -303,7 +305,7 @@ class Client(object):
     def close(self):
         if self.config.enabled:
             with self._thread_starter_lock:
-                for _, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].priority):
+                for _, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].start_stop_order):
                     manager.stop_thread()
         global CLIENT_SINGLETON
         CLIENT_SINGLETON = None

--- a/elasticapm/metrics/base_metrics.py
+++ b/elasticapm/metrics/base_metrics.py
@@ -103,6 +103,8 @@ class MetricsRegistry(ThreadManager):
             logger.debug("Cancelling collect timer")
             self._collect_timer.cancel()
             self._collect_timer = None
+            # collect one last time
+            self.collect()
 
     @property
     def collect_interval(self):

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -33,6 +33,7 @@
 import gzip
 import os
 import random
+import sys
 import threading
 import time
 import timeit
@@ -86,6 +87,7 @@ class Transport(ThreadManager):
         self._closed = False
         self._processors = processors if processors is not None else []
         super(Transport, self).__init__()
+        self.priority = sys.maxsize  # ensure that the transport thread is always started/stopped last
 
     @property
     def _max_flush_time(self):

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -87,7 +87,7 @@ class Transport(ThreadManager):
         self._closed = False
         self._processors = processors if processors is not None else []
         super(Transport, self).__init__()
-        self.priority = sys.maxsize  # ensure that the transport thread is always started/stopped last
+        self.start_stop_order = sys.maxsize  # ensure that the transport thread is always started/stopped last
 
     @property
     def _max_flush_time(self):

--- a/elasticapm/utils/threading.py
+++ b/elasticapm/utils/threading.py
@@ -91,7 +91,7 @@ class IntervalTimer(threading.Thread):
 class ThreadManager(object):
     def __init__(self):
         self.pid = None
-        self.priority = 100
+        self.start_stop_order = 100
 
     def start_thread(self, pid=None):
         if not pid:

--- a/elasticapm/utils/threading.py
+++ b/elasticapm/utils/threading.py
@@ -91,6 +91,7 @@ class IntervalTimer(threading.Thread):
 class ThreadManager(object):
     def __init__(self):
         self.pid = None
+        self.priority = 100
 
     def start_thread(self, pid=None):
         if not pid:


### PR DESCRIPTION
To ensure that the flushed metrics are actually sent, we need
to make sure that the transport thread is shut down last.

See also https://github.com/elastic/apm/pull/444

