### PR TITLE
Fix exit_span_min_duration to properly use ms

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,8 +38,10 @@ endif::[]
 
 * Add OpenTelemetry API bridge {pull}1411[#1411]
 
-//[float]
-//===== Bug fixes
+[float]
+===== Bug fixes
+
+* Fix `exit_span_min_duration` and disable by default {pull}1483[#1483]
 
 
 [[release-notes-6.x]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -761,11 +761,13 @@ Two spans are considered to be of the same kind if the following attributes are 
 [options="header"]
 |============
 | Environment                            | Django/Flask               | Default
-| `ELASTIC_APM_EXIT_SPAN_MIN_DURATION` | `EXIT_SPAN_MIN_DURATION` | `"1ms"`
+| `ELASTIC_APM_EXIT_SPAN_MIN_DURATION` | `EXIT_SPAN_MIN_DURATION` | `"0ms"`
 |============
 
 Exit spans are spans that represent a call to an external service, like a database.
 If such calls are very short, they are usually not relevant and can be ignored.
+
+This feature is disabled by default.
 
 NOTE: if a span propagates distributed tracing IDs, it will not be ignored, even if it is shorter than the configured threshold.
 This is to ensure that no broken traces are recorded.

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -598,7 +598,7 @@ class Config(_ConfigBase):
     )
     exit_span_min_duration = _ConfigValue(
         "EXIT_SPAN_MIN_DURATION",
-        default=1,
+        default=0,
         validators=[duration_validator],
         type=float,
     )

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -657,7 +657,7 @@ class Span(BaseSpan):
         p.child_ended(self)
 
     def report(self) -> None:
-        if self.discardable and self.duration < self.transaction.config_exit_span_min_duration:
+        if self.discardable and (self.duration * 1000) < self.transaction.config_exit_span_min_duration:
             self.transaction.track_dropped_span(self)
             self.transaction.dropped_spans += 1
         else:

--- a/tests/client/dropped_spans_tests.py
+++ b/tests/client/dropped_spans_tests.py
@@ -124,11 +124,11 @@ def test_transaction_max_span_dropped_statistics_not_collected_for_incompatible_
 @pytest.mark.parametrize("elasticapm_client", [{"exit_span_min_duration": "1ms"}], indirect=True)
 def test_transaction_fast_exit_span(elasticapm_client):
     elasticapm_client.begin_transaction("test_type")
-    with elasticapm.capture_span(span_type="x", name="x", leaf=True, duration=2):  # not dropped, too long
+    with elasticapm.capture_span(span_type="x", name="x", leaf=True, duration=0.002):  # not dropped, too long
         pass
-    with elasticapm.capture_span(span_type="y", name="y", leaf=True, duration=0.1):  # dropped
+    with elasticapm.capture_span(span_type="y", name="y", leaf=True, duration=0.0001):  # dropped
         pass
-    with elasticapm.capture_span(span_type="z", name="z", leaf=False, duration=0.1):  # not dropped, not exit
+    with elasticapm.capture_span(span_type="z", name="z", leaf=False, duration=0.0001):  # not dropped, not exit
         pass
     elasticapm_client.end_transaction("foo", duration=2.2)
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
@@ -139,6 +139,6 @@ def test_transaction_fast_exit_span(elasticapm_client):
     assert transaction["span_count"]["started"] == 3
     assert transaction["span_count"]["dropped"] == 1
     assert metrics[0]["span"]["type"] == "x"
-    assert metrics[0]["samples"]["span.self_time.sum.us"]["value"] == 2000000
+    assert metrics[0]["samples"]["span.self_time.sum.us"]["value"] == 2000
     assert metrics[1]["span"]["type"] == "y"
-    assert metrics[1]["samples"]["span.self_time.sum.us"]["value"] == 100000
+    assert metrics[1]["samples"]["span.self_time.sum.us"]["value"] == 100

--- a/tests/config/config_snapshotting_tests.py
+++ b/tests/config/config_snapshotting_tests.py
@@ -115,7 +115,7 @@ def test_config_snapshotting_span_compression_drop_exit_span(elasticapm_client):
         span_subtype="b",
         span_action="c",
         extra={"destination": {"service": {"resource": "x"}}},
-        duration=5,
+        duration=0.005,
     ):
         pass
     elasticapm_client.end_transaction()


### PR DESCRIPTION
## What does this pull request do?

`Span.duration` is measured in seconds, but was compared to the millisecond value in `exit_span_min_duration`. This meant that exit spans with durations less than 1 second were being dropped. 😱 

This fixes that issue, and also turns of `exit_span_min_duration` by default, which is coming in https://github.com/elastic/apm/pull/610

## Related issues
Closes #1482 
Closes #1476 
Ref #1418