### PR TITLE
fix default value for span_compression_exact_match_max_duration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * fix compatibility issues with httpx 0.21 {pull}1403[#1403]
+* fix `span_compression_exact_match_max_duration` default value {pull}1407[#1407]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -580,7 +580,7 @@ class Config(_ConfigBase):
     )
     span_compression_exact_match_max_duration = _ConfigValue(
         "span_compression_exact_match_max_duration",
-        default=5,
+        default=50,
         validators=[duration_validator],
         type=int,
     )


### PR DESCRIPTION
see https://github.com/elastic/apm/blob/5e1bfbc95fa0358ef195cedba8cb1be281988227/specs/agents/handling-huge-traces/tracing-spans-compress.md#configuration-option-span_compression_exact_match_max_duration

