### PR TITLE
Fix isort lint for starlette_tests.py

### DIFF
--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -28,12 +28,13 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
 import pytest  # isort:skip
 
 from tests.fixtures import TempStoreClient
 
 starlette = pytest.importorskip("starlette")  # isort:skip
+
+import os
 
 import mock
 import urllib3


### PR DESCRIPTION
## What does this pull request do?

Turns out we did have a lint error in #1174 -- not sure how it slipped through the tests run on the PR.

This fixes those lint errors, even though they're not erroring upstream because pre-commit only runs on changes. (Maybe we need to revisit that?)

For any who are interested, [this](https://github.com/PyCQA/isort/issues/1337) is why the `# isort:skip` wasn't working. If we wanted to have the `import os` at the top we would have to use `# isort:split`.

## Related issues
Fixes #1181 
