### PR TITLE
Fix sanic tests for 20.12.x

### DIFF
--- a/tests/contrib/sanic/sanic_tests.py
+++ b/tests/contrib/sanic/sanic_tests.py
@@ -45,6 +45,8 @@ pytestmark = [pytest.mark.sanic]  # isort:skip
 )
 def test_get(url, transaction_name, span_count, custom_context, sanic_elastic_app, elasticapm_client):
     sanic_app, apm = next(sanic_elastic_app(elastic_client=elasticapm_client))
+    if int(sanic.__version__.split(".")[0]) < 21 and url != "/":
+        pytest.skip("str type doesn't work in Sanic 20.x.x")
     source_request, response = sanic_app.test_client.get(
         url,
         headers={


### PR DESCRIPTION
## What does this pull request do?

Sanic 20.12.3 supports `string` type but not `str` type. Sanic 22.3.0 supports `str` but not `string`. 🤦‍♂️ 

Skip the test for the old version, which is less important than the newest version.