### PR TITLE
Fixed AsyncPG Integration who missed a lot of spans

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -49,18 +49,13 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
         ("asyncpg.protocol.protocol", "Protocol.bind_execute_many"),
         ("asyncpg.protocol.protocol", "Protocol.bind"),
         ("asyncpg.protocol.protocol", "Protocol.execute"),
-        ("asyncpg.protocol.protocol", "Protocol.prepare"),
         ("asyncpg.protocol.protocol", "Protocol.query"),
         ("asyncpg.protocol.protocol", "Protocol.copy_in"),
         ("asyncpg.protocol.protocol", "Protocol.copy_out"),
     ]
 
     def get_query(self, method, args):
-        if method == 'Protocol.prepare':
-            return "PREPARE {stmt_name} FROM '{query}'".format(
-                stmt_name=args[0], query=args[1]
-            )
-        elif method in ['Protocol.query', 'Protocol.copy_in', 'Protocol.copy_out']:
+        if method in ['Protocol.query', 'Protocol.copy_in', 'Protocol.copy_out']:
             return args[0]
         else:
             return args[0].query

--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -73,10 +73,10 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
         destination_info = {
             "address": kwargs.get("host", "localhost"),
             "port": int(kwargs.get("port", default_ports.get("postgresql"))),
-            "service": {"name": "postgres", "resource": "postgres", "type": "db"},
+            "service": {"name": "postgresql", "resource": "postgresql", "type": "db"},
         }
         context["destination"] = destination_info
         async with async_capture_span(
-            name, leaf=True, span_type="db", span_subtype="postgres", span_action=action, extra=context
+            name, leaf=True, span_type="db", span_subtype="postgresql", span_action=action, extra=context
         ):
             return await wrapped(*args, **kwargs)

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -81,7 +81,7 @@ async def test_execute_with_sleep(instrument, connection, elasticapm_client):
     assert 100 < span["duration"] < 110
     assert transaction["id"] == span["transaction_id"]
     assert span["type"] == "db"
-    assert span["subtype"] == "postgres"
+    assert span["subtype"] == "postgresql"
     assert span["action"] == "query"
     assert span["sync"] == False
     assert span["name"] == "SELECT FROM"
@@ -98,7 +98,7 @@ async def test_executemany(instrument, connection, elasticapm_client):
     assert len(spans) == 1
     span = spans[0]
     assert transaction["id"] == span["transaction_id"]
-    assert span["subtype"] == "postgres"
+    assert span["subtype"] == "postgresql"
     assert span["action"] == "query"
     assert span["sync"] == False
     assert span["name"] == "INSERT INTO test"
@@ -135,7 +135,7 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
     assert len(spans) == 1
     span = spans[0]
     assert transaction["id"] == span["transaction_id"]
-    assert span["subtype"] == "postgres"
+    assert span["subtype"] == "postgresql"
     assert span["action"] == "query"
     assert span["sync"] is False
     assert span["name"] == "SELECT FROM test"

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -95,8 +95,8 @@ async def test_executemany(instrument, connection, elasticapm_client):
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
     spans = elasticapm_client.spans_for_transaction(transaction)
 
-    assert len(spans) == 2
-    span = spans[1]
+    assert len(spans) == 1
+    span = spans[0]
     assert transaction["id"] == span["transaction_id"]
     assert span["subtype"] == "postgresql"
     assert span["action"] == "query"
@@ -132,8 +132,8 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
     spans = elasticapm_client.spans_for_transaction(transaction)
 
-    assert len(spans) == 2
-    span = spans[1]
+    assert len(spans) == 1
+    span = spans[0]
     assert transaction["id"] == span["transaction_id"]
     assert span["subtype"] == "postgresql"
     assert span["action"] == "query"

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -95,8 +95,8 @@ async def test_executemany(instrument, connection, elasticapm_client):
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
     spans = elasticapm_client.spans_for_transaction(transaction)
 
-    assert len(spans) == 1
-    span = spans[0]
+    assert len(spans) == 2
+    span = spans[1]
     assert transaction["id"] == span["transaction_id"]
     assert span["subtype"] == "postgresql"
     assert span["action"] == "query"
@@ -132,8 +132,8 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
     spans = elasticapm_client.spans_for_transaction(transaction)
 
-    assert len(spans) == 1
-    span = spans[0]
+    assert len(spans) == 2
+    span = spans[1]
     assert transaction["id"] == span["transaction_id"]
     assert span["subtype"] == "postgresql"
     assert span["action"] == "query"


### PR DESCRIPTION
Hey guys,

So I've noticed that the ElasticAPM Python Agent was not binding itself to the right methods to gather AsyncPG data. I've taken a look at how the NewRelic Agent did it and came up with this modification. So instead of using the Connection object, which is sometimes not used (i.e: sqlalchemy) Im binding at the protocol layer to ensure no spans are missed.

I have been running this on production for a while now and it's great :)

Enjoy