### PR TITLE
Update release process to not require admin access

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,4 +5,4 @@ Here you can explain the changes made on the PR.
 -->
 
 ## Related issues
-closes #ISSUE
+Closes #ISSUE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,11 +182,11 @@ If you have commit access, the process is as follows:
 1. For Majors: Add a new row to the EOL table in `docs/upgrading.asciidoc`. The EOL date is the release date plus 18 months.
 1. For Majors: Add the new major version to `conf.yaml` in the [elastic/docs](https://github.com/elastic/docs) repo.
 1. Commit changes with message `update CHANGELOG and bump version to X.Y.Z` where `X.Y.Z` is the version in `elasticapm/version.py`
-1. Tag the commit with `git tag -a vX.Y.Z`, for example `git tag -a v1.2.3`.
+1. Open a PR against `main` with this new commit. Review + merge.
+1. Open a PR from `main` to the current major branch (`6.x`, etc). Review + merge.
+1. Tag the new `HEAD` of the current major branch (`6.x`, etc) with `git tag -s vX.Y.Z`, for example `git tag -s v1.2.3`.
    Copy the changelog for the release to the tag message, removing any leading `#`.
-1. Reset the current major branch (`1.x`, `2.x` etc) to point to the current main, e.g. `git branch -f 1.x main`
-1. Push commits and tags upstream with `git push upstream main && git push upstream --tags` (and optionally to your own fork as well)
-1. Update major branch, e.g. `1.x` on upstream with `git push upstream 1.x`
+1. Push tag upstream with `git push upstream --tags`
 1. After tests pass, Jenkins will automatically build a source package, as well as binary wheels.
    To upload them to PyPI, go to [Jenkins](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/activity)
    and look for the build with the correct tag name (`vX.Y.Z`). Once the build is done, a dialog will be shown.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,3 +193,7 @@ If you have commit access, the process is as follows:
    Note that you need to be logged in to trigger an upload.
 1. Create a [Github release](https://github.com/elastic/apm-agent-python/releases)
    targeting the new tag. Copy the changelog into the body of the release.
+
+If, due to a regression, a bugfix release needs to be done from `6.x` rather
+than `main`, be sure to open a PR back to `main` so the release tag will be
+included on `git log` from `main`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,10 +183,10 @@ If you have commit access, the process is as follows:
 1. For Majors: Add the new major version to `conf.yaml` in the [elastic/docs](https://github.com/elastic/docs) repo.
 1. Commit changes with message `update CHANGELOG and bump version to X.Y.Z` where `X.Y.Z` is the version in `elasticapm/version.py`
 1. Open a PR against `main` with this new commit. Review + merge.
-1. Open a PR from `main` to the current major branch (`6.x`, etc). Review + merge.
-1. Tag the new `HEAD` of the current major branch (`6.x`, etc) with `git tag -s vX.Y.Z`, for example `git tag -s v1.2.3`.
+1. Tag the new `HEAD` of `main` with `git tag -s vX.Y.Z`, for example `git tag -s v1.2.3`.
    Copy the changelog for the release to the tag message, removing any leading `#`.
 1. Push tag upstream with `git push upstream --tags`
+1. Open a PR from `main` to the current major branch (`6.x`, etc). Review + merge.
 1. After tests pass, Jenkins will automatically build a source package, as well as binary wheels.
    To upload them to PyPI, go to [Jenkins](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/activity)
    and look for the build with the correct tag name (`vX.Y.Z`). Once the build is done, a dialog will be shown.


### PR DESCRIPTION
## What does this pull request do?

Currently our release process requires multiple no-check pushed to protected branches. As we (eventually) would like to stop using admin overrides on the repo, our release process needs an update.

This update will require both @beniwohli and I to be around at the same time for releases, as we'll need to approve the PRs. We'll also have to wait for tests to run on the release PRs. I don't think that's a terrible requirement, but it will hurt our ability to do fast regression releases.

Thoughts welcome.

cc @felixbarny @estolfo @AlexanderWert 
