### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/upstream/json-specs/transaction.json
+++ b/tests/upstream/json-specs/transaction.json
@@ -826,6 +826,13 @@
             "string"
           ]
         },
+        "id": {
+          "description": "A unique identifier of the invoked serverless function.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "trigger": {
           "description": "Trigger attributes.",
           "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/956baba50 [faas] add `id` field (https://github.com/elastic/apm-server/pull/6919)