### PR TITLE
fix compatibility issue in httpx tests

### DIFF
--- a/tests/instrumentation/asyncio_tests/httpx_tests.py
+++ b/tests/instrumentation/asyncio_tests/httpx_tests.py
@@ -40,6 +40,13 @@ from elasticapm.utils.disttracing import TraceParent
 
 pytestmark = [pytest.mark.httpx, pytest.mark.asyncio]
 
+httpx_version = tuple(map(int, httpx.__version__.split(".")[:3]))
+
+if httpx_version < (0, 20):
+    allow_redirects = {"allow_redirects": False}
+else:
+    allow_redirects = {"follow_redirects": False}
+
 
 async def test_httpx_instrumentation(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
@@ -48,7 +55,7 @@ async def test_httpx_instrumentation(instrument, elasticapm_client, waiting_http
     elasticapm_client.begin_transaction("transaction.test")
     async with async_capture_span("test_request", "test"):
         async with httpx.AsyncClient() as client:
-            await client.get(url, allow_redirects=False)
+            await client.get(url, **allow_redirects)
     elasticapm_client.end_transaction("MyView")
 
     transactions = elasticapm_client.events[TRANSACTION]
@@ -84,7 +91,7 @@ async def test_httpx_instrumentation_string_url(instrument, elasticapm_client, w
     elasticapm_client.begin_transaction("transaction.test")
     async with async_capture_span("test_request", "test"):
         async with httpx.AsyncClient() as client:
-            await client.get(url, allow_redirects=False)
+            await client.get(url, **allow_redirects)
     elasticapm_client.end_transaction("MyView")
 
     transactions = elasticapm_client.events[TRANSACTION]
@@ -155,7 +162,7 @@ async def test_httpx_error(instrument, elasticapm_client, waiting_httpserver, st
     url = "http://{0}/hello_world".format(parsed_url.netloc)
     async with async_capture_span("test_name", "test_type"):
         async with httpx.AsyncClient() as client:
-            await client.get(url, allow_redirects=False)
+            await client.get(url, **allow_redirects)
 
     elasticapm_client.end_transaction("MyView")
 


### PR DESCRIPTION
httpx 0.20.0 renamed `allow_redirects` to `follow_redirects`

