### PR TITLE
Fix django user info for frontegg authentication

### DIFF
--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -102,7 +102,12 @@ class DjangoClient(Client):
             if hasattr(user, "id"):
                 user_info["id"] = encoding.keyword_field(user.id)
             if hasattr(user, "get_username"):
-                user_info["username"] = encoding.keyword_field(encoding.force_text(user.get_username()))
+                try:
+                    user_info["username"] = encoding.keyword_field(encoding.force_text(user.get_username()))
+                except TypeError:
+                    # See https://github.com/elastic/apm-agent-python/issues/1514
+                    if hasattr(user, "username"):
+                        user_info["username"] = encoding.keyword_field(encoding.force_text(user.username))
             elif hasattr(user, "username"):
                 user_info["username"] = encoding.keyword_field(encoding.force_text(user.username))
 


### PR DESCRIPTION
## What does this pull request do?

Fixes an exception in Django user info generation when using `frontegg` user authentication.

This is a bit hacky but I'm having a really hard time tracking down the `frontegg` object that's replacing the user object in Django to figure out why we're getting the TypeError in the first place. So I just worked around it, get whatever user info we can and move on. If more users run into this issue or the missing user info, we can revisit.

## Related issues
Closes #1514
