### PR TITLE
Pass custom client to aiohttp tracing middleware

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,7 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Improve span coverage for `asyncpg` {pull}1328[#1328]
-
+* aiohttp: Correctly pass custom client to tracing middleware {pull}1345[#1345]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/contrib/aiohttp/__init__.py
+++ b/elasticapm/contrib/aiohttp/__init__.py
@@ -48,6 +48,6 @@ class ElasticAPM:
     def install_tracing(self, app, client):
         from elasticapm.contrib.aiohttp.middleware import tracing_middleware
 
-        app.middlewares.insert(0, tracing_middleware(app))
+        app.middlewares.insert(0, tracing_middleware(app, client))
         if client.config.instrument and client.config.enabled:
             elasticapm.instrument()

--- a/elasticapm/contrib/aiohttp/middleware.py
+++ b/elasticapm/contrib/aiohttp/middleware.py
@@ -44,9 +44,9 @@ class AioHttpTraceParent(TraceParent):
         return ",".join(headers.getall(key, [])) or None
 
 
-def tracing_middleware(app):
+def tracing_middleware(app, client=None):
     async def handle_request(request, handler):
-        elasticapm_client = get_client()
+        elasticapm_client = get_client() if client is None else client
         should_trace = elasticapm_client and not elasticapm_client.should_ignore_url(request.path)
         if should_trace:
             trace_parent = AioHttpTraceParent.from_headers(request.headers)


### PR DESCRIPTION
## What does this pull request do?

`elasticapm.contrib.aiohttp.ElasticAPM` allows an optional client
instance as argument, though that client is not used in the tracing
middleware. Instead, it always uses the `base` modules client singleton.

This change passes the client object to the tracing middleware allowing
for a consistent use of a custom client object.

## Related issues
