### PR TITLE
Filter Sanic config object to only include configration values in context

### DIFF
--- a/elasticapm/contrib/sanic/utils.py
+++ b/elasticapm/contrib/sanic/utils.py
@@ -28,6 +28,7 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 
+from string import ascii_uppercase
 from typing import Dict
 
 from sanic import Sanic
@@ -71,7 +72,8 @@ async def get_request_info(config: Config, request: Request) -> Dict[str, str]:
     :return: A dictionary containing the context information of the ongoing transaction
     """
     env = dict(get_env(request=request))
-    env.update(dict(request.app.config))
+    app_config = {k: v for k, v in dict(request.app.config).items() if all(letter in ascii_uppercase for letter in k)}
+    env.update(app_config)
     result = {
         "env": env,
         "method": request.method,


### PR DESCRIPTION
## What does this pull request do?

In the current `master`, the Sanic integration copies the entire `sanic.config.Config` object. This object includes some non-configuration values, which are not relevant to capturing in the environment context.

Furthermore, in Sanic v21.9.2, a change was introduced that added a reference to an object that could not be properly copied here: https://github.com/ahopkins/apm-agent-python/blob/060cec6efa22eecfaf773c2df935b6642f841bab/elasticapm/base.py#L456

This resulted in a failure for the response object to populate through the context and ultimately resulting in the error as seen in #1413.

This is a somewhat shortlived issue since the next version of Sanic will remove that. However, it underscores a flaw in this integration in that the only values that should be copied over from the `Config` object are those that are in all caps.

Therefore, this PR filters the values and will only extend the environment context with the _actual_ configuration values.

## Related issues
closes #1413 
