### PR TITLE
Fix sanic to properly use capture_body config

### DIFF
--- a/elasticapm/contrib/sanic/__init__.py
+++ b/elasticapm/contrib/sanic/__init__.py
@@ -259,7 +259,9 @@ class ElasticAPM:
                 trace_parent = TraceParent.from_headers(headers=request.headers)
                 self._client.begin_transaction("request", trace_parent=trace_parent)
                 await set_context(
-                    lambda: get_request_info(config=self._client.config, request=request),
+                    lambda: get_request_info(
+                        config=self._client.config, request=request, event_type=constants.TRANSACTION
+                    ),
                     "request",
                 )
                 self._setup_transaction_name(request=request)
@@ -278,8 +280,7 @@ class ElasticAPM:
         async def _instrument_response(request: Request, response: HTTPResponse):
             await set_context(
                 lambda: get_response_info(
-                    config=self._client.config,
-                    response=response,
+                    config=self._client.config, response=response, event_type=constants.TRANSACTION
                 ),
                 "response",
             )
@@ -324,7 +325,9 @@ class ElasticAPM:
             self._client.capture_exception(
                 exc_info=sys.exc_info(),
                 context={
-                    "request": await get_request_info(config=self._client.config, request=request),
+                    "request": await get_request_info(
+                        config=self._client.config, request=request, event_type=constants.ERROR
+                    ),
                 },
                 handled=True,
             )

--- a/elasticapm/contrib/sanic/utils.py
+++ b/elasticapm/contrib/sanic/utils.py
@@ -63,12 +63,13 @@ def get_env(request: Request) -> EnvInfoType:
 
 
 # noinspection PyBroadException
-async def get_request_info(config: Config, request: Request) -> Dict[str, str]:
+async def get_request_info(config: Config, request: Request, event_type: str) -> Dict[str, str]:
     """
     Generate a traceable context information from the inbound HTTP request
 
     :param config: Application Configuration used to tune the way the data is captured
     :param request: Inbound HTTP request
+    :param event_type: the event type (such as constants.TRANSACTION) for determing whether to capture the body
     :return: A dictionary containing the context information of the ongoing transaction
     """
     env = dict(get_env(request=request))
@@ -87,7 +88,7 @@ async def get_request_info(config: Config, request: Request) -> Dict[str, str]:
     if config.capture_headers:
         result["headers"] = dict(request.headers)
 
-    if request.method in constants.HTTP_WITH_BODY and config.capture_body:
+    if request.method in constants.HTTP_WITH_BODY and config.capture_body in ("all", event_type):
         if request.content_type.startswith("multipart") or "octet-stream" in request.content_type:
             result["body"] = "[DISCARDED]"
         try:
@@ -101,12 +102,13 @@ async def get_request_info(config: Config, request: Request) -> Dict[str, str]:
     return result
 
 
-async def get_response_info(config: Config, response: HTTPResponse) -> Dict[str, str]:
+async def get_response_info(config: Config, response: HTTPResponse, event_type: str) -> Dict[str, str]:
     """
     Generate a traceable context information from the inbound HTTP Response
 
     :param config: Application Configuration used to tune the way the data is captured
     :param response: outbound HTTP Response
+    :param event_type: the event type (such as constants.TRANSACTION) for determing whether to capture the body
     :return: A dictionary containing the context information of the ongoing transaction
     """
     result = {
@@ -120,7 +122,7 @@ async def get_response_info(config: Config, response: HTTPResponse) -> Dict[str,
     if config.capture_headers:
         result["headers"] = dict(response.headers)
 
-    if config.capture_body and "octet-stream" not in response.content_type:
+    if config.capture_body in ("all", event_type) and "octet-stream" not in response.content_type:
         result["body"] = response.body.decode("utf-8")
     else:
         result["body"] = "[REDACTED]"


### PR DESCRIPTION
## What does this pull request do?

The Sanic integration was assuming `config.capture_body` was a boolean, which meant that the default value of `"off"` resulted in capturing the body always. This fixes that assumption so that the config value works properly.

## Related issues
Closes #1484 
