### PR TITLE
Add instrumentation for aiobotocore

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -237,3 +237,8 @@ exclude:
     FRAMEWORK: aiomysql-newest
   - PYTHON_VERSION: python-3.10  # getting "loop argument must agree with lock" error
     FRAMEWORK: aiomysql-newest
+  # aiobotocore
+  - PYTHON_VERSION: pypy-3
+    FRAMEWORK: aiobotocore-newest
+  - PYTHON_VERSION: python-3.6
+    FRAMEWORK: aiobotocore-newest

--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -52,3 +52,4 @@ FRAMEWORK:
   - prometheus_client-newest
   - sanic-newest
   - aiomysql-newest
+  - aiobotocore-newest

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -84,3 +84,4 @@ FRAMEWORK:
   - httplib2-newest
   - sanic-20.12
   - sanic-newest
+  - aiobotocore-newest

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,11 @@ endif::[]
 [[release-notes-6.x]]
 === Python Agent version 6.x
 
+[float]
+===== Features
+
+* Add instrumentation for https://github.com/aio-libs/aiobotocore[`aiobotocore`] {pull}xxx[#xxx]
+
 [[release-notes-6.9.1]]
 ==== 6.9.1 - 2022-03-30
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,14 +29,22 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
 
-[[release-notes-6.x]]
-=== Python Agent version 6.x
-
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
 [float]
 ===== Features
 
 * Add instrumentation for https://github.com/aio-libs/aiobotocore[`aiobotocore`] {pull}xxx[#xxx]
+
+//[float]
+//===== Bug fixes
+//
+
+
+[[release-notes-6.x]]
+=== Python Agent version 6.x
 
 [[release-notes-6.9.1]]
 ==== 6.9.1 - 2022-03-30

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -571,6 +571,24 @@ Collected trace data for all services:
 Additionally, some services collect more specific data
 
 [float]
+[[automatic-instrumentation-aiobotocore]]
+==== AWS Aiobotocore
+
+Library: `aiobotocore` (`>=2.2.0`)
+
+Instrumented methods:
+
+ * `aiobotocore.client.BaseClient._make_api_call`
+
+Collected trace data for all services:
+
+ * AWS region (e.g. `eu-central-1`)
+ * AWS service name (e.g. `s3`)
+ * operation name (e.g. `ListBuckets`)
+
+Additionally, some services collect more specific data
+
+[float]
 [[automatic-instrumentation-s3]]
 ===== S3
 

--- a/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
@@ -1,0 +1,40 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from elasticapm.contrib.asyncio.traces import async_capture_span
+from elasticapm.instrumentation.packages.botocore import BotocoreInstrumentation
+
+
+class AioBotocoreInstrumentation(BotocoreInstrumentation):
+    name = "aiobotocore"
+
+    instrument_list = [("aiobotocore.client", "AioBaseClient._make_api_call")]
+
+    capture_span_ctx = async_capture_span

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -52,6 +52,8 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
 
     instrument_list = [("botocore.client", "BaseClient._make_api_call")]
 
+    capture_span_ctx = capture_span
+
     def call(self, module, method, wrapped, instance, args, kwargs):
         if "operation_name" in kwargs:
             operation_name = kwargs["operation_name"]
@@ -81,7 +83,7 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
         if not handler_info:
             handler_info = handle_default(operation_name, service, instance, args, kwargs, context)
 
-        with capture_span(
+        with self.capture_span_ctx(
             handler_info.signature,
             span_type=handler_info.span_type,
             leaf=True,

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -55,6 +55,10 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
     capture_span_ctx = capture_span
 
     def _call(self, service, instance, args, kwargs):
+        """
+        This is split out from `call()` so that it can be re-used by the
+        aiobotocore instrumentation without duplicating all of this code.
+        """
         if "operation_name" in kwargs:
             operation_name = kwargs["operation_name"]
         else:

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -54,18 +54,11 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
 
     capture_span_ctx = capture_span
 
-    def call(self, module, method, wrapped, instance, args, kwargs):
+    def _call(self, service, instance, args, kwargs):
         if "operation_name" in kwargs:
             operation_name = kwargs["operation_name"]
         else:
             operation_name = args[0]
-
-        service_model = instance.meta.service_model
-        if hasattr(service_model, "service_id"):  # added in boto3 1.7
-            service = service_model.service_id
-        else:
-            service = service_model.service_name.upper()
-            service = endpoint_to_service_id.get(service, service)
 
         parsed_url = urllib.parse.urlparse(instance.meta.endpoint_url)
         context = {
@@ -83,14 +76,29 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
         if not handler_info:
             handler_info = handle_default(operation_name, service, instance, args, kwargs, context)
 
-        with self.capture_span_ctx(
+        return self.capture_span_ctx(
             handler_info.signature,
             span_type=handler_info.span_type,
             leaf=True,
             span_subtype=handler_info.span_subtype,
             span_action=handler_info.span_action,
             extra=handler_info.context,
-        ) as span:
+        )
+
+    def _get_service(self, instance):
+        service_model = instance.meta.service_model
+        if hasattr(service_model, "service_id"):  # added in boto3 1.7
+            service = service_model.service_id
+        else:
+            service = service_model.service_name.upper()
+            service = endpoint_to_service_id.get(service, service)
+        return service
+
+    def call(self, module, method, wrapped, instance, args, kwargs):
+        service = self._get_service(instance)
+
+        ctx = self._call(service, instance, args, kwargs)
+        with ctx as span:
             if service in span_modifiers:
                 span_modifiers[service](span, args, kwargs)
             return wrapped(*args, **kwargs)

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -86,6 +86,7 @@ if sys.version_info >= (3, 7):
             "elasticapm.instrumentation.packages.asyncio.aioredis.RedisPipelineInstrumentation",
             "elasticapm.instrumentation.packages.asyncio.aioredis.RedisConnectionInstrumentation",
             "elasticapm.instrumentation.packages.asyncio.aiomysql.AioMySQLInstrumentation",
+            "elasticapm.instrumentation.packages.asyncio.aiobotocore.AioBotocoreInstrumentation",
         ]
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -162,6 +162,7 @@ markers =
     prometheus_client
     sanic
     jinja2
+    aiobotocore
 
 [isort]
 line_length=120

--- a/tests/instrumentation/asyncio_tests/aiobotocore_tests.py
+++ b/tests/instrumentation/asyncio_tests/aiobotocore_tests.py
@@ -1,0 +1,357 @@
+#  BSD 3-Clause License
+#
+#  Copyright (c) 2019, Elasticsearch BV
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+#  * Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import os
+import urllib.parse
+
+import pytest
+
+import elasticapm
+from elasticapm.conf import constants
+from elasticapm.instrumentation.packages.botocore import SQS_MAX_ATTRIBUTES
+from tests.utils import assert_any_record_contains
+
+aiosession = pytest.importorskip("aiobotocore.session")
+
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.aiobotocore]
+
+os.environ["AWS_ACCESS_KEY_ID"] = "key"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "secret"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+LOCALSTACK_ENDPOINT = os.environ.get("AWS_URL", None)
+
+from boto3.dynamodb.types import TypeSerializer
+
+dynamodb_serializer = TypeSerializer()
+
+if not LOCALSTACK_ENDPOINT:
+    pytestmark.append(pytest.mark.skip("Skipping aiobotocore tests, no AWS_URL environment variable set"))
+
+LOCALSTACK_ENDPOINT_URL = urllib.parse.urlparse(LOCALSTACK_ENDPOINT)
+
+
+@pytest.fixture()
+def session():
+    return aiosession.get_session()
+
+
+@pytest.fixture()
+async def dynamodb(session):
+    async with session.create_client("dynamodb", endpoint_url=LOCALSTACK_ENDPOINT) as db:
+        await db.create_table(
+            TableName="Movies",
+            KeySchema=[
+                {"AttributeName": "year", "KeyType": "HASH"},  # Partition key
+                {"AttributeName": "title", "KeyType": "RANGE"},  # Sort key
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "year", "AttributeType": "N"},
+                {"AttributeName": "title", "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+        )
+        yield db
+        await db.delete_table(TableName="Movies")
+
+
+@pytest.fixture()
+async def sqs_client_and_queue(session):
+    async with session.create_client("sqs", endpoint_url=LOCALSTACK_ENDPOINT) as sqs:
+        response = await sqs.create_queue(QueueName="myqueue", Attributes={"MessageRetentionPeriod": "86400"})
+        queue_url = response["QueueUrl"]
+        yield sqs, queue_url
+        await sqs.delete_queue(QueueUrl=queue_url)
+
+
+async def test_botocore_instrumentation(instrument, elasticapm_client, session):
+    elasticapm_client.begin_transaction("transaction.test")
+    async with session.create_client("ec2", endpoint_url=LOCALSTACK_ENDPOINT) as ec2:
+        await ec2.describe_instances()
+        elasticapm_client.end_transaction("MyView")
+    span = elasticapm_client.events[constants.SPAN][0]
+
+    assert span["name"] == "EC2:DescribeInstances"
+    assert span["type"] == "aws"
+    assert span["subtype"] == "ec2"
+    assert span["action"] == "DescribeInstances"
+
+
+async def test_s3(instrument, elasticapm_client, session):
+    async with session.create_client("s3", endpoint_url=LOCALSTACK_ENDPOINT) as client:
+        elasticapm_client.begin_transaction("test")
+        await client.create_bucket(Bucket="xyz")
+        await client.put_object(Bucket="xyz", Key="abc", Body=b"foo")
+        await client.list_objects(Bucket="xyz")
+        elasticapm_client.end_transaction("test", "test")
+    spans = elasticapm_client.events[constants.SPAN]
+    for span in spans:
+        assert span["type"] == "storage"
+        assert span["subtype"] == "s3"
+        assert span["context"]["destination"]["address"] == LOCALSTACK_ENDPOINT_URL.hostname
+        assert span["context"]["destination"]["port"] == LOCALSTACK_ENDPOINT_URL.port
+        assert span["context"]["destination"]["cloud"]["region"] == "us-east-1"
+        assert span["context"]["destination"]["service"]["name"] == "s3"
+        assert span["context"]["destination"]["service"]["resource"] == "xyz"
+        assert span["context"]["destination"]["service"]["type"] == "storage"
+    assert spans[0]["name"] == "S3 CreateBucket xyz"
+    assert spans[0]["action"] == "CreateBucket"
+    assert spans[1]["name"] == "S3 PutObject xyz"
+    assert spans[1]["action"] == "PutObject"
+    assert spans[2]["name"] == "S3 ListObjects xyz"
+    assert spans[2]["action"] == "ListObjects"
+
+
+async def test_dynamodb(instrument, elasticapm_client, dynamodb):
+    elasticapm_client.begin_transaction("test")
+    response = await dynamodb.put_item(
+        TableName="Movies",
+        Item={"title": dynamodb_serializer.serialize("Independence Day"), "year": dynamodb_serializer.serialize(1994)},
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    response = await dynamodb.query(
+        TableName="Movies",
+        ExpressionAttributeValues={
+            ":v1": {
+                "S": "Independence Day",
+            },
+            ":v2": {
+                "N": "1994",
+            },
+        },
+        ExpressionAttributeNames={"#y": "year"},
+        KeyConditionExpression="title = :v1 and #y = :v2",
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    response = await dynamodb.delete_item(
+        TableName="Movies",
+        Key={
+            "title": {
+                "S": '"Independence Day"',
+            },
+            "year": {
+                "N": "1994",
+            },
+        },
+    )
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    elasticapm_client.end_transaction("test", "test")
+    spans = elasticapm_client.events[constants.SPAN]
+    for span in spans:
+        assert span["type"] == "db"
+        assert span["subtype"] == "dynamodb"
+        assert span["action"] == "query"
+        assert span["context"]["db"]["instance"] == "us-east-1"
+        assert span["context"]["db"]["type"] == "dynamodb"
+        assert span["context"]["destination"]["address"] == LOCALSTACK_ENDPOINT_URL.hostname
+        assert span["context"]["destination"]["port"] == LOCALSTACK_ENDPOINT_URL.port
+        assert span["context"]["destination"]["cloud"]["region"] == "us-east-1"
+        assert span["context"]["destination"]["service"]["name"] == "dynamodb"
+        assert span["context"]["destination"]["service"]["resource"] == "Movies"
+        assert span["context"]["destination"]["service"]["type"] == "db"
+    assert spans[0]["name"] == "DynamoDB PutItem Movies"
+    assert spans[1]["name"] == "DynamoDB Query Movies"
+    assert spans[1]["context"]["db"]["statement"] == "title = :v1 and #y = :v2"
+    assert spans[2]["name"] == "DynamoDB DeleteItem Movies"
+
+
+async def test_sns(instrument, elasticapm_client, session):
+    async with session.create_client("sns", endpoint_url=LOCALSTACK_ENDPOINT) as sns:
+        elasticapm_client.begin_transaction("test")
+        response = await sns.create_topic(Name="mytopic")
+        topic_arn = response["TopicArn"]
+        await sns.list_topics()
+        await sns.publish(TopicArn=topic_arn, Subject="Saying", Message="this is my message to you-ou-ou")
+        elasticapm_client.end_transaction("test", "test")
+    spans = elasticapm_client.events[constants.SPAN]
+    assert spans[2]["name"] == "SNS Publish mytopic"
+    assert spans[2]["type"] == "messaging"
+    assert spans[2]["subtype"] == "sns"
+    assert spans[2]["action"] == "send"
+    assert spans[2]["context"]["destination"]["address"] == LOCALSTACK_ENDPOINT_URL.hostname
+    assert spans[2]["context"]["destination"]["port"] == LOCALSTACK_ENDPOINT_URL.port
+    assert spans[2]["context"]["destination"]["cloud"]["region"] == "us-east-1"
+    assert spans[2]["context"]["destination"]["service"]["name"] == "sns"
+    assert spans[2]["context"]["destination"]["service"]["resource"] == "sns/mytopic"
+    assert spans[2]["context"]["destination"]["service"]["type"] == "messaging"
+
+
+async def test_sqs_send(instrument, elasticapm_client, sqs_client_and_queue):
+    sqs, queue_url = sqs_client_and_queue
+    elasticapm_client.begin_transaction("test")
+    await sqs.send_message(
+        QueueUrl=queue_url,
+        MessageAttributes={
+            "Title": {"DataType": "String", "StringValue": "foo"},
+        },
+        MessageBody=("bar"),
+    )
+    transaction = elasticapm_client.end_transaction("test", "test")
+    span = elasticapm_client.events[constants.SPAN][0]
+    assert span["name"] == "SQS SEND to myqueue"
+    assert span["type"] == "messaging"
+    assert span["subtype"] == "sqs"
+    assert span["action"] == "send"
+    assert span["context"]["destination"]["cloud"]["region"] == "us-east-1"
+    assert span["context"]["destination"]["service"]["name"] == "sqs"
+    assert span["context"]["destination"]["service"]["resource"] == "sqs/myqueue"
+    assert span["context"]["destination"]["service"]["type"] == "messaging"
+
+    messages = await sqs.receive_message(
+        QueueUrl=queue_url,
+        AttributeNames=["All"],
+        MessageAttributeNames=[
+            "All",
+        ],
+    )
+    message = messages["Messages"][0]
+    assert "traceparent" in message["MessageAttributes"]
+    traceparent = message["MessageAttributes"]["traceparent"]["StringValue"]
+    assert transaction.trace_parent.trace_id in traceparent
+    assert span["id"] in traceparent
+
+
+async def test_sqs_send_batch(instrument, elasticapm_client, sqs_client_and_queue):
+    sqs, queue_url = sqs_client_and_queue
+    elasticapm_client.begin_transaction("test")
+    await sqs.send_message_batch(
+        QueueUrl=queue_url,
+        Entries=[
+            {
+                "Id": "foo",
+                "MessageBody": "foo",
+                "MessageAttributes": {"string": {"StringValue": "foo", "DataType": "String"}},
+            },
+        ],
+    )
+    transaction = elasticapm_client.end_transaction("test", "test")
+    span = elasticapm_client.events[constants.SPAN][0]
+    assert span["name"] == "SQS SEND_BATCH to myqueue"
+    assert span["type"] == "messaging"
+    assert span["subtype"] == "sqs"
+    assert span["action"] == "send"
+    assert span["context"]["destination"]["cloud"]["region"] == "us-east-1"
+    assert span["context"]["destination"]["service"]["name"] == "sqs"
+    assert span["context"]["destination"]["service"]["resource"] == "sqs/myqueue"
+    assert span["context"]["destination"]["service"]["type"] == "messaging"
+    messages = await sqs.receive_message(
+        QueueUrl=queue_url,
+        AttributeNames=["All"],
+        MessageAttributeNames=[
+            "All",
+        ],
+    )
+    message = messages["Messages"][0]
+    assert "traceparent" in message["MessageAttributes"]
+    traceparent = message["MessageAttributes"]["traceparent"]["StringValue"]
+    assert transaction.trace_parent.trace_id in traceparent
+    assert span["id"] in traceparent
+
+
+async def test_sqs_send_too_many_attributes_for_disttracing(instrument, elasticapm_client, sqs_client_and_queue, caplog):
+    sqs, queue_url = sqs_client_and_queue
+    attributes = {str(i): {"DataType": "String", "StringValue": str(i)} for i in range(SQS_MAX_ATTRIBUTES)}
+    elasticapm_client.begin_transaction("test")
+    with caplog.at_level("INFO"):
+        await sqs.send_message(
+            QueueUrl=queue_url,
+            MessageAttributes=attributes,
+            MessageBody=("bar"),
+        )
+    elasticapm_client.end_transaction("test", "test")
+    messages = await sqs.receive_message(
+        QueueUrl=queue_url,
+        AttributeNames=["All"],
+        MessageAttributeNames=[
+            "All",
+        ],
+    )
+    message = messages["Messages"][0]
+    assert "traceparent" not in message["MessageAttributes"]
+    assert_any_record_contains(caplog.records, "Not adding disttracing headers")
+
+
+async def test_sqs_send_disttracing_dropped_span(instrument, elasticapm_client, sqs_client_and_queue):
+    sqs, queue_url = sqs_client_and_queue
+    elasticapm_client.begin_transaction("test")
+    with elasticapm.capture_span("test", leaf=True):
+        await sqs.send_message(
+            QueueUrl=queue_url,
+            MessageAttributes={
+                "Title": {"DataType": "String", "StringValue": "foo"},
+            },
+            MessageBody=("bar"),
+        )
+    transaction = elasticapm_client.end_transaction("test", "test")
+    assert len(elasticapm_client.events[constants.SPAN]) == 1
+    messages = await sqs.receive_message(
+        QueueUrl=queue_url,
+        AttributeNames=["All"],
+        MessageAttributeNames=[
+            "All",
+        ],
+    )
+    message = messages["Messages"][0]
+    assert "traceparent" in message["MessageAttributes"]
+    traceparent = message["MessageAttributes"]["traceparent"]["StringValue"]
+    assert transaction.trace_parent.trace_id in traceparent
+    assert transaction.id in traceparent  # due to DroppedSpan, transaction.id is used instead of span.id
+
+
+async def test_sqs_receive(instrument, elasticapm_client, sqs_client_and_queue):
+    sqs, queue_url = sqs_client_and_queue
+    await sqs.send_message(
+        QueueUrl=queue_url,
+        MessageAttributes={
+            "Title": {"DataType": "String", "StringValue": "foo"},
+        },
+        MessageBody=("bar"),
+    )
+    elasticapm_client.begin_transaction("test")
+    await sqs.receive_message(
+        QueueUrl=queue_url,
+        AttributeNames=["All"],
+        MessageAttributeNames=[
+            "All",
+        ],
+    )
+    elasticapm_client.end_transaction("test", "test")
+    span = elasticapm_client.events[constants.SPAN][0]
+    assert span["name"] == "SQS RECEIVE from myqueue"
+    assert span["type"] == "messaging"
+    assert span["subtype"] == "sqs"
+    assert span["action"] == "receive"
+    assert span["context"]["destination"]["cloud"]["region"] == "us-east-1"
+    assert span["context"]["destination"]["service"]["name"] == "sqs"
+    assert span["context"]["destination"]["service"]["resource"] == "sqs/myqueue"
+    assert span["context"]["destination"]["service"]["type"] == "messaging"

--- a/tests/requirements/reqs-aiobotocore-newest.txt
+++ b/tests/requirements/reqs-aiobotocore-newest.txt
@@ -1,0 +1,3 @@
+aiobotocore
+boto3
+-r reqs-base.txt

--- a/tests/scripts/envs/aiobotocore.sh
+++ b/tests/scripts/envs/aiobotocore.sh
@@ -1,0 +1,5 @@
+export PYTEST_MARKER="-m aiobotocore"
+export DOCKER_DEPS="localstack"
+export AWS_URL="http://localstack:4566"
+export WAIT_FOR_HOST="localstack"
+export WAIT_FOR_PORT=4566


### PR DESCRIPTION
## What does this pull request do?

This adds instrumentation for aiobotocore. It heavily uses the existing instrumentation from boto3.

I got the tests to run locally for this, but noticed that the instrumentation of `aiohttp.client` already sends spans for `aiobotocore`. Though they are not labelled as AWS specific as the `boto3` instrumenter does.

As is, this implementation currently results in 2 spans for each request. I am looking for some advice on what is the better approach here. Try to remove the wrapper on the `ClientSession` used by `aiobotocore` or change the spans created by `ClientSession`?

## Related issues
Nothing opened (yet)