### PR TITLE
Fix inconsistent case for `API_KEY` config in docs

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -350,8 +350,8 @@ WARNING: Secret tokens only provide any security if your APM Server uses TLS.
 
 [options="header"]
 |============
-| Environment           | `Config` key | Default | Example
-| `ELASTIC_APM_API_KEY` | `api_key`    | `None`   | A base64-encoded string
+| Environment           | Django/Flask | Default | Example
+| `ELASTIC_APM_API_KEY` | `API_KEY`    | `None`   | A base64-encoded string
 |============
 
 experimental::[]


### PR DESCRIPTION
## What does this pull request do?

A customer was trying to use `API_KEY` in flask config as a lower-case config value. This fixes that config value to be more consistent with our other entries.