### PR TITLE
Shorten long SQL query to prevent oversized event

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,11 @@ endif::[]
 [[release-notes-6.x]]
 === Python Agent version 6.x
 
+[float]
+===== Bug fixes
+
+* asyncpg: Limit SQL queries in context data to 10000 characters {pull}842[#842]
+
 [[release-notes-6.7.0]]
 === 6.7.0 - 2021-11-17
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,13 +29,20 @@ endif::[]
 //[float]
 //===== Bug fixes
 
-[[release-notes-6.x]]
-=== Python Agent version 6.x
+=== Unreleased
+
+//[float]
+//===== Features
+
 
 [float]
 ===== Bug fixes
 
-* asyncpg: Limit SQL queries in context data to 10000 characters {pull}842[#842]
+* asyncpg: Limit SQL queries in context data to 10000 characters {pull}1416[#1416]
+
+
+[[release-notes-6.x]]
+=== Python Agent version 6.x
 
 [[release-notes-6.7.0]]
 === 6.7.0 - 2021-11-17

--- a/elasticapm/instrumentation/packages/asyncio/asyncpg.py
+++ b/elasticapm/instrumentation/packages/asyncio/asyncpg.py
@@ -32,6 +32,7 @@ from elasticapm.contrib.asyncio.traces import async_capture_span
 from elasticapm.instrumentation.packages.asyncio.base import AsyncAbstractInstrumentedModule
 from elasticapm.instrumentation.packages.dbapi2 import extract_signature
 from elasticapm.utils import default_ports
+from elasticapm.utils.encoding import shorten
 
 
 class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
@@ -63,7 +64,8 @@ class AsyncPGInstrumentation(AsyncAbstractInstrumentedModule):
     async def call(self, module, method, wrapped, instance, args, kwargs):
         query = self.get_query(method, args)
         name = extract_signature(query)
-        context = {"db": {"type": "sql", "statement": query}}
+        sql_string = shorten(query, string_length=10000)
+        context = {"db": {"type": "sql", "statement": sql_string}}
         action = "query"
         destination_info = {
             "address": kwargs.get("host", "localhost"),

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -143,9 +143,7 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
 
 async def test_truncate_long_sql(connection, elasticapm_client):
     elasticapm_client.begin_transaction("test")
-    await connection.execute(
-        f"SELECT id, username FROM test WHERE username = {'x' * 10010};"
-    )
+    await connection.execute(f"SELECT id, name FROM test WHERE name = {'x' * 10010};")
     elasticapm_client.end_transaction("test", "OK")
 
     transactions = elasticapm_client.events[constants.TRANSACTION]

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -143,7 +143,7 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
 
 async def test_truncate_long_sql(connection, elasticapm_client):
     elasticapm_client.begin_transaction("test")
-    await connection.execute(f"SELECT id, name FROM test WHERE name = {'x' * 10010};")
+    await connection.execute(f"SELECT id, name FROM test WHERE name = '{'x' * 10010}';")
     elasticapm_client.end_transaction("test", "OK")
 
     transactions = elasticapm_client.events[constants.TRANSACTION]

--- a/tests/instrumentation/asyncio_tests/asyncpg_tests.py
+++ b/tests/instrumentation/asyncio_tests/asyncpg_tests.py
@@ -141,6 +141,7 @@ async def test_fetch_methods(connection, elasticapm_client, method, verify):
     assert span["name"] == "SELECT FROM test"
 
 
+@pytest.mark.usefixtures("instrument")
 async def test_truncate_long_sql(connection, elasticapm_client):
     elasticapm_client.begin_transaction("test")
     await connection.execute(f"SELECT id, name FROM test WHERE name = '{'x' * 10010}';")
@@ -149,5 +150,6 @@ async def test_truncate_long_sql(connection, elasticapm_client):
     transactions = elasticapm_client.events[constants.TRANSACTION]
     spans = elasticapm_client.spans_for_transaction(transactions[0])
 
-    assert len(spans[0]["context"]["db"]["statement"]) == 10000
-    assert spans[0]["context"]["db"]["statement"].endswith("...")
+    statement = spans[0]["context"]["db"]["statement"]
+    assert len(statement) == 10000
+    assert statement.endswith("...")


### PR DESCRIPTION
## What does this pull request do?

APM server allows events with a max size of 10000 characters. Shorten
queries traced in `asyncpg` to max allowed.

## Related issues
See: #842

## Note
Did not manage to run the tests for this locally. Will leave it to CI to tell me.