### PR TITLE
add transaction name to error objects

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,7 +29,7 @@ endif::[]
 [float]
 ===== Features
  * use "unknown-python-service" as default service name if no service name is configured {pull}1438[#1438]
-
+ * add transaction name to error objects {pull}1441[#1441]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -547,7 +547,11 @@ class Client(object):
             # parent id might already be set in the handler
             event_data.setdefault("parent_id", span.id if span else transaction.id)
             event_data["transaction_id"] = transaction.id
-            event_data["transaction"] = {"sampled": transaction.is_sampled, "type": transaction.transaction_type}
+            event_data["transaction"] = {
+                "sampled": transaction.is_sampled,
+                "type": transaction.transaction_type,
+                "name": transaction.name,
+            }
 
         return event_data
 

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -770,6 +770,52 @@ def test_transaction_metrics_error(django_elasticapm_client, client):
         assert transaction["outcome"] == "failure"
 
 
+def test_transaction_metrics_exception(django_elasticapm_client, client):
+    with override_settings(
+        **middleware_setting(django.VERSION, ["elasticapm.contrib.django.middleware.TracingMiddleware"])
+    ):
+        assert len(django_elasticapm_client.events[TRANSACTION]) == 0
+        try:
+            client.get(reverse("elasticapm-raise-exc"))
+        except Exception:
+            pass
+        assert len(django_elasticapm_client.events[TRANSACTION]) == 1
+
+        transactions = django_elasticapm_client.events[TRANSACTION]
+        errors = django_elasticapm_client.events[ERROR]
+
+        assert len(transactions) == 1
+        assert len(errors) == 1
+        transaction = transactions[0]
+        error = errors[0]
+        assert transaction["duration"] > 0
+        assert transaction["result"] == "HTTP 5xx"
+        assert transaction["name"] == "GET tests.contrib.django.testapp.views.raise_exc"
+        assert transaction["outcome"] == "failure"
+        assert transaction["name"] == error["transaction"]["name"]
+
+
+def test_transaction_metrics_404(django_elasticapm_client, client):
+    with override_settings(
+        **middleware_setting(django.VERSION, ["elasticapm.contrib.django.middleware.TracingMiddleware"])
+    ):
+        assert len(django_elasticapm_client.events[TRANSACTION]) == 0
+        try:
+            r = client.get("/non-existant-url")
+        except Exception as e:
+            pass
+        assert len(django_elasticapm_client.events[TRANSACTION]) == 1
+
+        transactions = django_elasticapm_client.events[TRANSACTION]
+
+        assert len(transactions) == 1
+        transaction = transactions[0]
+        assert transaction["duration"] > 0
+        assert transaction["result"] == "HTTP 4xx"
+        assert transaction["name"] == ""
+        assert transaction["outcome"] == "success"
+
+
 def test_transaction_metrics_debug(django_elasticapm_client, client):
     with override_settings(
         DEBUG=True, **middleware_setting(django.VERSION, ["elasticapm.contrib.django.middleware.TracingMiddleware"])

--- a/tests/contrib/django/testapp/urls.py
+++ b/tests/contrib/django/testapp/urls.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import
 
 import django
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponseServerError
 
 from tests.contrib.django.testapp import views
 
@@ -46,7 +46,7 @@ except ImportError:
 def handler500(request):
     if getattr(settings, "BREAK_THAT_500", False):
         raise ValueError("handler500")
-    return HttpResponse("")
+    return HttpResponseServerError("")
 
 
 urlpatterns = (


### PR DESCRIPTION
also, move determination of transaction name in Django to earliest
possible moment.


## Related issues
closes #1409
