### PR TITLE
Update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     -   id: black
         language_version: python3


### PR DESCRIPTION
## What does this pull request do?

All our linting recently started failing. I think it's due to the new version of [click](https://github.com/pallets/click/releases/tag/8.1.0), and the newest version of [black](https://github.com/psf/black/releases/tag/22.3.0) explicitly calls out compatibility with the new version of click.
