### PR TITLE
Fix redis supported technologies doc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ endif::[]
 ===== Features
 
 * Add additional context information about elasticsearch client requests {pull}1108[#1108]
+* Add `use_certifi` config option to allow users to disable `certifi` {pull}1163[#1163]
 
 [float]
 ===== Bug fixes

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -345,7 +345,7 @@ Collected trace data:
 [[automatic-instrumentation-db-redis]]
 ==== Redis
 
-Library: `redis` (`>=2.8,<3.2.0`)
+Library: `redis` (`>=2.8`)
 
 Instrumented methods:
 
@@ -570,8 +570,8 @@ Additionally, some services collect more specific data
 ===== DynamoDB
 
  * Table name
- 
- 
+
+
 [float]
 [[automatic-instrumentation-sns]]
 ===== SNS


### PR DESCRIPTION
Our CI is testing against [lastest redis](https://github.com/elastic/apm-agent-python/blob/master/tests/requirements/reqs-redis-newest.txt) so we don't need this upper boundary.

Also updated the CHANGELOG from #1163

Fixes #1179