### PR TITLE
chore: change the linting message to looks like the rest

### DIFF
--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -16,7 +16,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?linters(?:\\W+please)?.*')
+    issueCommentTrigger('(?i)(/test)?linters?.*')
   }
   stages {
     stage('Sanity checks') {

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -16,7 +16,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i)(/test)?linters?.*')
+    issueCommentTrigger('(?i)(/test).linters.*')
   }
   stages {
     stage('Sanity checks') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
                 script {
                   // To enable the full test matrix upon GitHub PR comments
                   def frameworkFile = '.ci/.jenkins_framework.yml'
-                  if (env.GITHUB_COMMENT?.contains('full tests')) {
+                  if (env.GITHUB_COMMENT?.contains('full')) {
                     log(level: 'INFO', text: 'Full test matrix has been enabled.')
                     frameworkFile = '.ci/.jenkins_framework_full.yml'
                   }
@@ -214,7 +214,7 @@ pipeline {
               anyOf {
                 branch 'master'
                 expression { return params.Run_As_Master_Branch }
-                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
+                expression { return env.GITHUB_COMMENT?.contains('benchmark') }
               }
               expression { return params.bench_ci }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run (full|benchmark) tests)")
+    issueCommentTrigger("(${obltGitHubComments()}.(full|benchmark)?)")
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
It changes the message to trigger the linting from `jenkins run the linters please` to `/test linters` we will add the message to the comment in PR to do not have to remember it.

It also makes shorter the messages to launch the benchmarks and the full matrix tests `/test full` and `/test benchmark` now

NOTE: the message will not activate until we merge the PR
