### PR TITLE
decrement span_counter when span is compressed

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix some context fields and metadata handling in AWS Lambda support {pull}1368[#1368]
+* Fix an issue where compressed spans would count against `transaction_max_spans` {pull}1377[#1377]
 
 [[release-notes-6.6.0]]
 ==== 6.6.0 - 2021-10-18

--- a/tests/client/span_compression_tests.py
+++ b/tests/client/span_compression_tests.py
@@ -30,7 +30,7 @@
 import pytest
 
 import elasticapm
-from elasticapm.conf.constants import SPAN
+from elasticapm.conf.constants import SPAN, TRANSACTION
 
 
 @pytest.mark.parametrize(
@@ -220,3 +220,37 @@ def test_buffer_is_reported_if_next_child_ineligible(elasticapm_client):
     elasticapm_client.end_transaction("test")
     spans = elasticapm_client.events[SPAN]
     assert len(spans) == 3
+
+
+@pytest.mark.parametrize(
+    "elasticapm_client",
+    [{"span_compression_same_kind_max_duration": "5ms", "span_compression_exact_match_max_duration": "5ms"}],
+    indirect=True,
+)
+def test_compressed_spans_not_counted(elasticapm_client):
+    elasticapm_client.begin_transaction("test")
+    with elasticapm.capture_span(
+        "test1",
+        span_type="a",
+        span_subtype="b",
+        span_action="c",
+        leaf=True,
+        duration=2,
+        extra={"destination": {"service": {"resource": "x"}}},
+    ) as span1:
+        pass
+    with elasticapm.capture_span(
+        "test2",
+        span_type="a",
+        span_subtype="b",
+        span_action="c",
+        leaf=True,
+        duration=3,
+        extra={"destination": {"service": {"resource": "x"}}},
+    ) as span2:
+        pass
+    elasticapm_client.end_transaction("test")
+    transaction = elasticapm_client.events[TRANSACTION][0]
+    spans = elasticapm_client.events[SPAN]
+    assert len(spans) == transaction["span_count"]["started"] == 1
+    assert transaction["span_count"]["dropped"] == 0


### PR DESCRIPTION
this ensures that compressed spans are not counted against
transaction_max_spans

alternative for #1376
