### PR TITLE
Fix event.dataset in structlog

### DIFF
--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -57,7 +57,7 @@ def structlog_processor(logger, method_name, event_dict):
     client = get_client()
     if client:
         event_dict["service.name"] = client.config.service_name
-        event_dict["event.dataset"] = f"{client.config.service_name}"
+        event_dict["event"] = {"dataset": f"{client.config.service_name}"}
     if transaction and transaction.trace_parent:
         event_dict["trace.id"] = transaction.trace_parent.trace_id
     span = execution_context.get_span()

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -269,6 +269,7 @@ def test_structlog_processor_no_span(elasticapm_client):
     new_dict = structlog_processor(None, None, event_dict)
     assert new_dict["transaction.id"] == transaction.id
     assert new_dict["trace.id"] == transaction.trace_parent.trace_id
+    assert new_dict["event"]["dataset"] == "myapp"
     assert "span.id" not in new_dict
 
 


### PR DESCRIPTION
## What does this pull request do?

In the logging integration, `event.dataset` should be a nested object, not a single key. This was causing issues noted in #1351 

## Related issues
Fixes #1351 
