### PR TITLE
jjbb: remove periodic trigger

### DIFF
--- a/.ci/jobs/apm-agent-python-linting-mbp.yml
+++ b/.ci/jobs/apm-agent-python-linting-mbp.yml
@@ -41,5 +41,4 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
     prune-dead-branches: true

--- a/.ci/jobs/apm-agent-python-mbp.yml
+++ b/.ci/jobs/apm-agent-python-mbp.yml
@@ -45,5 +45,4 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
     prune-dead-branches: true

--- a/.ci/jobs/apm-agent-python-nightly-mbp.yml
+++ b/.ci/jobs/apm-agent-python-nightly-mbp.yml
@@ -43,5 +43,4 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1w
     prune-dead-branches: true


### PR DESCRIPTION
## What does this pull request do?

Remove the periodic trigger as we don't really need this based on the webhook push based events. 
This will reduce the number of builds which have been stalled for quite some time.

In addition, this will help us to update the job definition and pick up the `main` branch which it's not available at the moment.