### PR TITLE
re-implement HttpRequest.get_raw_uri that is removed in Django 4.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 * Improve span coverage for `asyncpg` {pull}1328[#1328]
 * aiohttp: Correctly pass custom client to tracing middleware {pull}1345[#1345] 
 * Fixed an issue with httpx instrumentation {pull}1337[#1337]
+* Fixed an issue with Django 4.0 removing a private method {pull}1347[#1347]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/contrib/django/utils.py
+++ b/elasticapm/contrib/django/utils.py
@@ -31,6 +31,7 @@
 
 import logging
 
+from django.http import HttpRequest
 from django.template.base import Node
 
 from elasticapm.utils.stacks import get_frame_info
@@ -91,3 +92,20 @@ def iterate_with_template_sources(
             exclude_paths_re=exclude_paths_re,
             locals_processor_func=locals_processor_func,
         )
+
+
+def get_raw_uri(request: HttpRequest) -> str:
+    """
+    Return an absolute URI from variables available in this request. Skip
+    allowed hosts protection, so may return insecure URI.
+
+    Re-implementation of Request.get_raw_uri that was removed with Django 4.0.
+
+    :param request: a Request object
+    :return: the URL
+    """
+    return "{scheme}://{host}{path}".format(
+        scheme=request.scheme,
+        host=request._get_raw_host(),
+        path=request.get_full_path(),
+    )


### PR DESCRIPTION
closes #1342
