### PR TITLE
Cast transaction name to str

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ endif::[]
 * Update the `User-Agent` header to the new https://github.com/elastic/apm/pull/514[spec] {pull}1378[#1378]
 * Improve status_code handling in AWS Lambda integration {pull}1382[#1382]
 * Fix `aiohttp` exception handling to allow for non-500 responses including `HTTPOk` {pull}1384[#1384]
+* Force transaction names to strings {pull}1389[#1389]
 
 [float]
 ===== Other

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -793,7 +793,7 @@ class Tracer(object):
         transaction = execution_context.get_transaction(clear=True)
         if transaction:
             if transaction.name is None:
-                transaction.name = transaction_name if transaction_name is not None else ""
+                transaction.name = str(transaction_name) if transaction_name is not None else ""
             transaction.end(duration=duration)
             if self._should_ignore(transaction.name):
                 return
@@ -925,7 +925,7 @@ def label(**labels):
         transaction.label(**labels)
 
 
-def set_transaction_name(name, override=True):
+def set_transaction_name(name: str, override: bool = True) -> None:
     """
     Sets the name of the transaction
 
@@ -937,7 +937,7 @@ def set_transaction_name(name, override=True):
     if not transaction:
         return
     if transaction.name is None or override:
-        transaction.name = name
+        transaction.name = str(name)
 
 
 def set_transaction_result(result, override=True):

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -352,13 +352,13 @@ def test_set_transaction_name(elasticapm_client):
 
     elasticapm_client.begin_transaction("test")
 
-    elasticapm.set_transaction_name("another_name")
+    elasticapm.set_transaction_name(["another_name"])
 
     elasticapm_client.end_transaction("test_name", 200)
 
     transactions = elasticapm_client.events[TRANSACTION]
     assert transactions[0]["name"] == "test_name"
-    assert transactions[1]["name"] == "another_name"
+    assert transactions[1]["name"] == "['another_name']"
 
 
 def test_set_transaction_custom_data(elasticapm_client):

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -346,19 +346,26 @@ def test_dedot_is_not_run_when_unsampled(elasticapm_client):
     assert "context" not in unsampled_transaction
 
 
-def test_set_transaction_name(elasticapm_client):
+@pytest.mark.parametrize(
+    "name1,name2,expected1,expected2",
+    [
+        ("test_name", "another_name", "test_name", "another_name"),
+        (["test_name"], {"another_name": "foo"}, "['test_name']", "{'another_name': 'foo'}"),
+    ],
+)
+def test_set_transaction_name(elasticapm_client, name1, name2, expected1, expected2):
     elasticapm_client.begin_transaction("test")
-    elasticapm_client.end_transaction("test_name", 200)
+    elasticapm_client.end_transaction(name1, 200)
 
     elasticapm_client.begin_transaction("test")
 
-    elasticapm.set_transaction_name(["another_name"])
+    elasticapm.set_transaction_name(name2)
 
-    elasticapm_client.end_transaction("test_name", 200)
+    elasticapm_client.end_transaction(name1, 200)
 
     transactions = elasticapm_client.events[TRANSACTION]
-    assert transactions[0]["name"] == "test_name"
-    assert transactions[1]["name"] == "['another_name']"
+    assert transactions[0]["name"] == expected1
+    assert transactions[1]["name"] == expected2
 
 
 def test_set_transaction_custom_data(elasticapm_client):


### PR DESCRIPTION
I decided not to do any error handling around casting to `str()` as suggested in #1167 -- while theoretically it can throw errors, the user would have to be doing something exceptionally odd to make that happen and I don't think it's worth muddying the code. We cast to `str()` regularly without error handling.

## Related issues
Closes #1167 
