### PR TITLE
suppress the default_app_config attribute in Django 3.2+

### DIFF
--- a/elasticapm/contrib/django/__init__.py
+++ b/elasticapm/contrib/django/__init__.py
@@ -27,7 +27,9 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from django import VERSION as DJANGO_VERSION
 
 from elasticapm.contrib.django.client import *  # noqa E401
 
-default_app_config = "elasticapm.contrib.django.apps.ElasticAPMConfig"
+if DJANGO_VERSION < (3, 2):
+    default_app_config = "elasticapm.contrib.django.apps.ElasticAPMConfig"

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1614,4 +1614,4 @@ def test_default_app_config_present_by_version():
     if django.VERSION < (3, 2):
         assert default_app_config_is_defined
     else:
-        assert default_app_config_is_defined
+        assert not default_app_config_is_defined

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1604,3 +1604,14 @@ def test_django_ignore_transaction_urls(client, django_elasticapm_client):
         django_elasticapm_client.config.update(1, transaction_ignore_urls="/no*")
         client.get("/no-error")
     assert len(django_elasticapm_client.events[TRANSACTION]) == 1
+
+
+def test_default_app_config_present_by_version():
+    # The default_app_config attribute was deprecated in Django 3.2
+    import elasticapm.contrib.django
+
+    default_app_config_is_defined = hasattr(elasticapm.contrib.django, "default_app_config")
+    if django.VERSION < (3, 2):
+        assert default_app_config_is_defined
+    else:
+        assert default_app_config_is_defined


### PR DESCRIPTION
The attribute was deprecated in Django 3.2, defining it causes a `RemovedInDjango41Warning`.

fixes #1130
