### PR TITLE
pypy tests fail with an SQLite error message on pypy

### DIFF
--- a/.ci/.jenkins_python_full.yml
+++ b/.ci/.jenkins_python_full.yml
@@ -4,4 +4,4 @@ PYTHON_VERSION:
   - python-3.8
   - python-3.9
   - python-3.10
-  - pypy-3
+#  - pypy-3  # excluded due to build issues with SQLite/Django


### PR DESCRIPTION
    django.db.utils.NotSupportedError: deterministic=True requires building _sqlite3 with SQLite 3.8.3 or higher


