### PR TITLE
Update flask.asciidoc

### DIFF
--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -12,7 +12,7 @@ Install the Elastic APM agent using pip:
 
 [source,bash]
 ----
-$ pip install elastic-apm[flask]
+$ pip install "elastic-apm[flask]"
 ----
 
 or add `elastic-apm[flask]` to your project's `requirements.txt` file.


### PR DESCRIPTION
Shell command fails with certain shells (for ex. zsh), adding quotes.

## What does this pull request do?

I quoted the package name to avoid the command failing on certain shells (zsh for example).

## Related issues
