### PR TITLE
pin markupsafe for Flask < 2.0

### DIFF
--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -10,6 +10,7 @@ FRAMEWORK:
   - flask-0.12
   - flask-1.1
   - flask-2.0
+  - jinja2-3
   - opentracing-newest
   - twisted-18
   - celery-4-flask-1.0

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -17,6 +17,8 @@ FRAMEWORK:
   - flask-1.0
   - flask-1.1
   - flask-2.0
+  - jinja2-2
+  - jinja2-3
   - celery-4-flask-1.0
   - celery-4-django-1.11
   - celery-4-django-2.0

--- a/tests/instrumentation/jinja2_tests/jinja2_tests.py
+++ b/tests/instrumentation/jinja2_tests/jinja2_tests.py
@@ -28,13 +28,18 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import pytest  # isort:skip
+
+pytest.importorskip("jinja2")  # isort:skip
+
 import os
 
-import pytest
 from jinja2 import Environment, FileSystemLoader
 from jinja2.environment import Template
 
 from elasticapm.conf.constants import TRANSACTION
+
+pytestmark = [pytest.mark.jinja2]
 
 
 @pytest.fixture()

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -31,15 +31,11 @@ py-cpuinfo==8.0.0
 
 urllib3
 certifi
-Jinja2
 Logbook
-MarkupSafe
 WebOb
-Werkzeug
 argparse
 blinker>=1.1
 greenlet
-itsdangerous
 mock
 msgpack-python
 pep8

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -34,7 +34,6 @@ certifi
 Logbook
 WebOb
 argparse
-blinker>=1.1
 greenlet
 mock
 msgpack-python

--- a/tests/requirements/reqs-django-1.11.txt
+++ b/tests/requirements/reqs-django-1.11.txt
@@ -1,2 +1,3 @@
 Django>=1.11,<2.0
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-2.0.txt
+++ b/tests/requirements/reqs-django-2.0.txt
@@ -1,2 +1,3 @@
 Django>=2.0,<2.1
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-2.1.txt
+++ b/tests/requirements/reqs-django-2.1.txt
@@ -1,2 +1,3 @@
 Django>=2.1,<2.2
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-2.2.txt
+++ b/tests/requirements/reqs-django-2.2.txt
@@ -1,2 +1,3 @@
 Django>=2.2,<2.3
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-3.0.txt
+++ b/tests/requirements/reqs-django-3.0.txt
@@ -1,2 +1,3 @@
 Django>=3.0b1,<3.1
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-3.1.txt
+++ b/tests/requirements/reqs-django-3.1.txt
@@ -1,2 +1,3 @@
 Django>=3.1,<3.2
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-3.2.txt
+++ b/tests/requirements/reqs-django-3.2.txt
@@ -1,2 +1,3 @@
 Django>=3.2b1,<3.3
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-4.0.txt
+++ b/tests/requirements/reqs-django-4.0.txt
@@ -1,2 +1,3 @@
 Django>=4.0a1,<4.1
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-django-master.txt
+++ b/tests/requirements/reqs-django-master.txt
@@ -1,2 +1,3 @@
 https://github.com/django/django/archive/master.zip#egg=Django==100
+jinja2<4
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-0.10.txt
+++ b/tests/requirements/reqs-flask-0.10.txt
@@ -1,2 +1,4 @@
 Flask>=0.10,<0.11
+itsdangerous==2.0.1
+blinker>=1.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-0.11.txt
+++ b/tests/requirements/reqs-flask-0.11.txt
@@ -1,2 +1,4 @@
 Flask>=0.11,<0.12
+itsdangerous==2.0.1
+blinker>=1.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-0.12.txt
+++ b/tests/requirements/reqs-flask-0.12.txt
@@ -1,2 +1,4 @@
 Flask>=0.12,<0.13
+itsdangerous==2.0.1
+blinker>=1.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-1.0.txt
+++ b/tests/requirements/reqs-flask-1.0.txt
@@ -1,3 +1,5 @@
 Flask>=1.0,<1.1
 MarkupSafe<2.1
+itsdangerous==2.0.1
+blinker>=1.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-1.0.txt
+++ b/tests/requirements/reqs-flask-1.0.txt
@@ -1,2 +1,3 @@
 Flask>=1.0,<1.1
+MarkupSafe<2.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-1.1.txt
+++ b/tests/requirements/reqs-flask-1.1.txt
@@ -1,2 +1,3 @@
 Flask>=1.1,<1.2
+MarkupSafe<2.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-1.1.txt
+++ b/tests/requirements/reqs-flask-1.1.txt
@@ -1,3 +1,5 @@
 Flask>=1.1,<1.2
 MarkupSafe<2.1
+itsdangerous==2.0.1
+blinker>=1.1
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-2.0.txt
+++ b/tests/requirements/reqs-flask-2.0.txt
@@ -1,2 +1,4 @@
 Flask>=2.0,<3
+blinker>=1.1
+itsdangerous
 -r reqs-base.txt

--- a/tests/requirements/reqs-jinja2-2.txt
+++ b/tests/requirements/reqs-jinja2-2.txt
@@ -1,0 +1,3 @@
+jinja2<3
+MarkupSafe<2.1
+-r reqs-base.txt

--- a/tests/requirements/reqs-jinja2-3.txt
+++ b/tests/requirements/reqs-jinja2-3.txt
@@ -1,0 +1,2 @@
+jinja2<4
+-r reqs-base.txt

--- a/tests/scripts/envs/jinja2.sh
+++ b/tests/scripts/envs/jinja2.sh
@@ -1,0 +1,1 @@
+export PYTEST_MARKER="-m jinja2"


### PR DESCRIPTION
## What does this pull request do?

Remove flask-specific requirements from `reqs-base.txt`, and pin `MarkupSafe` to a compatible version for `flask < 2.0`
