### PR TITLE
Fix Starlette/FastAPI middleware for non-http scopes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,20 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+[float]
+===== Features
+
+
+[float]
+===== Bug fixes
+
+* Fix handling of non-http scopes in Starlette/FastAPI middleware {pull}1187[#1187]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -133,6 +133,7 @@ class ElasticAPM:
         # we only handle the http scope, skip anything else.
         if scope["type"] != "http":
             await self.app(scope, receive, send)
+            return
 
         @functools.wraps(send)
         async def wrapped_send(message):

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -130,9 +130,9 @@ class ElasticAPM:
             receive: receive awaitable callable
             send: send awaitable callable
         """
-        # we only handle the http scope, raise an exception for anything else
-        # see https://www.uvicorn.org/#the-asgi-interface
-        assert scope["type"] == "http"
+        # we only handle the http scope, skip anything else.
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
 
         @functools.wraps(send)
         async def wrapped_send(message):


### PR DESCRIPTION
## What does this pull request do?

Raising an error as we do in #1185 is not the correct behavior for non-http scopes in our middleware. Just because we don't handle non-http scopes doesn't mean Starlette/FastAPI can't. Instead of raising an exception, we just need to skip all of our processing and await the app and immediately return.

I verified that this works as a fix for both #1184 and #1186.

## Related issues
Closes #1186 
