### PR TITLE
avoid typing_extensions 3.10.0.1

### DIFF
--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -51,3 +51,4 @@ structlog
 
 pytest-asyncio==0.15.1 ; python_version >= '3.7'
 asynctest==0.13.0 ; python_version >= '3.7'
+typing_extensions!=3.10.0.1 ; python_version >= '3.10' # see https://github.com/python/typing/issues/865


### PR DESCRIPTION
That specific version has a bug on Python 3.10

See https://github.com/python/typing/issues/865

## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues
closes #ISSUE
