### PR TITLE
include matrix info in pytest output

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,8 +30,8 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 import importlib
+import os
 import sys
 from os.path import abspath, dirname
 
@@ -69,3 +69,8 @@ for module, fixtures in {
         pytest_plugins.append(fixtures)
     except ImportError:
         pass
+
+
+def pytest_report_header(config):
+    if "PYTHON_VERSION" in os.environ:
+        return "matrix: {}/{}".format(os.environ.get("PYTHON_VERSION"), os.environ.get("WEBFRAMEWORK"))


### PR DESCRIPTION
this makes it a bit (not much) easier to tell in which matrix test exactly a test has run
in the Jenkins UI


