### PR TITLE
Fix sanic tests

### DIFF
--- a/tests/contrib/sanic/fixtures.py
+++ b/tests/contrib/sanic/fixtures.py
@@ -125,7 +125,7 @@ def sanic_elastic_app(elasticapm_client):
                 pass
             return json({"response": "ok"})
 
-        @app.get("/greet/<name:string>")
+        @app.get("/greet/<name:str>")
         async def greet_person(request: Request, name: str):
             return json({"response": f"Hello {name}"})
 

--- a/tests/contrib/sanic/sanic_tests.py
+++ b/tests/contrib/sanic/sanic_tests.py
@@ -41,7 +41,7 @@ pytestmark = [pytest.mark.sanic]  # isort:skip
 
 @pytest.mark.parametrize(
     "url, transaction_name, span_count, custom_context",
-    [("/", "GET /", 1, {}), ("/greet/sanic", "GET /greet/<name:string>", 0, {"name": "sanic"})],
+    [("/", "GET /", 1, {}), ("/greet/sanic", "GET /greet/<name:str>", 0, {"name": "sanic"})],
 )
 def test_get(url, transaction_name, span_count, custom_context, sanic_elastic_app, elasticapm_client):
     sanic_app, apm = next(sanic_elastic_app(elastic_client=elasticapm_client))


### PR DESCRIPTION
## What does this pull request do?

See https://github.com/sanic-org/sanic/issues/2423 for some context.

Our Sanic tests were failing due to not being able to get the route from one of the requests.

It took me awhile to track down the issue, but it turns out the router stopped accepting `<name:string>` and wants `<name:str>` instead. This was not listed as a breaking change in their release notes, so I recommended they add it.

## Related issues
Closes #1515
