### PR TITLE
don't initialize a client with a real transport in logging test

### DIFF
--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -361,7 +361,7 @@ def test_formatter():
 def test_logging_handler_no_client(recwarn):
     # In 6.0, this should be changed to expect a ValueError instead of a log
     warnings.simplefilter("always")
-    LoggingHandler()
+    LoggingHandler(transport_class="tests.fixtures.DummyTransport")
     while True:
         # If we never find our desired warning this will eventually throw an
         # AssertionError


### PR DESCRIPTION
this client will start to try making connections to the default
APM Server, fail to reach it, and spam the log with connection
errors.

We can avoid this by using a dummy transport
