### PR TITLE
remove aiohttp 4.0 from tests, as the last alpha is from 2019

### DIFF
--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -65,7 +65,6 @@ FRAMEWORK:
   - gevent-newest
   - zerorpc-0.4
   - aiohttp-3.0
-  - aiohttp-4.0
   - aiohttp-newest
   - aiopg-newest
   - asyncpg-newest

--- a/tests/requirements/reqs-aiohttp-4.0.txt
+++ b/tests/requirements/reqs-aiohttp-4.0.txt
@@ -1,2 +1,0 @@
-aiohttp>=4.0.0a1,<5.0
--r reqs-base.txt


### PR DESCRIPTION
it appears that aiohttp abandoned that release train and continues
development on 3.x

## Related issues
closes #1391
