### PR TITLE
ci: packer_cache never fail

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -8,7 +8,7 @@ if [ -x "$(command -v docker)" ]; then
     do
         imageName="apm-agent-python:${version}"
         registryImageName="docker.elastic.co/observability-ci/${imageName}"
-        (retry 2 docker pull "${registryImageName}")
+        (retry 2 docker pull "${registryImageName}") || echo 'Skip failing packer_cache'
         docker tag "${registryImageName}" "${imageName}"
     done
 fi


### PR DESCRIPTION
## What does this pull request do?

Avoid failing the packer_cache process.


## Why

https://github.com/elastic/apm-agent-python/issues/1505 broke the script, but the packer_cache should work on best-effort, so if possible then cache the images, otherwise do not fail.

Then the packer cache image generation can move on with the next packer_cache project. Otherwise, we won't be using latest cache images
