### PR TITLE
Fix cookie sanitization if Cookie is capitalized

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,13 @@ repos:
     rev: 5.7.0
     hooks:
     -   id: isort
--   repo: https://github.com/ambv/black
-    rev: 20.8b1
+-   repo: local
     hooks:
     -   id: black
-        language_version: python3
+        name: black
+        entry: black --check
+        language: system
+        types: [python]
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,11 @@ repos:
     rev: 5.7.0
     hooks:
     -   id: isort
--   repo: local
+-   repo: https://github.com/ambv/black
+    rev: 20.8b1
     hooks:
     -   id: black
-        name: black
-        entry: black --check
-        language: system
-        types: [python]
+        language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,8 @@ endif::[]
 [float]
 ===== Bug fixes
 
+* Fixed cookie sanitization when Cookie is capitalized {pull}1301[#1301]
+
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -118,7 +118,14 @@ def sanitize_http_request_cookies(client, event):
             cookie_string, "; ", "=", sanitize_field_names=client.config.sanitize_field_names
         )
     except (KeyError, TypeError):
-        pass
+        try:
+            # Sometimes it's Cookie, not cookie
+            cookie_string = force_text(event["context"]["request"]["headers"]["Cookie"], errors="replace")
+            event["context"]["request"]["headers"]["Cookie"] = _sanitize_string(
+                cookie_string, "; ", "=", sanitize_field_names=client.config.sanitize_field_names
+            )
+        except (KeyError, TypeError):
+            pass
     return event
 
 

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -222,6 +222,25 @@ def test_sanitize_http_request_cookies(elasticapm_client, custom_field, expected
 
     assert result["context"]["request"]["headers"]["cookie"] == expected_header_cookies
 
+    http_test_data["context"]["request"]["headers"].pop("cookie")
+    http_test_data["context"]["request"]["headers"][
+        "Cookie"
+    ] = "foo=bar; password=12345; secret=12345; csrftoken=abc; custom-sensitive-cookie=123"
+
+    result = processors.sanitize_http_request_cookies(elasticapm_client, http_test_data)
+    expected = {
+        "foo": "bar",
+        "password": processors.MASK,
+        "secret": processors.MASK,
+        "sessionid": processors.MASK,
+    }
+
+    expected.update(custom_field)
+
+    assert result["context"]["request"]["cookies"] == expected
+
+    assert result["context"]["request"]["headers"]["Cookie"] == expected_header_cookies
+
 
 @pytest.mark.parametrize(
     "elasticapm_client, expected_cookies",


### PR DESCRIPTION
## What does this pull request do?

Sometimes, the `cookie` header is actually `Cookie`, so check for both if there's an error.

## Related issues
Closes #1297 
