### PR TITLE
raise an exception for non-http scopes in the Starlette middleware

### DIFF
--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -130,6 +130,9 @@ class ElasticAPM:
             receive: receive awaitable callable
             send: send awaitable callable
         """
+        # we only handle the http scope, raise an exception for anything else
+        # see https://www.uvicorn.org/#the-asgi-interface
+        assert scope["type"] == "http"
 
         @functools.wraps(send)
         async def wrapped_send(message):


### PR DESCRIPTION
## What does this pull request do?

For scope types that we do not support, raising an exception seems to be the appropriate way to signal the lack of support to the server, see e.g. https://www.uvicorn.org/#the-asgi-interface

> It's good practice for applications to raise an exception on scope types that they do not handle.

Without this, the server could wait forever for us to handle a scope that we do not support.


## Related issues
closes #1184
