### PR TITLE
sanic-20.12 requires an old uvloop version not supported in Python 3.10

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -13,29 +13,29 @@ exclude:
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: flask-0.11 # see https://github.com/pallets/flask/commit/6e46d0cd, 0.11.2 was never released
   # Python 3.10 removed a bunch of classes from collections, now in collections.abc
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: django-1.11
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: django-2.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: celery-4-django-2.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: celery-4-django-1.11
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: celery-3-django-1.11
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: celery-3-flask-1.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: celery-3-django-2.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: graphene-2
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: aiohttp-3.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: aiohttp-4.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: cassandra-3.4
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.5
   # requests
   - PYTHON_VERSION: python-3.6
@@ -46,12 +46,12 @@ exclude:
     FRAMEWORK: requests-1.2
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: requests-1.2
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: requests-1.2
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: requests-1.2
   # pymongo
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-2.9
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: pymongo-3.0
@@ -61,7 +61,7 @@ exclude:
     FRAMEWORK: pymongo-3.0
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: pymongo-3.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.0
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: pymongo-3.1
@@ -71,7 +71,7 @@ exclude:
     FRAMEWORK: pymongo-3.1
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: pymongo-3.1
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.1
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: pymongo-3.2
@@ -81,7 +81,7 @@ exclude:
     FRAMEWORK: pymongo-3.2
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: pymongo-3.2
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.2
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: pymongo-3.3
@@ -91,7 +91,7 @@ exclude:
     FRAMEWORK: pymongo-3.3
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: pymongo-3.3
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.3
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: pymongo-3.4
@@ -101,7 +101,7 @@ exclude:
     FRAMEWORK: pymongo-3.4
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: pymongo-3.4
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: pymongo-3.4
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: pymongo-3.0
@@ -114,7 +114,7 @@ exclude:
     FRAMEWORK: memcached-1.51
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: memcached-1.51
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: memcached-1.51
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: memcached-1.51
@@ -129,14 +129,14 @@ exclude:
     FRAMEWORK: pymssql-newest
   - PYTHON_VERSION: python-3.9 # currently fails with error on python 3.8 due to cython issues
     FRAMEWORK: pymssql-newest
-  - PYTHON_VERSION: python-3.10-rc # currently fails with error on python 3.8 due to cython issues
+  - PYTHON_VERSION: python-3.10 # currently fails with error on python 3.8 due to cython issues
     FRAMEWORK: pymssql-newest
   # psycopg2
   - PYTHON_VERSION: python-3.8 # see https://github.com/psycopg/psycopg2/issues/858
     FRAMEWORK: psycopg2-2.7
   - PYTHON_VERSION: python-3.9 # see https://github.com/psycopg/psycopg2/issues/858
     FRAMEWORK: psycopg2-2.7
-  - PYTHON_VERSION: python-3.10-rc # see https://github.com/psycopg/psycopg2/issues/858
+  - PYTHON_VERSION: python-3.10 # see https://github.com/psycopg/psycopg2/issues/858
     FRAMEWORK: psycopg2-2.7
   - PYTHON_VERSION: pypy-3  # async keyword clash in old version of psycopg2cffi
     FRAMEWORK: psycopg2-2.7
@@ -152,27 +152,14 @@ exclude:
     FRAMEWORK: boto3-1.0
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: boto3-1.0
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: boto3-1.0
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: boto3-1.0
-  # boto3 is currently not importable on Python 3.9, see https://github.com/boto/botocore/issues/2002
-  - PYTHON_VERSION: python-3.9
-    FRAMEWORK: boto3-1.0
-  - PYTHON_VERSION: python-3.9
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: boto3-1.5
-  - PYTHON_VERSION: python-3.9
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: boto3-1.6
-  - PYTHON_VERSION: python-3.9
-    FRAMEWORK: boto3-newest
-  - PYTHON_VERSION: python-3.10-rc
-    FRAMEWORK: boto3-1.0
-  - PYTHON_VERSION: python-3.10-rc
-    FRAMEWORK: boto3-1.5
-  - PYTHON_VERSION: python-3.10-rc
-    FRAMEWORK: boto3-1.6
-  - PYTHON_VERSION: python-3.10-rc
-    FRAMEWORK: boto3-newest
   # zerorpc - only run on py2
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: zerorpc-0.4
@@ -184,11 +171,8 @@ exclude:
     FRAMEWORK: zerorpc-0.4
   - PYTHON_VERSION: python-3.9
     FRAMEWORK: zerorpc-0.4
-  - PYTHON_VERSION: python-3.10-rc
+  - PYTHON_VERSION: python-3.10
     FRAMEWORK: zerorpc-0.4
-  # gevent
-  - PYTHON_VERSION: python-3.10-rc # causes issues with PosixPath.__enter__, unsure why
-    FRAMEWORK: gevent-newest
   # aiohttp client, only supported in Python 3.7+
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: aiohttp-3.0
@@ -230,8 +214,6 @@ exclude:
     FRAMEWORK: asyncpg-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: asyncpg-newest
-  - PYTHON_VERSION: python-3.10-rc # https://github.com/MagicStack/asyncpg/issues/699
-    FRAMEWORK: asyncpg-newest
   # sanic
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: sanic-newest
@@ -241,17 +223,19 @@ exclude:
     FRAMEWORK: sanic-20.12
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: sanic-newest
+  - PYTHON_VERSION: python-3.10  # install of uvloop 0.14 fails: https://github.com/MagicStack/uvloop/issues/356
+    FRAMEWORK: sanic-20.12
   - PYTHON_VERSION: pypy-3
   # aioredis
     FRAMEWORK: aioredis-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aioredis-newest
-  - PYTHON_VERSION: python-3.10-rc  # getting "loop argument must agree with lock" error
+  - PYTHON_VERSION: python-3.10  # getting "loop argument must agree with lock" error
     FRAMEWORK: aioredis-newest
   # aiomysql
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: aiomysql-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aiomysql-newest
-  - PYTHON_VERSION: python-3.10-rc  # getting "loop argument must agree with lock" error
+  - PYTHON_VERSION: python-3.10  # getting "loop argument must agree with lock" error
     FRAMEWORK: aiomysql-newest

--- a/.ci/.jenkins_python.yml
+++ b/.ci/.jenkins_python.yml
@@ -3,5 +3,5 @@ PYTHON_VERSION:
   - python-3.7
   - python-3.8
   - python-3.9
-  - python-3.10-rc
+  - python-3.10
   - pypy-3

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: BSD License

--- a/tests/requirements/reqs-boto3-newest.txt
+++ b/tests/requirements/reqs-boto3-newest.txt
@@ -1,2 +1,2 @@
-boto3>=1.7,<1.8
+boto3
 -r reqs-base.txt


### PR DESCRIPTION
also, rename pytion-3.10-rc to python-3.10 and clean up some other
excludes

## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues
closes #ISSUE
