### PR TITLE
use a limited amount of Python versions for PR runs

### DIFF
--- a/.ci/.jenkins_python.yml
+++ b/.ci/.jenkins_python.yml
@@ -1,7 +1,3 @@
 PYTHON_VERSION:
   - python-3.6
-  - python-3.7
-  - python-3.8
-  - python-3.9
   - python-3.10
-  - pypy-3

--- a/.ci/.jenkins_python_full.yml
+++ b/.ci/.jenkins_python_full.yml
@@ -1,3 +1,7 @@
 PYTHON_VERSION:
   - python-3.6
+  - python-3.7
+  - python-3.8
+  - python-3.9
   - python-3.10
+  - pypy-3

--- a/.ci/.jenkins_python_full.yml
+++ b/.ci/.jenkins_python_full.yml
@@ -1,0 +1,3 @@
+PYTHON_VERSION:
+  - python-3.6
+  - python-3.10

--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -62,7 +62,7 @@ pipeline {
               pythonTasksGen = new PythonParallelTaskGenerator(
                 xKey: 'PYTHON_VERSION',
                 yKey: 'FRAMEWORK',
-                xFile: ".ci/.jenkins_python.yml",
+                xFile: ".ci/.jenkins_python_full.yml",
                 yFile: ".ci/.jenkins_framework_full.yml",
                 exclusionFile: ".ci/.jenkins_exclude.yml",
                 tag: "Python",

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -3,7 +3,7 @@
 source /usr/local/bin/bash_standard_lib.sh
 
 if [ -x "$(command -v docker)" ]; then
-    grep "-" .ci/.jenkins_python.yml | cut -d'-' -f2- | \
+    grep "-" .ci/.jenkins_python_full.yml | cut -d'-' -f2- | \
     while read -r version;
     do
         imageName="apm-agent-python:${version}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,12 +117,12 @@ pipeline {
               dir("${BASE_DIR}"){
                 script {
                   // To enable the full test matrix upon GitHub PR comments
-                  def pythonFile = '.ci/jenkins_python.yml'
+                  def pythonFile = '.ci/.jenkins_python.yml'
                   def frameworkFile = '.ci/.jenkins_framework.yml'
                   if (env.GITHUB_COMMENT?.contains('full')) {
                     log(level: 'INFO', text: 'Full test matrix has been enabled.')
                     frameworkFile = '.ci/.jenkins_framework_full.yml'
-                    pythonFile = '.ci/jenkins_python_full.yml'
+                    pythonFile = '.ci/.jenkins_python_full.yml'
                   }
                   pythonTasksGen = new PythonParallelTaskGenerator(
                     xKey: 'PYTHON_VERSION',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,15 +117,17 @@ pipeline {
               dir("${BASE_DIR}"){
                 script {
                   // To enable the full test matrix upon GitHub PR comments
+                  def pythonFile = '.ci/jenkins_python.yml'
                   def frameworkFile = '.ci/.jenkins_framework.yml'
                   if (env.GITHUB_COMMENT?.contains('full')) {
                     log(level: 'INFO', text: 'Full test matrix has been enabled.')
                     frameworkFile = '.ci/.jenkins_framework_full.yml'
+                    pythonFile = '.ci/jenkins_python_full.yml'
                   }
                   pythonTasksGen = new PythonParallelTaskGenerator(
                     xKey: 'PYTHON_VERSION',
                     yKey: 'FRAMEWORK',
-                    xFile: ".ci/.jenkins_python.yml",
+                    xFile: pythonFile,
                     yFile: frameworkFile,
                     exclusionFile: ".ci/.jenkins_exclude.yml",
                     tag: "Python",


### PR DESCRIPTION
## What does this pull request do?

the CI runs on PRs are getting prohibitively long. To work around
this, we can use only a limited set of Python versions for PR runs
and do a full, nightly run (the same approach we already use for
framework versions).

