### PR TITLE
Add Django 3.2 to supported technologies doc

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -35,6 +35,7 @@ We support these Django versions:
  * 2.2
  * 3.0
  * 3.1
+ * 3.2
 
 For upcoming Django versions, we generally aim to ensure compatibility starting with the first Release Candidate.
 


### PR DESCRIPTION
Support was added in https://github.com/elastic/apm-agent-python/pull/1064
