### PR TITLE
Filter to supported Jenkins branches

### DIFF
--- a/.ci/jobs/apm-agent-python-mbp.yml
+++ b/.ci/jobs/apm-agent-python-mbp.yml
@@ -19,6 +19,7 @@
         repo: apm-agent-python
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        head-filter-regex: '^(master|PR-.*|[5-9]\.x)$'
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:


### PR DESCRIPTION
## What does this pull request do?

Filters to only the currently supported branches.

Current view:

<img width="668" alt="Screen Shot 2021-08-02 at 10 54 34 AM" src="https://user-images.githubusercontent.com/111616/127833388-d4e71323-2202-4a25-b9b7-fbaf21cd58af.png">

Proposed view:

<img width="387" alt="Screen Shot 2021-08-02 at 10 52 38 AM" src="https://user-images.githubusercontent.com/111616/127833428-7b9456f1-0a91-4cfc-87c2-c940e2484742.png">

## Related issues

This is per a discussion with @basepi in a private repo. I will link back to this issue from there.
