### PR TITLE
fix issue in span serialization when using APM Server < 7.16

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Fix `otel_attributes`-related regression with older versions of APM Server (<7.16) {pull}1510[#1510]
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -577,7 +577,7 @@ class Span(BaseSpan):
                         result["otel"]["attributes"] = self.context.pop("otel_attributes")
             else:
                 # Attributes map to labels for older versions
-                attributes = self.context.pop("otel_attributes")
+                attributes = self.context.pop("otel_attributes", {})
                 if attributes and ("tags" not in self.context):
                     self.context["tags"] = {}
                 for key, value in attributes.items():


### PR DESCRIPTION
the issue wasn't originally caught in testing because we hard code
the server_version to a certain value (currently 8.0.0), and this
bug was in a branch that only is hit with a server version lower
than 7.16

fixes #1509
