### PR TITLE
add start_stop_order to VersionedConfig.__slots__

### DIFF
--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -647,6 +647,7 @@ class VersionedConfig(ThreadManager):
         "transport",
         "_update_thread",
         "pid",
+        "start_stop_order",
     )
 
     def __init__(self, config_object, version, transport=None):

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -428,3 +428,13 @@ def test_valid_values_validator():
     assert v("Bar", "foo") == "Bar"
     with pytest.raises(ConfigurationError):
         v("foobar", "foo")
+
+
+def test_versioned_config_attribute_access(elasticapm_client):
+    # see https://github.com/elastic/apm-agent-python/issues/1147
+    val = elasticapm_client.config.start_stop_order
+    assert isinstance(val, int)
+    # update config to ensure start_stop_order isn't read from the proxied Config object
+    elasticapm_client.config.update("2", capture_body=True)
+    val = elasticapm_client.config.start_stop_order
+    assert isinstance(val, int)


### PR DESCRIPTION
This ensures that the attribute is set on VersionedConfig itself,
not on the proxied Config object. The later works, but only until
the configuration is updated and the Config object is switched out
with a new one that doesn't have the attribute.

fixes #1147

