### PR TITLE
limit the transport exception message to 10000 characters

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -106,7 +106,7 @@ class Transport(HTTPTransportBase):
                 else:
                     message = "HTTP %s: " % response.status
                     print_trace = True
-                message += body.decode("utf8", errors="replace")
+                message += body.decode("utf8", errors="replace")[:10000]
                 raise TransportException(message, data, print_trace=print_trace)
             return response.getheader("Location")
         finally:


### PR DESCRIPTION
In cases where the response from APM Server is very large,
the log is spammed with extremely long log messages.

