### PR TITLE
remove usage of compat helpers for Python 2 compatibility

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -40,6 +40,7 @@ import re
 import sys
 import threading
 import time
+import urllib.parse
 import warnings
 from copy import deepcopy
 from typing import Optional, Tuple
@@ -119,8 +120,7 @@ class Client(object):
         self.config = VersionedConfig(config, version=None)
 
         # Insert the log_record_factory into the logging library
-        # The LogRecordFactory functionality is only available on python 3.2+
-        if compat.PY3 and not self.config.disable_log_record_factory:
+        if not self.config.disable_log_record_factory:
             record_factory = logging.getLogRecordFactory()
             # Only way to know if it's wrapped is to create a log record
             throwaway_record = record_factory(__name__, logging.DEBUG, __file__, 252, "dummy_msg", [], None)
@@ -146,7 +146,7 @@ class Client(object):
             "timeout": self.config.server_timeout,
             "processors": self.load_processors(),
         }
-        self._api_endpoint_url = compat.urlparse.urljoin(
+        self._api_endpoint_url = urllib.parse.urljoin(
             self.config.server_url if self.config.server_url.endswith("/") else self.config.server_url + "/",
             constants.EVENTS_API_PATH,
         )
@@ -488,7 +488,7 @@ class Client(object):
         if custom.get("culprit"):
             culprit = custom.pop("culprit")
 
-        for k, v in compat.iteritems(result):
+        for k, v in result.items():
             if k not in event_data:
                 event_data[k] = v
 
@@ -520,7 +520,7 @@ class Client(object):
         if "stacktrace" in log and not culprit:
             culprit = stacks.get_culprit(log["stacktrace"], self.config.include_paths, self.config.exclude_paths)
 
-        if "level" in log and isinstance(log["level"], compat.integer_types):
+        if "level" in log and isinstance(log["level"], int):
             log["level"] = logging.getLevelName(log["level"]).lower()
 
         if log:

--- a/elasticapm/contrib/aiohttp/utils.py
+++ b/elasticapm/contrib/aiohttp/utils.py
@@ -32,7 +32,7 @@ from typing import Union
 from aiohttp.web import HTTPException, Request, Response
 
 from elasticapm.conf import Config
-from elasticapm.utils import compat, get_url_dict
+from elasticapm.utils import get_url_dict
 
 
 def get_data_from_request(request: Request, config: Config, event_type: str):
@@ -53,9 +53,9 @@ def get_data_from_request(request: Request, config: Config, event_type: str):
 def get_data_from_response(response: Union[HTTPException, Response], config: Config, event_type: str):
     result = {}
     status = getattr(response, "status", getattr(response, "status_code", None))
-    if isinstance(status, compat.integer_types):
+    if isinstance(status, int):
         result["status_code"] = status
     if config.capture_headers and getattr(response, "headers", None):
         headers = response.headers
-        result["headers"] = {key: ";".join(headers.getall(key)) for key in compat.iterkeys(headers)}
+        result["headers"] = {key: ";".join(headers.getall(key)) for key in headers.keys()}
     return result

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -141,12 +141,12 @@ class DjangoClient(Client):
                 elif content_type and content_type.startswith("multipart/form-data"):
                     data = compat.multidict_to_dict(request.POST)
                     if request.FILES:
-                        data["_files"] = {field: file.name for field, file in compat.iteritems(request.FILES)}
+                        data["_files"] = {field: file.name for field, file in request.FILES.items()}
                 else:
                     try:
                         data = request.body
                     except Exception as e:
-                        self.logger.debug("Can't capture request body: %s", compat.text_type(e))
+                        self.logger.debug("Can't capture request body: %s", str(e))
                         data = "<unavailable>"
                 if data is not None:
                     result["body"] = data
@@ -249,8 +249,6 @@ class ProxyClient(object):
     __ne__ = lambda x, o: get_client() != o
     __gt__ = lambda x, o: get_client() > o
     __ge__ = lambda x, o: get_client() >= o
-    if compat.PY2:
-        __cmp__ = lambda x, o: cmp(get_client(), o)  # noqa F821
     __hash__ = lambda x: hash(get_client())
     # attributes are currently not callable
     # __call__ = lambda x, *a, **kw: get_client()(*a, **kw)
@@ -280,11 +278,9 @@ class ProxyClient(object):
     __invert__ = lambda x: ~(get_client())
     __complex__ = lambda x: complex(get_client())
     __int__ = lambda x: int(get_client())
-    if compat.PY2:
-        __long__ = lambda x: long(get_client())  # noqa F821
     __float__ = lambda x: float(get_client())
     __str__ = lambda x: str(get_client())
-    __unicode__ = lambda x: compat.text_type(get_client())
+    __unicode__ = lambda x: str(get_client())
     __oct__ = lambda x: oct(get_client())
     __hex__ = lambda x: hex(get_client())
     __index__ = lambda x: get_client().__index__()

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 
 import logging
 import sys
+import urllib.parse
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -40,7 +41,6 @@ from django.core.management.color import color_style
 from django.utils import termcolors
 
 from elasticapm.contrib.django.client import DjangoClient
-from elasticapm.utils.compat import urlparse
 
 try:
     from django.core.management.base import OutputWrapper
@@ -200,7 +200,7 @@ class Command(BaseCommand):
 
         server_url = client.config.server_url
         if server_url:
-            parsed_url = urlparse.urlparse(server_url)
+            parsed_url = urllib.parse.urlparse(server_url)
             if parsed_url.scheme.lower() in ("http", "https"):
                 # parse netloc, making sure people did not supply basic auth
                 if "@" in parsed_url.netloc:

--- a/elasticapm/contrib/flask/utils.py
+++ b/elasticapm/contrib/flask/utils.py
@@ -57,7 +57,7 @@ def get_data_from_request(request, config, event_type):
                 if request.files:
                     body["_files"] = {
                         field: val[0].filename if len(val) == 1 else [f.filename for f in val]
-                        for field, val in compat.iterlists(request.files)
+                        for field, val in request.files.lists()
                     }
             else:
                 try:
@@ -75,10 +75,10 @@ def get_data_from_request(request, config, event_type):
 def get_data_from_response(response, config, event_type):
     result = {}
 
-    if isinstance(getattr(response, "status_code", None), compat.integer_types):
+    if isinstance(getattr(response, "status_code", None), int):
         result["status_code"] = response.status_code
 
     if config.capture_headers and getattr(response, "headers", None):
         headers = response.headers
-        result["headers"] = {key: ";".join(headers.getlist(key)) for key in compat.iterkeys(headers)}
+        result["headers"] = {key: ";".join(headers.getlist(key)) for key in headers.keys()}
     return result

--- a/elasticapm/contrib/opentracing/span.py
+++ b/elasticapm/contrib/opentracing/span.py
@@ -32,7 +32,7 @@ from opentracing.span import Span as OTSpanBase
 from opentracing.span import SpanContext as OTSpanContextBase
 
 from elasticapm import traces
-from elasticapm.utils import compat, get_url_dict
+from elasticapm.utils import get_url_dict
 from elasticapm.utils.logging import get_logger
 
 try:
@@ -86,7 +86,7 @@ class OTSpan(OTSpanBase):
             elif key == "result":
                 self.elastic_apm_ref.result = value
             elif key == tags.HTTP_STATUS_CODE:
-                self.elastic_apm_ref.result = "HTTP {}xx".format(compat.text_type(value)[0])
+                self.elastic_apm_ref.result = "HTTP {}xx".format(str(value)[0])
                 traces.set_context({"status_code": value}, "response")
             elif key == "user.id":
                 traces.set_user_context(user_id=value)

--- a/elasticapm/contrib/opentracing/tracer.py
+++ b/elasticapm/contrib/opentracing/tracer.py
@@ -39,7 +39,7 @@ import elasticapm
 from elasticapm import get_client, instrument, traces
 from elasticapm.conf import constants
 from elasticapm.contrib.opentracing.span import OTSpan, OTSpanContext
-from elasticapm.utils import compat, disttracing
+from elasticapm.utils import disttracing
 
 
 class Tracer(TracerBase):
@@ -107,7 +107,7 @@ class Tracer(TracerBase):
             span_context = OTSpanContext(trace_parent=trace_parent.copy_from(span_id=span.id))
             ot_span = OTSpan(self, span_context, span)
         if tags:
-            for k, v in compat.iteritems(tags):
+            for k, v in tags.items():
                 ot_span.set_tag(k, v)
         return ot_span
 

--- a/elasticapm/contrib/pylons/__init__.py
+++ b/elasticapm/contrib/pylons/__init__.py
@@ -32,7 +32,6 @@
 from elasticapm import get_client
 from elasticapm.base import Client
 from elasticapm.middleware import ElasticAPM as Middleware
-from elasticapm.utils import compat
 
 
 def list_from_setting(config, setting):
@@ -44,6 +43,6 @@ def list_from_setting(config, setting):
 
 class ElasticAPM(Middleware):
     def __init__(self, app, config, client_cls=Client):
-        client_config = {key[11:]: val for key, val in compat.iteritems(config) if key.startswith("elasticapm.")}
+        client_config = {key[11:]: val for key, val in config.items() if key.startswith("elasticapm.")}
         client = get_client() or client_cls(**client_config)
         super(ElasticAPM, self).__init__(app, client)

--- a/elasticapm/contrib/sanic/utils.py
+++ b/elasticapm/contrib/sanic/utils.py
@@ -40,7 +40,7 @@ from sanic.response import HTTPResponse
 from elasticapm.base import Client
 from elasticapm.conf import Config, constants
 from elasticapm.contrib.sanic.sanic_types import EnvInfoType
-from elasticapm.utils import compat, get_url_dict
+from elasticapm.utils import get_url_dict
 
 
 class SanicAPMConfig(dict):
@@ -114,7 +114,7 @@ async def get_response_info(config: Config, response: HTTPResponse) -> Dict[str,
         "finished": True,
         "headers_sent": True,
     }
-    if isinstance(response.status, compat.integer_types):
+    if isinstance(response.status, int):
         result["status_code"] = response.status
 
     if config.capture_headers:

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -40,7 +40,7 @@ from typing import Optional
 import elasticapm
 from elasticapm.base import Client, get_client
 from elasticapm.conf import constants
-from elasticapm.utils import compat, encoding, get_name_from_func, nested_key
+from elasticapm.utils import encoding, get_name_from_func, nested_key
 from elasticapm.utils.disttracing import TraceParent
 from elasticapm.utils.logging import get_logger
 
@@ -385,7 +385,7 @@ def get_url_dict(event: dict) -> dict:
         query = event["rawQueryString"]
     elif event.get("queryStringParameters"):
         query = "?"
-        for k, v in compat.iteritems(event["queryStringParameters"]):
+        for k, v in event["queryStringParameters"].items():
             query += "{}={}".format(k, v)
     url = protocol + "://" + host + stage + path + query
 

--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -34,7 +34,7 @@ from starlette.requests import Request
 from starlette.types import Message
 
 from elasticapm.conf import Config, constants
-from elasticapm.utils import compat, get_url_dict
+from elasticapm.utils import get_url_dict
 
 
 async def get_data_from_request(request: Request, config: Config, event_type: str) -> dict:
@@ -91,7 +91,7 @@ async def get_data_from_response(message: dict, config: Config, event_type: str)
 
     if config.capture_headers and "headers" in message:
         headers = Headers(raw=message["headers"])
-        result["headers"] = {key: ";".join(headers.getlist(key)) for key in compat.iterkeys(headers)}
+        result["headers"] = {key: ";".join(headers.getlist(key)) for key in headers.keys()}
 
     return result
 

--- a/elasticapm/contrib/tornado/utils.py
+++ b/elasticapm/contrib/tornado/utils.py
@@ -29,7 +29,6 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import elasticapm
 from elasticapm.conf import constants
-from elasticapm.utils import compat
 
 try:
     import tornado
@@ -76,6 +75,6 @@ def get_data_from_response(request_handler, config, event_type):
 
     if config.capture_headers and request_handler._headers:
         headers = request_handler._headers
-        result["headers"] = {key: ";".join(headers.get_list(key)) for key in compat.iterkeys(headers)}
+        result["headers"] = {key: ";".join(headers.get_list(key)) for key in headers.keys()}
         pass
     return result

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -33,7 +33,7 @@ import random
 import sys
 
 from elasticapm.conf.constants import EXCEPTION_CHAIN_MAX_DEPTH
-from elasticapm.utils import compat, varmap
+from elasticapm.utils import varmap
 from elasticapm.utils.encoding import keyword_field, shorten, to_unicode
 from elasticapm.utils.logging import get_logger
 from elasticapm.utils.stacks import get_culprit, get_stack_info, iter_traceback_frames
@@ -146,29 +146,28 @@ class Exception(BaseEvent):
         if hasattr(exc_value, "_elastic_apm_span_id"):
             data["parent_id"] = exc_value._elastic_apm_span_id
             del exc_value._elastic_apm_span_id
-        if compat.PY3:
-            depth = kwargs.get("_exc_chain_depth", 0)
-            if depth > EXCEPTION_CHAIN_MAX_DEPTH:
-                return
-            cause = exc_value.__cause__
-            chained_context = exc_value.__context__
+        depth = kwargs.get("_exc_chain_depth", 0)
+        if depth > EXCEPTION_CHAIN_MAX_DEPTH:
+            return
+        cause = exc_value.__cause__
+        chained_context = exc_value.__context__
 
-            # we follow the pattern of Python itself here and only capture the chained exception
-            # if cause is not None and __suppress_context__ is False
-            if chained_context and not (exc_value.__suppress_context__ and cause is None):
-                if cause:
-                    chained_exc_type = type(cause)
-                    chained_exc_value = cause
-                else:
-                    chained_exc_type = type(chained_context)
-                    chained_exc_value = chained_context
-                chained_exc_info = chained_exc_type, chained_exc_value, chained_context.__traceback__
+        # we follow the pattern of Python itself here and only capture the chained exception
+        # if cause is not None and __suppress_context__ is False
+        if chained_context and not (exc_value.__suppress_context__ and cause is None):
+            if cause:
+                chained_exc_type = type(cause)
+                chained_exc_value = cause
+            else:
+                chained_exc_type = type(chained_context)
+                chained_exc_value = chained_context
+            chained_exc_info = chained_exc_type, chained_exc_value, chained_context.__traceback__
 
-                chained_cause = Exception.capture(
-                    client, exc_info=chained_exc_info, culprit="None", _exc_chain_depth=depth + 1
-                )
-                if chained_cause:
-                    data["exception"]["cause"] = [chained_cause["exception"]]
+            chained_cause = Exception.capture(
+                client, exc_info=chained_exc_info, culprit="None", _exc_chain_depth=depth + 1
+            )
+            if chained_cause:
+                data["exception"]["cause"] = [chained_cause["exception"]]
         return data
 
 

--- a/elasticapm/handlers/logbook.py
+++ b/elasticapm/handlers/logbook.py
@@ -37,7 +37,6 @@ import traceback
 import logbook
 
 from elasticapm.base import Client
-from elasticapm.utils import compat
 from elasticapm.utils.encoding import to_unicode
 
 LOOKBOOK_LEVELS = {
@@ -54,7 +53,7 @@ class LogbookHandler(logbook.Handler):
     def __init__(self, *args, **kwargs):
         if len(args) == 1:
             arg = args[0]
-            # if isinstance(arg, compat.string_types):
+            # if isinstance(arg, str):
             # self.client = kwargs.pop('client_cls', Client)(dsn=arg)
             if isinstance(arg, Client):
                 self.client = arg
@@ -102,7 +101,7 @@ class LogbookHandler(logbook.Handler):
             exception = None
 
         return self.client.capture_message(
-            param_message={"message": compat.text_type(record.msg), "params": record.args},
+            param_message={"message": str(record.msg), "params": record.args},
             exception=exception,
             level=LOOKBOOK_LEVELS[record.level],
             logger_name=record.channel,

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -39,7 +39,7 @@ import warnings
 from elasticapm import get_client
 from elasticapm.base import Client
 from elasticapm.traces import execution_context
-from elasticapm.utils import compat, wrapt
+from elasticapm.utils import wrapt
 from elasticapm.utils.encoding import to_unicode
 from elasticapm.utils.stacks import iter_stack_frames
 
@@ -92,7 +92,7 @@ class LoggingHandler(logging.Handler):
     def _emit(self, record, **kwargs):
         data = {}
 
-        for k, v in compat.iteritems(record.__dict__):
+        for k, v in record.__dict__.items():
             if "." not in k and k not in ("culprit",):
                 continue
             data[k] = v
@@ -155,7 +155,7 @@ class LoggingHandler(logging.Handler):
 
         return self.client.capture(
             "Message",
-            param_message={"message": compat.text_type(record.msg), "params": record.args},
+            param_message={"message": str(record.msg), "params": record.args},
             stack=stack,
             custom=custom,
             exception=exception,
@@ -265,10 +265,7 @@ class Formatter(logging.Formatter):
             "trace.id=%(elasticapm_trace_id)s "
             "span.id=%(elasticapm_span_id)s"
         )
-        if compat.PY3:
-            super(Formatter, self).__init__(fmt=fmt, datefmt=datefmt, style=style)
-        else:
-            super(Formatter, self).__init__(fmt=fmt, datefmt=datefmt)
+        super(Formatter, self).__init__(fmt=fmt, datefmt=datefmt, style=style)
 
     def format(self, record):
         if not hasattr(record, "elasticapm_transaction_id"):

--- a/elasticapm/instrumentation/packages/azure.py
+++ b/elasticapm/instrumentation/packages/azure.py
@@ -29,11 +29,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import urllib.parse
 from collections import namedtuple
 
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.traces import capture_span
-from elasticapm.utils.compat import urlparse
 from elasticapm.utils.logging import get_logger
 
 logger = get_logger("elasticapm.instrument")
@@ -56,11 +56,11 @@ class AzureInstrumentation(AbstractInstrumentedModule):
             request = kwargs["request"]
 
         if hasattr(request, "url"):  # Azure Storage HttpRequest
-            parsed_url = urlparse.urlparse(request.url)
+            parsed_url = urllib.parse.urlparse(request.url)
             hostname = parsed_url.hostname
             port = parsed_url.port
             path = parsed_url.path
-            query_params = urlparse.parse_qs(parsed_url.query)
+            query_params = urllib.parse.parse_qs(parsed_url.query)
         else:  # CosmosDB HTTPRequest
             hostname = request.host
             port = hostname.split(":")[1] if ":" in hostname else 80

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -28,12 +28,12 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import urllib.parse
 from collections import namedtuple
 
 from elasticapm.conf import constants
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.traces import capture_span, execution_context
-from elasticapm.utils.compat import urlparse
 from elasticapm.utils.logging import get_logger
 
 logger = get_logger("elasticapm.instrument")
@@ -65,7 +65,7 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
             service = service_model.service_name.upper()
             service = endpoint_to_service_id.get(service, service)
 
-        parsed_url = urlparse.urlparse(instance.meta.endpoint_url)
+        parsed_url = urllib.parse.urlparse(instance.meta.endpoint_url)
         context = {
             "destination": {
                 "address": parsed_url.hostname,

--- a/elasticapm/instrumentation/packages/cassandra.py
+++ b/elasticapm/instrumentation/packages/cassandra.py
@@ -31,7 +31,6 @@
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.instrumentation.packages.dbapi2 import extract_signature
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat
 
 
 class CassandraInstrumentation(AbstractInstrumentedModule):
@@ -65,7 +64,7 @@ class CassandraInstrumentation(AbstractInstrumentedModule):
                 query_str = query.query_string
             elif hasattr(query, "prepared_statement") and hasattr(query.prepared_statement, "query"):
                 query_str = query.prepared_statement.query
-            elif isinstance(query, compat.string_types):
+            elif isinstance(query, str):
                 query_str = query
             else:
                 query_str = None

--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -37,7 +37,7 @@ import re
 
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat, wrapt
+from elasticapm.utils import wrapt
 from elasticapm.utils.encoding import force_text, shorten
 
 
@@ -85,7 +85,7 @@ def _scan_for_table_with_tokens(tokens, keyword):
             else:
                 return lexeme
 
-        if isinstance(lexeme, compat.string_types) and lexeme.upper() == keyword:
+        if isinstance(lexeme, str) and lexeme.upper() == keyword:
             seen_keyword = True
 
 

--- a/elasticapm/instrumentation/packages/psycopg2.py
+++ b/elasticapm/instrumentation/packages/psycopg2.py
@@ -38,7 +38,7 @@ from elasticapm.instrumentation.packages.dbapi2 import (
     extract_signature,
 )
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat, default_ports
+from elasticapm.utils import default_ports
 
 
 class PGCursorProxy(CursorProxy):
@@ -52,7 +52,7 @@ class PGCursorProxy(CursorProxy):
         if hasattr(sql, "as_string"):
             sql = sql.as_string(self.__wrapped__)
         # if the sql string is already a byte string, we need to decode it using the connection encoding
-        if isinstance(sql, compat.binary_type):
+        if isinstance(sql, bytes):
             sql = sql.decode(psycopg2_extensions.encodings[self.__wrapped__.connection.encoding])
         return sql
 

--- a/elasticapm/instrumentation/packages/urllib.py
+++ b/elasticapm/instrumentation/packages/urllib.py
@@ -28,11 +28,12 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import urllib.parse
 
 from elasticapm.conf import constants
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
 from elasticapm.traces import DroppedSpan, capture_span, execution_context
-from elasticapm.utils import compat, default_ports, sanitize_url
+from elasticapm.utils import default_ports, sanitize_url
 from elasticapm.utils.disttracing import TracingOptions
 
 
@@ -45,7 +46,7 @@ def request_host(request):
 
     """
     url = request.get_full_url()
-    parse_result = compat.urlparse.urlparse(url)
+    parse_result = urllib.parse.urlparse(url)
     scheme, host, port = parse_result.scheme, parse_result.hostname, parse_result.port
     try:
         port = int(port)
@@ -62,10 +63,7 @@ def request_host(request):
 class UrllibInstrumentation(AbstractInstrumentedModule):
     name = "urllib"
 
-    if compat.PY2:
-        instrument_list = [("urllib2", "AbstractHTTPHandler.do_open")]
-    else:
-        instrument_list = [("urllib.request", "AbstractHTTPHandler.do_open")]
+    instrument_list = [("urllib.request", "AbstractHTTPHandler.do_open")]
 
     def call(self, module, method, wrapped, instance, args, kwargs):
         request_object = args[1] if len(args) > 1 else kwargs["req"]

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -228,7 +228,7 @@ def add_context_lines_to_frames(client, event):
         event,
         lambda frame: per_file[frame["context_metadata"][0]].append(frame) if "context_metadata" in frame else None,
     )
-    for filename, frames in per_file.items():
+    for frames in per_file.values():
         for frame in frames:
             # context_metadata key has been set in elasticapm.utils.stacks.get_frame_info for
             # all frames for which we should gather source code context lines

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -33,7 +33,7 @@ import warnings
 from collections import defaultdict
 
 from elasticapm.conf.constants import BASE_SANITIZE_FIELD_NAMES, ERROR, MASK, SPAN, TRANSACTION
-from elasticapm.utils import compat, varmap
+from elasticapm.utils import varmap
 from elasticapm.utils.encoding import force_text
 from elasticapm.utils.stacks import get_lines_from_file
 
@@ -228,7 +228,7 @@ def add_context_lines_to_frames(client, event):
         event,
         lambda frame: per_file[frame["context_metadata"][0]].append(frame) if "context_metadata" in frame else None,
     )
-    for filename, frames in compat.iteritems(per_file):
+    for filename, frames in per_file.items():
         for frame in frames:
             # context_metadata key has been set in elasticapm.utils.stacks.get_frame_info for
             # all frames for which we should gather source code context lines

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -42,7 +42,7 @@ from elasticapm.conf import constants
 from elasticapm.conf.constants import LABEL_RE, SPAN, TRANSACTION
 from elasticapm.context import init_execution_context
 from elasticapm.metrics.base_metrics import Timer
-from elasticapm.utils import compat, encoding, get_name_from_func, nested_key, url_to_destination_resource
+from elasticapm.utils import encoding, get_name_from_func, nested_key, url_to_destination_resource
 from elasticapm.utils.disttracing import TraceParent, TracingOptions
 from elasticapm.utils.logging import get_logger
 from elasticapm.utils.time import time_to_perf_counter
@@ -229,7 +229,7 @@ class Transaction(BaseSpan):
     def end(self, skip_frames: int = 0, duration: Optional[float] = None):
         super().end(skip_frames, duration)
         if self._breakdown:
-            for (span_type, span_subtype), timer in compat.iteritems(self._span_timers):
+            for (span_type, span_subtype), timer in self._span_timers.items():
                 labels = {
                     "span.type": span_type,
                     "transaction.name": self.name,

--- a/elasticapm/transport/http_base.py
+++ b/elasticapm/transport/http_base.py
@@ -32,7 +32,6 @@
 
 from elasticapm.conf import constants
 from elasticapm.transport.base import Transport
-from elasticapm.utils import compat
 
 
 class HTTPTransportBase(Transport):
@@ -52,11 +51,7 @@ class HTTPTransportBase(Transport):
         self._server_cert = server_cert
         self._timeout = timeout
         self._headers = {
-            k.encode("ascii")
-            if isinstance(k, compat.text_type)
-            else k: v.encode("ascii")
-            if isinstance(v, compat.text_type)
-            else v
+            k.encode("ascii") if isinstance(k, str) else k: v.encode("ascii") if isinstance(v, str) else v
             for k, v in (headers if headers is not None else {}).items()
         }
         base, sep, tail = self._url.rpartition(constants.EVENTS_API_PATH)

--- a/elasticapm/utils/compat.py
+++ b/elasticapm/utils/compat.py
@@ -32,10 +32,7 @@
 
 import atexit
 import functools
-import operator
 import platform
-import sys
-import types
 
 
 def noop_decorator(func):
@@ -69,79 +66,6 @@ def atexit_register(func):
         atexit.register(func)
 
 
-# Compatibility layer for Python2/Python3, partly inspired by /modified from six, https://github.com/benjaminp/six
-# Remainder of this file: Copyright Benjamin Peterson, MIT License https://github.com/benjaminp/six/blob/master/LICENSE
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
-
-
-if PY2:
-    from urllib import getproxies_environment, proxy_bypass_environment  # noqa F401
-
-    import Queue as queue  # noqa F401
-    import StringIO
-    import urlparse  # noqa F401
-    from urllib2 import HTTPError  # noqa F401
-
-    StringIO = BytesIO = StringIO.StringIO
-
-    string_types = (basestring,)  # noqa F821
-    integer_types = (int, long)  # noqa F821
-    class_types = (type, types.ClassType)
-    text_type = unicode  # noqa F821
-    binary_type = str
-    irange = xrange  # noqa F821
-
-    def b(s):
-        return s
-
-    get_function_code = operator.attrgetter("func_code")
-
-    def iterkeys(d, **kwargs):
-        return d.iterkeys(**kwargs)
-
-    def iteritems(d, **kwargs):
-        return d.iteritems(**kwargs)
-
-    # for django.utils.datastructures.MultiValueDict
-    def iterlists(d, **kw):
-        return d.iterlists(**kw)
-
-
-else:
-    import io
-    import queue  # noqa F401
-    from urllib import parse as urlparse  # noqa F401
-    from urllib.error import HTTPError  # noqa F401
-    from urllib.request import getproxies_environment, proxy_bypass_environment  # noqa F401
-
-    StringIO = io.StringIO
-    BytesIO = io.BytesIO
-
-    string_types = (str,)
-    integer_types = (int,)
-    class_types = (type,)
-    text_type = str
-    binary_type = bytes
-    irange = range
-
-    def b(s):
-        return s.encode("latin-1")
-
-    get_function_code = operator.attrgetter("__code__")
-
-    def iterkeys(d, **kwargs):
-        return iter(d.keys(**kwargs))
-
-    def iteritems(d, **kwargs):
-        return iter(d.items(**kwargs))
-
-    # for django.utils.datastructures.MultiValueDict
-    def iterlists(d, **kw):
-        return iter(d.lists(**kw))
-
-
 def get_default_library_patters():
     """
     Returns library paths depending on the used platform.
@@ -169,7 +93,7 @@ def multidict_to_dict(d):
     :param d: a MultiDict or MultiValueDict instance
     :return: a dict instance
     """
-    return dict((k, v[0] if len(v) == 1 else v) for k, v in iterlists(d))
+    return dict((k, v[0] if len(v) == 1 else v) for k, v in d.lists())
 
 
 try:

--- a/elasticapm/utils/deprecation.py
+++ b/elasticapm/utils/deprecation.py
@@ -32,8 +32,6 @@ import functools
 import warnings
 
 # https://wiki.python.org/moin/PythonDecoratorLibrary#Smart_deprecation_warnings_.28with_valid_filenames.2C_line_numbers.2C_etc..29
-# Updated to work with 2.6 and 3+.
-from elasticapm.utils import compat
 
 
 def deprecated(alternative=None):
@@ -50,8 +48,8 @@ def deprecated(alternative=None):
             warnings.warn_explicit(
                 msg,
                 category=DeprecationWarning,
-                filename=compat.get_function_code(func).co_filename,
-                lineno=compat.get_function_code(func).co_firstlineno + 1,
+                filename=func.__code__.co_filename,
+                lineno=func.__code__.co_firstlineno + 1,
             )
             return func(*args, **kwargs)
 

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -33,7 +33,6 @@ import itertools
 import re
 
 from elasticapm.conf import constants
-from elasticapm.utils import compat
 from elasticapm.utils.logging import get_logger
 
 logger = get_logger("elasticapm.utils")
@@ -154,7 +153,7 @@ class TraceParent(object):
         return ret
 
     def _set_tracestate(self):
-        elastic_value = ";".join(["{}:{}".format(k, v) for k, v in compat.iteritems(self.tracestate_dict)])
+        elastic_value = ";".join(["{}:{}".format(k, v) for k, v in self.tracestate_dict.items()])
         # No character validation needed, as we validate in `add_tracestate`. Just validate length.
         if len(elastic_value) > 256:
             logger.debug("Modifications to TraceState would violate length limits, ignoring.")
@@ -183,8 +182,8 @@ class TraceParent(object):
         within the valid range. Checking here means we never have to re-check
         a pair once set, which saves time in the _set_tracestate() function.
         """
-        key = compat.text_type(key)
-        val = compat.text_type(val)
+        key = str(key)
+        val = str(val)
         for bad in (":", ";", ",", "="):
             if bad in key or bad in val:
                 logger.debug("New tracestate key/val pair contains invalid character '{}', ignoring.".format(bad))

--- a/elasticapm/utils/stacks.py
+++ b/elasticapm/utils/stacks.py
@@ -35,15 +35,9 @@ import itertools
 import os
 import re
 import sys
+from functools import lru_cache
 
-from elasticapm.utils import compat
 from elasticapm.utils.encoding import transform
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from cachetools.func import lru_cache
-
 
 _coding_re = re.compile(r"coding[:=]\s*([-\w.]+)")
 
@@ -77,14 +71,13 @@ def get_lines_from_file(filename, lineno, context_lines, loader=None, module_nam
                         break
                 file_obj.seek(0)
                 lines = [
-                    compat.text_type(line, encoding, "replace")
-                    for line in itertools.islice(file_obj, lower_bound, upper_bound + 1)
+                    str(line, encoding, "replace") for line in itertools.islice(file_obj, lower_bound, upper_bound + 1)
                 ]
                 offset = lineno - lower_bound
                 return (
-                    [l.strip("\r\n") for l in lines[0:offset]],
+                    [line.strip("\r\n") for line in lines[0:offset]],
                     lines[offset].strip("\r\n"),
-                    [l.strip("\r\n") for l in lines[offset + 1 :]] if len(lines) > offset else [],
+                    [line.strip("\r\n") for line in lines[offset + 1 :]] if len(lines) > offset else [],
                 )
         except (OSError, IOError, IndexError):
             pass
@@ -291,7 +284,7 @@ def get_frame_info(
             except Exception:
                 f_locals = "<invalid local scope>"
         if locals_processor_func:
-            f_locals = {varname: locals_processor_func(var) for varname, var in compat.iteritems(f_locals)}
+            f_locals = {varname: locals_processor_func(var) for varname, var in f_locals.items()}
         frame_result["vars"] = transform(f_locals)
     return frame_result
 

--- a/elasticapm/utils/wsgi.py
+++ b/elasticapm/utils/wsgi.py
@@ -34,12 +34,8 @@ This module implements WSGI related helpers adapted from ``werkzeug.wsgi``
 :copyright: (c) 2010 by the Werkzeug Team, see AUTHORS for more details.
 :license: BSD, see LICENSE for more details.
 """
-from elasticapm.utils import compat
 
-try:
-    from urllib import quote
-except ImportError:
-    from urllib.parse import quote
+from urllib.parse import quote
 
 
 # `get_headers` comes from `werkzeug.datastructures.EnvironHeaders`
@@ -47,7 +43,7 @@ def get_headers(environ):
     """
     Returns only proper HTTP headers.
     """
-    for key, value in compat.iteritems(environ):
+    for key, value in environ.items():
         key = str(key)
         if key.startswith("HTTP_") and key not in ("HTTP_CONTENT_TYPE", "HTTP_CONTENT_LENGTH"):
             yield key[5:].replace("_", "-").lower(), value

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -47,9 +47,7 @@ from pytest_localserver.https import DEFAULT_CERTIFICATE
 
 import elasticapm
 from elasticapm.base import Client
-from elasticapm.conf.constants import ERROR, KEYWORD_MAX_LENGTH, SPAN, TRANSACTION
-from elasticapm.utils import compat, encoding
-from elasticapm.utils.disttracing import TraceParent
+from elasticapm.conf.constants import ERROR
 from tests.fixtures import DummyTransport, TempStoreClient
 from tests.utils import assert_any_record_contains
 
@@ -217,8 +215,8 @@ def test_config_non_string_types():
     client = TempStoreClient(
         server_url="localhost", service_name=MyValue("bar"), secret_token=MyValue("bay"), metrics_interval="0ms"
     )
-    assert isinstance(client.config.secret_token, compat.string_types)
-    assert isinstance(client.config.service_name, compat.string_types)
+    assert isinstance(client.config.secret_token, str)
+    assert isinstance(client.config.service_name, str)
     client.close()
 
 

--- a/tests/client/exception_tests.py
+++ b/tests/client/exception_tests.py
@@ -35,7 +35,7 @@ import pytest
 
 import elasticapm
 from elasticapm.conf.constants import ERROR, KEYWORD_MAX_LENGTH
-from elasticapm.utils import compat, encoding
+from elasticapm.utils import encoding
 from tests.utils.stacks import get_me_more_test_frames
 
 

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -36,7 +36,7 @@ from tests.utils import assert_any_record_contains
 
 django = pytest.importorskip("django")  # isort:skip
 
-
+import io
 import json
 import logging
 import os
@@ -64,7 +64,6 @@ from elasticapm.contrib.django.apps import ElasticAPMConfig
 from elasticapm.contrib.django.client import client, get_client
 from elasticapm.contrib.django.handlers import LoggingHandler
 from elasticapm.contrib.django.middleware.wsgi import ElasticAPM
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 from tests.contrib.django.conftest import BASE_TEMPLATE_DIR
 from tests.contrib.django.testapp.views import IgnoredException, MyException
@@ -267,7 +266,7 @@ def test_user_info_with_custom_user_non_string_username(django_elasticapm_client
         assert "user" in event["context"]
         user_info = event["context"]["user"]
         assert "username" in user_info
-        assert isinstance(user_info["username"], compat.text_type)
+        assert isinstance(user_info["username"], str)
         assert user_info["username"] == "1"
 
 
@@ -515,10 +514,10 @@ def test_response_error_id_middleware(django_elasticapm_client, client):
 
 @pytest.mark.parametrize("django_elasticapm_client", [{"capture_body": "errors"}], indirect=True)
 def test_raw_post_data_partial_read(django_elasticapm_client):
-    v = compat.b('{"foo": "bar"}')
+    v = '{"foo": "bar"}'.encode("latin-1")
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(v + compat.b("\r\n\r\n")),
+            "wsgi.input": io.BytesIO(v + compat.b("\r\n\r\n")),
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
             "SERVER_PORT": "80",
@@ -548,7 +547,7 @@ def test_raw_post_data_partial_read(django_elasticapm_client):
 def test_post_data(django_elasticapm_client):
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(),
+            "wsgi.input": io.BytesIO(),
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
             "SERVER_PORT": "80",
@@ -579,7 +578,7 @@ def test_post_data(django_elasticapm_client):
 def test_post_raw_data(django_elasticapm_client):
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(compat.b("foobar")),
+            "wsgi.input": io.BytesIO(compat.b("foobar")),
             "wsgi.url_scheme": "http",
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
@@ -620,7 +619,7 @@ def test_post_read_error_logging(django_elasticapm_client, caplog, rf):
 def test_disallowed_hosts_error_django_19(django_elasticapm_client):
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(),
+            "wsgi.input": io.BytesIO(),
             "wsgi.url_scheme": "http",
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
@@ -640,7 +639,7 @@ def test_disallowed_hosts_error_django_19(django_elasticapm_client):
 def test_disallowed_hosts_error_django_18(django_elasticapm_client):
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(),
+            "wsgi.input": io.BytesIO(),
             "wsgi.url_scheme": "http",
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
@@ -664,7 +663,7 @@ def test_disallowed_hosts_error_django_18(django_elasticapm_client):
 def test_request_capture(django_elasticapm_client):
     request = WSGIRequest(
         environ={
-            "wsgi.input": compat.BytesIO(),
+            "wsgi.input": io.BytesIO(),
             "REQUEST_METHOD": "POST",
             "SERVER_NAME": "testserver",
             "SERVER_PORT": "80",
@@ -1500,9 +1499,7 @@ def test_capture_empty_body(client, django_elasticapm_client):
 )
 def test_capture_files(client, django_elasticapm_client):
     with pytest.raises(MyException), open(os.path.abspath(__file__)) as f:
-        client.post(
-            reverse("elasticapm-raise-exc"), data={"a": "b", "f1": compat.BytesIO(100 * compat.b("1")), "f2": f}
-        )
+        client.post(reverse("elasticapm-raise-exc"), data={"a": "b", "f1": io.BytesIO(100 * compat.b("1")), "f2": f})
     error = django_elasticapm_client.events[ERROR][0]
     if django_elasticapm_client.config.capture_body in (constants.ERROR, "all"):
         assert error["context"]["request"]["body"] == {"a": "b", "_files": {"f1": "f1", "f2": "django_tests.py"}}

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -38,7 +38,6 @@ from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, render
 
 import elasticapm
-from elasticapm.utils import compat
 
 
 class MyException(Exception):
@@ -50,7 +49,7 @@ class IgnoredException(Exception):
 
 
 def no_error(request, id=None):
-    resp = HttpResponse(compat.text_type(id))
+    resp = HttpResponse(str(id))
     resp["My-Header"] = "foo"
     return resp
 

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -32,22 +32,18 @@ import pytest  # isort:skip
 
 pytest.importorskip("flask")  # isort:skip
 
+import io
 import logging
 import os
+from urllib.request import urlopen
 
 import mock
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import ERROR, TRANSACTION
 from elasticapm.contrib.flask import ElasticAPM
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 from tests.contrib.flask.utils import captured_templates
-
-try:
-    from urllib.request import urlopen
-except ImportError:
-    from urllib2 import urlopen
 
 pytestmark = pytest.mark.flask
 
@@ -280,8 +276,8 @@ def test_post_files(flask_apm_client):
             "/an-error/",
             data={
                 "foo": ["bar", "baz"],
-                "f1": (compat.BytesIO(compat.b("1")), "bla"),
-                "f2": [(f, "flask_tests.py"), (compat.BytesIO(compat.b("1")), "blub")],
+                "f1": (io.BytesIO("1".encode("latin-1")), "bla"),
+                "f2": [(f, "flask_tests.py"), (io.BytesIO("1".encode("latin-1")), "blub")],
             },
         )
     assert response.status_code == 500

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -30,6 +30,7 @@
 
 import codecs
 import gzip
+import io
 import json
 import logging
 import logging.handlers
@@ -53,7 +54,6 @@ from elasticapm.base import Client
 from elasticapm.conf.constants import SPAN
 from elasticapm.traces import execution_context
 from elasticapm.transport.http_base import HTTPTransportBase
-from elasticapm.utils import compat
 from elasticapm.utils.threading import ThreadManager
 
 try:
@@ -128,7 +128,7 @@ class ValidatingWSGIApp(ContentServer):
         if request.content_encoding == "deflate":
             data = zlib.decompress(data)
         elif request.content_encoding == "gzip":
-            with gzip.GzipFile(fileobj=compat.BytesIO(data)) as f:
+            with gzip.GzipFile(fileobj=io.BytesIO(data)) as f:
                 data = f.read()
         data = data.decode(request.charset)
         if request.content_type == "application/x-ndjson":
@@ -146,7 +146,7 @@ class ValidatingWSGIApp(ContentServer):
                     success += 1
                 except jsonschema.ValidationError as e:
                     fail += 1
-                    content += "/".join(map(compat.text_type, e.absolute_schema_path)) + ": " + e.message + "\n"
+                    content += "/".join(map(str, e.absolute_schema_path)) + ": " + e.message + "\n"
             code = 202 if not fail else 400
         response = Response(status=code)
         response.headers.clear()

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -42,8 +42,7 @@ from elasticapm.conf import Config
 from elasticapm.conf.constants import ERROR
 from elasticapm.handlers.logging import Formatter, LoggingFilter, LoggingHandler
 from elasticapm.handlers.structlog import structlog_processor
-from elasticapm.traces import Tracer, capture_span
-from elasticapm.utils import compat
+from elasticapm.traces import capture_span
 from elasticapm.utils.stacks import iter_stack_frames
 from tests.fixtures import TempStoreClient
 
@@ -327,7 +326,6 @@ def test_structlog_processor_span(elasticapm_client):
         assert "span.id" not in new_dict
 
 
-@pytest.mark.skipif(not compat.PY3, reason="Log record factories are only 3.2+")
 def test_automatic_log_record_factory_install(elasticapm_client):
     """
     Use the elasticapm_client fixture to load the client, which in turn installs

--- a/tests/instrumentation/asyncio_tests/httpx_tests.py
+++ b/tests/instrumentation/asyncio_tests/httpx_tests.py
@@ -31,11 +31,11 @@
 import pytest  # isort:skip
 
 httpx = pytest.importorskip("httpx")  # isort:skip
+import urllib.parse
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import TRANSACTION
 from elasticapm.contrib.asyncio.traces import async_capture_span
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 
 pytestmark = [pytest.mark.httpx, pytest.mark.asyncio]
@@ -51,7 +51,7 @@ else:
 async def test_httpx_instrumentation(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     async with async_capture_span("test_request", "test"):
         async with httpx.AsyncClient() as client:
@@ -156,7 +156,7 @@ async def test_url_sanitization(instrument, elasticapm_client, waiting_httpserve
 async def test_httpx_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     url = "http://{0}/hello_world".format(parsed_url.netloc)

--- a/tests/instrumentation/base_tests.py
+++ b/tests/instrumentation/base_tests.py
@@ -40,7 +40,7 @@ import elasticapm
 from elasticapm.conf import constants
 from elasticapm.conf.constants import SPAN, TRANSACTION
 from elasticapm.instrumentation.packages.base import AbstractInstrumentedModule
-from elasticapm.utils import compat, wrapt
+from elasticapm.utils import wrapt
 from tests.utils import assert_any_record_contains
 
 
@@ -100,30 +100,7 @@ def test_double_instrument(elasticapm_client):
         inst.uninstrument()
 
 
-@pytest.mark.skipif(compat.PY3, reason="different object model")
-def test_uninstrument_py2(caplog):
-    assert isinstance(Dummy.dummy, types.MethodType)
-    assert not isinstance(Dummy.dummy, wrapt.BoundFunctionWrapper)
-
-    instrumentation = _TestDummyInstrumentation()
-    with caplog.at_level(logging.DEBUG, "elasticapm.instrument"):
-        instrumentation.instrument()
-    record = caplog.records[0]
-    assert "Instrumented" in record.message
-    assert record.args == ("test_dummy_instrument", "tests.instrumentation.base_tests.Dummy.dummy")
-    assert isinstance(Dummy.dummy, wrapt.BoundFunctionWrapper)
-
-    with caplog.at_level(logging.DEBUG, "elasticapm.instrument"):
-        instrumentation.uninstrument()
-    record = caplog.records[1]
-    assert "Uninstrumented" in record.message
-    assert record.args == ("test_dummy_instrument", "tests.instrumentation.base_tests.Dummy.dummy")
-    assert isinstance(Dummy.dummy, types.MethodType)
-    assert not isinstance(Dummy.dummy, wrapt.BoundFunctionWrapper)
-
-
-@pytest.mark.skipif(compat.PY2, reason="different object model")
-def test_uninstrument_py3(caplog):
+def test_uninstrument(caplog):
     original = Dummy.dummy
     assert not isinstance(Dummy.dummy, wrapt.BoundFunctionWrapper)
 

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -28,13 +28,13 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
+import urllib.parse
 
 import pytest
 
 import elasticapm
 from elasticapm.conf import constants
 from elasticapm.instrumentation.packages.botocore import SQS_MAX_ATTRIBUTES
-from elasticapm.utils.compat import urlparse
 from tests.utils import assert_any_record_contains
 
 boto3 = pytest.importorskip("boto3")
@@ -55,7 +55,7 @@ dynamodb_serializer = TypeSerializer()
 if not LOCALSTACK_ENDPOINT:
     pytestmark.append(pytest.mark.skip("Skipping botocore tests, no AWS_URL environment variable set"))
 
-LOCALSTACK_ENDPOINT_URL = urlparse.urlparse(LOCALSTACK_ENDPOINT)
+LOCALSTACK_ENDPOINT_URL = urllib.parse.urlparse(LOCALSTACK_ENDPOINT)
 
 
 @pytest.fixture()

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -41,7 +41,6 @@ from elasticsearch.serializer import JSONSerializer
 
 import elasticapm
 from elasticapm.conf.constants import TRANSACTION
-from elasticapm.utils import compat
 
 pytestmark = [pytest.mark.elasticsearch]
 
@@ -67,7 +66,7 @@ class SpecialEncoder(JSONSerializer):
         if isinstance(obj, dict):
 
             def yield_key_value(d):
-                for key, value in compat.iteritems(d):
+                for key, value in d.items():
                     try:
                         yield self.default(key), self.force_key_encoding(value)
                     except TypeError:

--- a/tests/instrumentation/httplib2_tests.py
+++ b/tests/instrumentation/httplib2_tests.py
@@ -32,12 +32,13 @@ import pytest  # isort:skip
 
 pytest.importorskip("httplib2")  # isort:skip
 
+import urllib.parse
+
 import httplib2
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import TRANSACTION
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 
 pytestmark = pytest.mark.httplib2
@@ -47,7 +48,7 @@ pytestmark = pytest.mark.httplib2
 def test_httplib2_instrumentation(instrument, elasticapm_client, waiting_httpserver, args):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
         httplib2.Http().request(url, *args)
@@ -81,7 +82,7 @@ def test_httplib2_instrumentation(instrument, elasticapm_client, waiting_httpser
 def test_httplib2_instrumentation_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
         httplib2.Http().request(url, "GET")

--- a/tests/instrumentation/httpx_tests.py
+++ b/tests/instrumentation/httpx_tests.py
@@ -31,11 +31,11 @@
 import pytest  # isort:skip
 
 httpx = pytest.importorskip("httpx")  # isort:skip
+import urllib.parse
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import TRANSACTION
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 
 pytestmark = pytest.mark.httpx
@@ -51,7 +51,7 @@ else:
 def test_httpx_instrumentation(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
         httpx.get(url, **allow_redirects)
@@ -152,7 +152,7 @@ def test_url_sanitization(instrument, elasticapm_client, waiting_httpserver):
 def test_httpx_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     url = "http://{0}/hello_world".format(parsed_url.netloc)

--- a/tests/instrumentation/requests_tests.py
+++ b/tests/instrumentation/requests_tests.py
@@ -32,13 +32,14 @@ import pytest  # isort:skip
 
 pytest.importorskip("requests")  # isort:skip
 
+import urllib.parse
+
 import requests
 from requests.exceptions import InvalidURL, MissingSchema
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import TRANSACTION
 from elasticapm.traces import capture_span
-from elasticapm.utils import compat
 from elasticapm.utils.disttracing import TraceParent
 
 pytestmark = pytest.mark.requests
@@ -47,7 +48,7 @@ pytestmark = pytest.mark.requests
 def test_requests_instrumentation(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
         requests.get(url, allow_redirects=False)
@@ -85,7 +86,7 @@ def test_requests_instrumentation(instrument, elasticapm_client, waiting_httpser
 def test_requests_instrumentation_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = compat.urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction.test")
     with capture_span("test_request", "test"):
         requests.get(url, allow_redirects=False)

--- a/tests/instrumentation/urllib3_tests.py
+++ b/tests/instrumentation/urllib3_tests.py
@@ -27,6 +27,7 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import urllib.parse
 
 import pytest
 import urllib3
@@ -34,14 +35,13 @@ import urllib3
 from elasticapm.conf import constants
 from elasticapm.conf.constants import SPAN, TRANSACTION
 from elasticapm.traces import capture_span
-from elasticapm.utils.compat import urlparse
 from elasticapm.utils.disttracing import TraceParent
 
 
 def test_urllib3(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     with capture_span("test_name", "test_type"):
@@ -83,7 +83,7 @@ def test_urllib3(instrument, elasticapm_client, waiting_httpserver):
 def test_urllib3_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     with capture_span("test_name", "test_type"):
@@ -260,7 +260,7 @@ def test_instance_headers_are_respected(
 
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     transaction_object = elasticapm_client.begin_transaction("transaction", trace_parent=traceparent)
     transaction_object.is_sampled = is_sampled
     pool = urllib3.HTTPConnectionPool(

--- a/tests/instrumentation/urllib_tests.py
+++ b/tests/instrumentation/urllib_tests.py
@@ -27,6 +27,9 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import urllib.parse
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 import mock
 import pytest
@@ -34,26 +37,16 @@ import pytest
 from elasticapm.conf import constants
 from elasticapm.conf.constants import SPAN, TRANSACTION
 from elasticapm.traces import capture_span
-from elasticapm.utils.compat import urlparse
 from elasticapm.utils.disttracing import TraceParent
 
-try:
-    from urllib.error import HTTPError, URLError
-    from urllib.request import urlopen
-
-    request_method = "http.client.HTTPConnection.request"
-    getresponse_method = "http.client.HTTPConnection.getresponse"
-except ImportError:
-    from urllib2 import HTTPError, URLError, urlopen
-
-    request_method = "httplib.HTTPConnection.request"
-    getresponse_method = "httplib.HTTPConnection.getresponse"
+request_method = "http.client.HTTPConnection.request"
+getresponse_method = "http.client.HTTPConnection.getresponse"
 
 
 def test_urllib(instrument, elasticapm_client, waiting_httpserver):
     waiting_httpserver.serve_content("")
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     with capture_span("test_name", "test_type"):
@@ -94,7 +87,7 @@ def test_urllib(instrument, elasticapm_client, waiting_httpserver):
 def test_urllib_error(instrument, elasticapm_client, waiting_httpserver, status_code):
     waiting_httpserver.serve_content("", code=status_code)
     url = waiting_httpserver.url + "/hello_world"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     with capture_span("test_name", "test_type"):
@@ -125,7 +118,7 @@ def test_urllib_standard_port(mock_getresponse, mock_request, instrument, elasti
     mock_getresponse.return_value = mock.Mock(code=200, status=200)
 
     url = "http://example.com/"
-    parsed_url = urlparse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(url)
     elasticapm_client.begin_transaction("transaction")
     expected_sig = "GET {0}".format(parsed_url.netloc)
     r = urlopen(url)

--- a/tests/metrics/breakdown_tests.py
+++ b/tests/metrics/breakdown_tests.py
@@ -27,13 +27,11 @@
 #  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-import time
 
 import mock
 import pytest
 
 import elasticapm
-from elasticapm.utils import compat
 
 
 def test_bare_transaction(elasticapm_client):
@@ -149,14 +147,14 @@ def test_metrics_reset_after_collect(elasticapm_client):
         pass
     elasticapm_client.end_transaction("test", "OK", duration=15)
     breakdown = elasticapm_client._metrics.get_metricset("elasticapm.metrics.sets.breakdown.BreakdownMetricSet")
-    for labels, c in compat.iteritems(breakdown._counters):
+    for labels, c in breakdown._counters.items():
         assert c.val != 0
-    for labels, t in compat.iteritems(breakdown._timers):
+    for labels, t in breakdown._timers.items():
         assert t.val != (0, 0)
     list(breakdown.collect())
-    for labels, c in compat.iteritems(breakdown._counters):
+    for labels, c in breakdown._counters.items():
         assert c.val == 0
-    for labels, t in compat.iteritems(breakdown._timers):
+    for labels, t in breakdown._timers.items():
         assert t.val == (0, 0)
 
 

--- a/tests/metrics/cpu_psutil_tests.py
+++ b/tests/metrics/cpu_psutil_tests.py
@@ -33,7 +33,6 @@ import time
 import pytest
 
 from elasticapm.metrics.base_metrics import MetricsRegistry
-from elasticapm.utils import compat
 
 cpu_psutil = pytest.importorskip("elasticapm.metrics.sets.cpu_psutil")
 pytestmark = pytest.mark.psutil
@@ -42,7 +41,7 @@ pytestmark = pytest.mark.psutil
 def test_cpu_mem_from_psutil(elasticapm_client):
     metricset = cpu_psutil.CPUMetricSet(MetricsRegistry(elasticapm_client))
     # do something that generates some CPU load
-    for i in compat.irange(10 ** 6):
+    for i in range(10 ** 6):
         j = i * i
     data = next(metricset.collect())
     # we can't really test any specific values here as it depends on the system state.
@@ -66,7 +65,7 @@ def test_compare_psutil_linux_metricsets(elasticapm_client):
     psutil_metricset = cpu_psutil.CPUMetricSet(MetricsRegistry(elasticapm_client))
     linux_metricset = cpu_linux.CPUMetricSet(MetricsRegistry(elasticapm_client))
     # do something that generates some CPU load
-    for i in compat.irange(10 ** 6):
+    for i in range(10 ** 6):
         j = i * i
     psutil_data = next(psutil_metricset.collect())
     linux_data = next(linux_metricset.collect())

--- a/tests/processors/tests.py
+++ b/tests/processors/tests.py
@@ -41,7 +41,6 @@ import pytest
 import elasticapm
 from elasticapm import Client, processors
 from elasticapm.conf.constants import BASE_SANITIZE_FIELD_NAMES_UNPROCESSED, ERROR, SPAN, TRANSACTION
-from elasticapm.utils import compat
 from tests.utils import assert_any_record_contains
 
 
@@ -347,7 +346,7 @@ def test_sanitize_dict():
 
 
 def test_non_utf8_encoding(elasticapm_client, http_test_data):
-    broken = compat.b("broken=") + u"aéöüa".encode("latin-1")
+    broken = "broken=".encode("latin-1") + u"aéöüa".encode("latin-1")
     http_test_data["context"]["request"]["headers"]["cookie"] = broken
     result = processors.sanitize_http_request_cookies(elasticapm_client, http_test_data)
     assert result["context"]["request"]["headers"]["cookie"] == u"broken=a\ufffd\ufffd\ufffda"

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -39,7 +39,6 @@ import pytest
 
 from elasticapm.transport.base import Transport, TransportState
 from elasticapm.transport.exceptions import TransportException
-from elasticapm.utils import compat
 from tests.fixtures import DummyTransport, TempStoreClient
 from tests.utils import assert_any_record_contains
 
@@ -105,10 +104,7 @@ def test_metadata_prepended(mock_send, elasticapm_client):
     transport.close()
     assert mock_send.call_count == 1
     args, kwargs = mock_send.call_args
-    if compat.PY2:
-        data = gzip.GzipFile(fileobj=compat.StringIO(args[0])).read()
-    else:
-        data = gzip.decompress(args[0])
+    data = gzip.decompress(args[0])
     data = data.decode("utf-8").split("\n")
     assert "metadata" in data[0]
 

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -40,7 +40,6 @@ from urllib3.exceptions import MaxRetryError, TimeoutError
 from elasticapm.conf import constants
 from elasticapm.transport.exceptions import TransportException
 from elasticapm.transport.http import Transport, version_string_to_tuple
-from elasticapm.utils import compat
 from tests.utils import assert_any_record_contains
 
 try:
@@ -55,7 +54,7 @@ def test_send(waiting_httpserver, elasticapm_client):
     transport = Transport(waiting_httpserver.url, client=elasticapm_client)
     transport.start_thread()
     try:
-        url = transport.send(compat.b("x"))
+        url = transport.send("x".encode("latin-1"))
         assert url == "http://example.com/foo"
     finally:
         transport.close()
@@ -148,7 +147,7 @@ def test_header_encodings(elasticapm_client):
     urllib assumes it needs to encode the data as well, which is already a zlib
     encoded bytestring, and explodes.
     """
-    headers = {compat.text_type("X"): compat.text_type("V")}
+    headers = {str("X"): str("V")}
     elasticapm_client.server_version = (8, 0)  # avoid making server_info request
     transport = Transport("http://localhost:9999", headers=headers, client=elasticapm_client)
     transport.start_thread()
@@ -157,11 +156,9 @@ def test_header_encodings(elasticapm_client):
             mock_urlopen.return_value = mock.Mock(status=202)
             transport.send("")
         _, args, kwargs = mock_urlopen.mock_calls[0]
-        if compat.PY2:
-            assert isinstance(args[1], compat.binary_type)
         for k, v in kwargs["headers"].items():
-            assert isinstance(k, compat.binary_type)
-            assert isinstance(v, compat.binary_type)
+            assert isinstance(k, bytes)
+            assert isinstance(v, bytes)
     finally:
         transport.close()
 
@@ -173,7 +170,7 @@ def test_ssl_verify_fails(waiting_httpsserver, elasticapm_client):
     transport.start_thread()
     try:
         with pytest.raises(TransportException) as exc_info:
-            url = transport.send(compat.b("x"))
+            url = transport.send("x".encode("latin-1"))
         assert "certificate verify failed" in str(exc_info)
     finally:
         transport.close()
@@ -186,7 +183,7 @@ def test_ssl_verify_disable(waiting_httpsserver, elasticapm_client):
     transport = Transport(waiting_httpsserver.url, verify_server_cert=False, client=elasticapm_client)
     transport.start_thread()
     try:
-        url = transport.send(compat.b("x"))
+        url = transport.send("x".encode("latin-1"))
         assert url == "https://example.com/foo"
     finally:
         transport.close()
@@ -202,7 +199,7 @@ def test_ssl_verify_disable_http(waiting_httpserver, elasticapm_client):
     transport = Transport(waiting_httpserver.url, verify_server_cert=False, client=elasticapm_client)
     transport.start_thread()
     try:
-        url = transport.send(compat.b("x"))
+        url = transport.send("x".encode("latin-1"))
         assert url == "http://example.com/foo"
     finally:
         transport.close()
@@ -223,7 +220,7 @@ def test_ssl_cert_pinning_http(waiting_httpserver, elasticapm_client):
     )
     transport.start_thread()
     try:
-        url = transport.send(compat.b("x"))
+        url = transport.send("x".encode("latin-1"))
         assert url == "http://example.com/foo"
     finally:
         transport.close()
@@ -241,7 +238,7 @@ def test_ssl_cert_pinning(waiting_httpsserver, elasticapm_client):
     )
     transport.start_thread()
     try:
-        url = transport.send(compat.b("x"))
+        url = transport.send("x".encode("latin-1"))
         assert url == "https://example.com/foo"
     finally:
         transport.close()
@@ -249,17 +246,8 @@ def test_ssl_cert_pinning(waiting_httpsserver, elasticapm_client):
 
 @pytest.mark.flaky(reruns=3)  # test is flaky on Windows
 def test_ssl_cert_pinning_fails(waiting_httpsserver, elasticapm_client):
-    if compat.PY3:
-        waiting_httpsserver.serve_content(code=202, content="", headers={"Location": "https://example.com/foo"})
-        url = waiting_httpsserver.url
-    else:
-        # if we use the local test server here, execution blocks somewhere deep in OpenSSL on Python 2.7, presumably
-        # due to a threading issue that has been fixed in later versions. To avoid that, we have to commit a minor
-        # cardinal sin here and do an outside request to https://example.com (which will also fail the fingerprint
-        # assertion).
-        #
-        # May the Testing Goat have mercy on our souls.
-        url = "https://example.com"
+    waiting_httpsserver.serve_content(code=202, content="", headers={"Location": "https://example.com/foo"})
+    url = waiting_httpsserver.url
     transport = Transport(
         url,
         server_cert=os.path.join(os.path.dirname(__file__), "wrong_cert.pem"),
@@ -269,7 +257,7 @@ def test_ssl_cert_pinning_fails(waiting_httpsserver, elasticapm_client):
     transport.start_thread()
     try:
         with pytest.raises(TransportException) as exc_info:
-            transport.send(compat.b("x"))
+            transport.send("x".encode("latin-1"))
     finally:
         transport.close()
 

--- a/tests/utils/cgroup_tests.py
+++ b/tests/utils/cgroup_tests.py
@@ -28,10 +28,11 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import mock
+import io
+
 import pytest
 
-from elasticapm.utils import cgroup, compat
+from elasticapm.utils import cgroup
 
 
 @pytest.mark.parametrize(
@@ -87,6 +88,6 @@ from elasticapm.utils import cgroup, compat
     ],
 )
 def test_cgroup_parsing(test_input, expected):
-    f = compat.StringIO(test_input)
+    f = io.StringIO(test_input)
     result = cgroup.parse_cgroups(f)
     assert result == expected

--- a/tests/utils/encoding/tests.py
+++ b/tests/utils/encoding/tests.py
@@ -35,7 +35,6 @@ from __future__ import absolute_import
 import decimal
 import uuid
 
-from elasticapm.utils import compat
 from elasticapm.utils.encoding import enforce_label_format, shorten, transform
 
 
@@ -49,20 +48,18 @@ def test_transform_incorrect_unicode():
 
 def test_transform_correct_unicode():
     x = "רונית מגן"
-    if compat.PY2:
-        x = x.decode("utf-8")
 
     result = transform(x)
-    assert type(result) == compat.text_type
+    assert type(result) == str
     assert result == x
 
 
 def test_transform_bad_string():
-    x = compat.b("The following character causes problems: \xd4")
+    x = "The following character causes problems: \xd4".encode("latin-1")
 
     result = transform(x)
-    assert type(result) == compat.binary_type
-    assert result == compat.b("(Error decoding value)")
+    assert type(result) == bytes
+    assert result == "(Error decoding value)".encode("latin-1")
 
 
 def test_transform_float():
@@ -129,15 +126,12 @@ def test_transform_dict_keys_utf8_as_str():
     assert type(result) == dict
     keys = list(result.keys())
     assert len(keys) == 1
-    assert type(keys[0]), compat.binary_type
-    if compat.PY3:
-        assert keys[0] == "רונית מגן"
-    else:
-        assert keys[0] == u"רונית מגן"
+    assert type(keys[0]), bytes
+    assert keys[0] == "רונית מגן"
 
 
 def test_transform_dict_keys_utf8_as_unicode():
-    x = {compat.text_type("\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df"): "bar"}
+    x = {str("\u05e8\u05d5\u05e0\u05d9\u05ea \u05de\u05d2\u05df"): "bar"}
 
     result = transform(x)
     keys = list(result.keys())
@@ -180,10 +174,7 @@ def test_transform_broken_repr():
     x = Foo()
 
     result = transform(x)
-    if compat.PY2:
-        expected = u"<BadRepr: <class 'tests.utils.encoding.tests.Foo'>>"
-    else:
-        expected = "<BadRepr: <class 'tests.utils.encoding.tests.test_transform_broken_repr.<locals>.Foo'>>"
+    expected = "<BadRepr: <class 'tests.utils.encoding.tests.test_transform_broken_repr.<locals>.Foo'>>"
     assert result == expected
 
 

--- a/tests/utils/json_utils/tests.py
+++ b/tests/utils/json_utils/tests.py
@@ -36,7 +36,6 @@ import datetime
 import decimal
 import uuid
 
-from elasticapm.utils import compat
 from elasticapm.utils import json_encoder as json
 
 
@@ -61,10 +60,7 @@ def test_frozenset():
 
 
 def test_bytes():
-    if compat.PY2:
-        res = bytes("foobar")
-    else:
-        res = bytes("foobar", encoding="ascii")
+    res = bytes("foobar", encoding="ascii")
     assert json.dumps(res) == '"foobar"'
 
 

--- a/tests/utils/stacks/tests.py
+++ b/tests/utils/stacks/tests.py
@@ -40,7 +40,7 @@ from mock import Mock
 
 import elasticapm
 from elasticapm.conf import constants
-from elasticapm.utils import compat, stacks
+from elasticapm.utils import stacks
 from elasticapm.utils.stacks import get_culprit, get_stack_info
 from tests.utils.stacks import get_me_a_test_frame, get_me_more_test_frames
 
@@ -56,7 +56,7 @@ class Context(object):
 
     __getitem__ = lambda s, *a: s.dict.__getitem__(*a)
     __setitem__ = lambda s, *a: s.dict.__setitem__(*a)
-    iterkeys = lambda s, *a: compat.iterkeys(s.dict, *a)
+    iterkeys = lambda s, *a: s.dict.keys(*a)
 
 
 def test_get_culprit_bad_module():


### PR DESCRIPTION
## What does this pull request do?

Removes all usage of Python 2-specific usage of the `compat` module.

First commit is only the `elasticapm` module, second commit is the test suite.

## Related issues
closes #ISSUE
