### PR TITLE
catch and log exceptions in the interval timer function

### DIFF
--- a/elasticapm/utils/threading.py
+++ b/elasticapm/utils/threading.py
@@ -30,9 +30,12 @@
 
 from __future__ import absolute_import
 
+import logging
 import os
 import threading
 from timeit import default_timer
+
+logger = logging.getLogger("elasticapm.utils.threading")
 
 
 class IntervalTimer(threading.Thread):
@@ -77,11 +80,15 @@ class IntervalTimer(threading.Thread):
                 # we've been cancelled, time to go home
                 return
             start = default_timer()
-            rval = self._function(*self._args, **self._kwargs)
-            if self._evaluate_function_interval and isinstance(rval, (int, float)):
-                interval_override = rval
-            else:
-                interval_override = None
+            try:
+                rval = self._function(*self._args, **self._kwargs)
+                if self._evaluate_function_interval and isinstance(rval, (int, float)):
+                    interval_override = rval
+                else:
+                    interval_override = None
+            except Exception:
+                logger.error("Exception in interval timer function", exc_info=True)
+
             execution_time = default_timer() - start
 
     def cancel(self):


### PR DESCRIPTION
Instead of letting the thread die, we log the exception with
a stack trace to ease debugging.

Specifically, we have a hard to debug exception in the configuration updater,
and need a stack trace to debug the issue. But this should be helpful in other
cases, too.