### PR TITLE
skip pubsub test on redis 2

### DIFF
--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -41,8 +41,8 @@ FRAMEWORK:
   - pymongo-3.4
   - pymongo-3.5
   - pymongo-newest
-  - redis-2.8
-  - redis-2.9
+  - redis-3
+  - redis-2
   - redis-newest
   - psycopg2-2.7
   - psycopg2-newest

--- a/tests/instrumentation/redis_tests.py
+++ b/tests/instrumentation/redis_tests.py
@@ -165,6 +165,7 @@ def test_unix_domain_socket_connection_destination_info():
     assert destination_info["address"] == "unix:///some/path"
 
 
+@pytest.mark.skipif(redis.VERSION < (3,), reason="pubsub not available as context manager in redis-py 2")
 @pytest.mark.integrationtest
 def test_publish_subscribe(instrument, elasticapm_client, redis_conn):
     elasticapm_client.begin_transaction("transaction.test")

--- a/tests/requirements/reqs-redis-2.txt
+++ b/tests/requirements/reqs-redis-2.txt
@@ -1,2 +1,2 @@
-redis>=2.8,<2.9
+redis<3
 -r reqs-base.txt

--- a/tests/requirements/reqs-redis-3.0.txt
+++ b/tests/requirements/reqs-redis-3.0.txt
@@ -1,2 +1,0 @@
-redis>=3.0.0,<3.1.0
--r reqs-base.txt

--- a/tests/requirements/reqs-redis-3.txt
+++ b/tests/requirements/reqs-redis-3.txt
@@ -1,2 +1,2 @@
-redis>=2.9,<2.10
+redis<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-redis-newest.txt
+++ b/tests/requirements/reqs-redis-newest.txt
@@ -1,2 +1,2 @@
-redis>=2.10
+redis
 -r reqs-base.txt


### PR DESCRIPTION
the pubsub test uses a context manager API that isn't available on redis 2.

Also, don't test specific redis 2 versions, only the most recent 2.x

