### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/upstream/json-specs/error.json
+++ b/tests/upstream/json-specs/error.json
@@ -147,6 +147,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/tests/upstream/json-specs/span.json
+++ b/tests/upstream/json-specs/span.json
@@ -320,6 +320,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/tests/upstream/json-specs/transaction.json
+++ b/tests/upstream/json-specs/transaction.json
@@ -146,6 +146,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/527987315 intake: Add `context.message.routing_key` to API (https://github.com/elastic/apm-server/pull/6177)