### PR TITLE
ci: use coverageReport for code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@test/support-coverage-file') _
+@Library('apm@current') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field
@@ -189,7 +189,6 @@ pipeline {
                 changeRequest()
                 expression { return !params.Run_As_Main_Branch }
               }
-              expression { return false }
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,7 +108,6 @@ pipeline {
             allOf {
               expression { return env.ONLY_DOCS == "false" }
               expression { return params.tests_ci }
-              expression { return false }
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,7 @@ pipeline {
             allOf {
               expression { return env.ONLY_DOCS == "false" }
               expression { return params.tests_ci }
+              expression { return false }
             }
           }
           steps {
@@ -189,6 +190,7 @@ pipeline {
                 changeRequest()
                 expression { return !params.Run_As_Main_Branch }
               }
+              expression { return false }
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@test/support-coverage-reporting') _
+@Library('apm@test/support-coverage-file') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@current') _
+@Library('apm@test/support-coverage-reporting') _
 
 import co.elastic.matrix.*
 import groovy.transform.Field
@@ -498,7 +498,8 @@ def convergeCoverage() {
         )
       }
     }
-    sh('python3 -m coverage combine && python3 -m coverage xml')
+    sh(script: 'python3 -m coverage combine && python3 -m coverage xml', label: 'python coverage')
+    // TODO: use coverageReport
     cobertura coberturaReportFile: 'coverage.xml'
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,7 +336,6 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(analyzeFlakey: true, jobName: getFlakyJobName(withBranch: 'main'))
-      generateReport(id: 'coverage', input: 'tests-coverage.json', template: true, compare: true)
     }
   }
 }
@@ -501,8 +500,7 @@ def convergeCoverage() {
       }
     }
     sh(script: 'python3 -m coverage combine && python3 -m coverage xml', label: 'python coverage')
-    // TODO: use coverageReport
-    cobertura coberturaReportFile: 'coverage.xml'
+    coverageReport(baseDir: '.', reportFiles: 'coverage.html', coverageFiles: 'coverage.xml')
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -499,8 +499,8 @@ def convergeCoverage() {
       }
     }
     sh(script: 'python3 -m coverage combine && python3 -m coverage xml', label: 'python coverage')
-    coverageReport(baseDir: '.', reportFiles: 'coverage.html', coverageFiles: 'coverage.xml')
   }
+  coverageReport(baseDir: "${BASE_DIR}", reportFiles: 'coverage.html', coverageFiles: 'coverage.xml')
 }
 
 def generateResultsReport() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -334,6 +334,7 @@ pipeline {
   post {
     cleanup {
       notifyBuildResult(analyzeFlakey: true, jobName: getFlakyJobName(withBranch: 'main'))
+      generateReport(id: 'coverage', input: 'tests-coverage.json', template: true, compare: true)
     }
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Use the new step for the code coverage

## Related issues

As soon as https://github.com/elastic/apm-pipeline-library/pull/1673 is merged and released then the code coverage report on a PR basis will be available

## Test

The below tests are the ones I used for supporting the GitHub comments with the Code Coverage delta between the PR and the target branch

If it cannot be compared with the target branch:

<img width="433" alt="image" src="https://user-images.githubusercontent.com/2871786/165109861-55160258-8030-4a51-bd60-4b56b441c9fc.png">


If it can be compared with the target branch:

<img width="399" alt="image" src="https://user-images.githubusercontent.com/2871786/165131353-4d064d24-955e-46e3-bd1d-416825d66983.png">
