### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/upstream/json-specs/span.json
+++ b/tests/upstream/json-specs/span.json
@@ -554,6 +554,33 @@
       "type": "string",
       "maxLength": 1024
     },
+    "links": {
+      "description": "Links holds links to other spans, potentially in other traces.",
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "span_id": {
+            "description": "SpanID holds the ID of the linked span.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "trace_id": {
+            "description": "TraceID holds the ID of the linked span's trace.",
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "required": [
+          "span_id",
+          "trace_id"
+        ]
+      },
+      "minItems": 0
+    },
     "name": {
       "description": "Name is the generic designation of a span in the scope of a transaction.",
       "type": "string",

--- a/tests/upstream/json-specs/transaction.json
+++ b/tests/upstream/json-specs/transaction.json
@@ -877,6 +877,33 @@
       "type": "string",
       "maxLength": 1024
     },
+    "links": {
+      "description": "Links holds links to other spans, potentially in other traces.",
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "span_id": {
+            "description": "SpanID holds the ID of the linked span.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "trace_id": {
+            "description": "TraceID holds the ID of the linked span's trace.",
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "required": [
+          "span_id",
+          "trace_id"
+        ]
+      },
+      "minItems": 0
+    },
     "marks": {
       "description": "Marks capture the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent. Marks are only reported by RUM agents.",
       "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/1438888d7 model/modeldecoder/v2: add span links (https://github.com/elastic/apm-server/pull/7553)