### PR TITLE
Never error in json serialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,11 +37,13 @@ endif::[]
 [float]
 ===== Features
 
-* Renamed the experimental `log_ecs_formatting` config to `log_ecs_reformatting` {pull}1300[#1300]
+* Rename the experimental `log_ecs_formatting` config to `log_ecs_reformatting` {pull}1300[#1300]
 
 
 [float]
 ===== Bug fixes
+
+* Fix potential errors in json serialization {pull}1203[#1203]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/utils/json_encoder.py
+++ b/elasticapm/utils/json_encoder.py
@@ -52,7 +52,10 @@ class BetterJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if type(obj) in self.ENCODERS:
             return self.ENCODERS[type(obj)](obj)
-        return super(BetterJSONEncoder, self).default(obj)
+        try:
+            return super(BetterJSONEncoder, self).default(obj)
+        except TypeError:
+            return str(obj)
 
 
 def better_decoder(data):

--- a/tests/utils/json_utils/tests.py
+++ b/tests/utils/json_utils/tests.py
@@ -71,3 +71,8 @@ def test_bytes():
 def test_decimal():
     res = decimal.Decimal("1.0")
     assert json.dumps(res) == "1.0"
+
+
+def test_unsupported():
+    res = object()
+    assert json.dumps(res).startswith('"<object object at')


### PR DESCRIPTION
## What does this pull request do?

Fixes the default case for json serialization so we never throw an error and interrupt the host application.

## Related issues
Closes #1202 
