### PR TITLE
bump log level for multiple set_client calls to WARNING

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -631,5 +631,5 @@ def set_client(client):
     global CLIENT_SINGLETON
     if CLIENT_SINGLETON:
         logger = get_logger("elasticapm")
-        logger.debug("Client object is being set more than once", stack_info=True)
+        logger.warning("Client object is being set more than once", stack_info=True)
     CLIENT_SINGLETON = client


### PR DESCRIPTION
it turns out that setting the agent multiple times can
result in difficult-to-debug issues, especially when
initially using the DjangoClient, and having it replaced
with a "bare" Client. See #1093, #1148

By bumping this log message to WARNING, it is a bit more
obvious what the problem could be.

