### PR TITLE
work around issue with older flask versions and newest jinja2 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -161,6 +161,7 @@ markers =
     httpx
     prometheus_client
     sanic
+    jinja2
 
 [isort]
 line_length=120

--- a/tests/requirements/reqs-flask-1.0.txt
+++ b/tests/requirements/reqs-flask-1.0.txt
@@ -1,3 +1,4 @@
+jinja2<3.1.0
 Flask>=1.0,<1.1
 MarkupSafe<2.1
 itsdangerous==2.0.1

--- a/tests/requirements/reqs-flask-1.1.txt
+++ b/tests/requirements/reqs-flask-1.1.txt
@@ -1,3 +1,4 @@
+jinja2<3.1.0
 Flask>=1.1,<1.2
 MarkupSafe<2.1
 itsdangerous==2.0.1


### PR DESCRIPTION
## What does this pull request do?

A newly released version of jinja2 is incompatible with older flask versions. We work around this by running those tests with an older version of jinja2.

## Related issues
closes #1502
