### PR TITLE
Move the APM server fetch log to `debug`

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -194,7 +194,7 @@ class Transport(HTTPTransportBase):
             body = response.data
             data = json_encoder.loads(body.decode("utf8"))
             version = data["version"]
-            logger.info("Fetched APM Server version %s", version)
+            logger.debug("Fetched APM Server version %s", version)
             self.client.server_version = version_string_to_tuple(version)
         except (urllib3.exceptions.RequestError, urllib3.exceptions.HTTPError) as e:
             logger.warning("HTTP error while fetching server information: %s", str(e))


### PR DESCRIPTION
## What does this pull request do?

This log was added at `info` level, which was breaking the Django test command. We probably shouldn't be logging this so high anyway, it's debug information.

## Related issues
Closes #1465 
