### PR TITLE
Update github actions to add community labels

### DIFF
--- a/.github/community-label.yml
+++ b/.github/community-label.yml
@@ -1,0 +1,5 @@
+# add 'community' label to all new issues and PRs created by the community
+community:
+  - '.*'
+triage:
+  - '.*'

--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -3,8 +3,6 @@ name: Auto Assign to Project(s)
 on:
   issues:
     types: [opened, edited, milestoned]
-  pull_request_target:
-    types: [opened, edited, milestoned]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
@@ -20,10 +18,3 @@ jobs:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'
         column_name: 'Planned'
-    - name: Assign new pull requests to project
-      uses: elastic/assign-one-project-github-action@1.2.2
-      if: github.event.action == 'opened' && github.event.pull_request
-      with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'In Progress'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,13 +4,43 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: AlexanderWert/issue-labeler@v2.3
+    - name: Add agent-python label
+      uses: AlexanderWert/issue-labeler@v2.3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-config.yml
         enable-versioned-regex: 0
+    - name: Check team membership for user
+      uses: elastic/get-user-teams-membership@v1.0.4
+      id: checkUserMember
+      with:
+        username: ${{ github.actor }}
+        team: 'apm'
+        usernamesToExclude: |
+          apmmachine
+          dependabot
+        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+    - name: Show team membership
+      run: |
+        echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
+        echo "::debug::isExcluded: ${{ steps.checkUserMember.outputs.isExcluded }}"
+    - name: Add community and triage lables
+      if: steps.checkUserMember.outputs.isTeamMember != 'true' && steps.checkUserMember.outputs.isExcluded != 'true'
+      uses: AlexanderWert/issue-labeler@v2.3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/community-label.yml
+        enable-versioned-regex: 0
+    - name: Assign new internal pull requests to project
+      uses: elastic/assign-one-project-github-action@1.2.2
+      if: (steps.checkUserMember.outputs.isTeamMember == 'true' || steps.checkUserMember.outputs.isExcluded == 'true') && github.event.pull_request
+      with:
+        project: 'https://github.com/orgs/elastic/projects/454'
+        project_id: '5882982'
+        column_name: 'In Progress'


### PR DESCRIPTION
Updates github actions automation to:
- add triage and community labels to issues and PRs created by non-team members
- update project assignment behavior to exclude community PRs from being automatically added to the project board 
