### PR TITLE
Handle TypeError for missing server version

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -188,7 +188,7 @@ class Transport(HTTPTransportBase):
             logger.warning("HTTP error while fetching server information: %s", str(e))
         except json.JSONDecodeError as e:
             logger.warning("JSON decoding error while fetching server information: %s", str(e))
-        except KeyError:
+        except (KeyError, TypeError):
             logger.warning("No version key found in server response: %s", response.data)
 
     @property

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -421,3 +421,16 @@ def test_fetch_server_info_no_version(waiting_httpserver, caplog, elasticapm_cli
         transport.fetch_server_info()
     assert elasticapm_client.server_version is None
     assert_any_record_contains(caplog.records, "No version key found in server response")
+
+
+def test_fetch_server_info_flat_string(waiting_httpserver, caplog, elasticapm_client):
+    waiting_httpserver.serve_content(
+        code=200,
+        content=b'"8.0.0-alpha1"',
+    )
+    url = waiting_httpserver.url
+    transport = Transport(url + "/" + constants.EVENTS_API_PATH, client=elasticapm_client)
+    with caplog.at_level("WARNING"):
+        transport.fetch_server_info()
+    assert elasticapm_client.server_version is None
+    assert_any_record_contains(caplog.records, "No version key found in server response")


### PR DESCRIPTION
If an HTTP response comes back from the "server" but isn't formed correctly, we can get the following error:

```
version = data["version"]
TypeError: 'int' object is not subscriptable
```

This came up when testing against the new (upcoming) lambda extension. Apparently it responded, but not with useful data. This PR fixes that error.

## Related issues
Ref #1194
