### PR TITLE
Conditionally log warning when adding labels

### DIFF
--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -1029,7 +1029,8 @@ def label(**labels):
     """
     transaction = execution_context.get_transaction()
     if not transaction:
-        error_logger.warning("Ignored labels %s. No transaction currently active.", ", ".join(labels.keys()))
+        if elasticapm.get_client().config.enabled:
+            error_logger.warning("Ignored labels %s. No transaction currently active.", ", ".join(labels.keys()))
     else:
         transaction.label(**labels)
 

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -41,7 +41,7 @@ from elasticapm.conf import Config, VersionedConfig
 from elasticapm.conf.constants import SPAN, TRANSACTION
 from elasticapm.traces import Tracer, capture_span, execution_context
 from elasticapm.utils.disttracing import TraceParent
-from tests.utils import assert_any_record_contains
+from tests.utils import any_record_contains, assert_any_record_contains
 
 
 @pytest.fixture()
@@ -283,10 +283,14 @@ def test_label_transaction():
     assert transaction_dict["context"]["tags"] == {"foo": "bar", "baz": "bazzinga"}
 
 
-def test_label_while_no_transaction(caplog):
+@pytest.mark.parametrize(
+    "elasticapm_client", [{"enabled": True}, {"enabled": False}], indirect=True,
+)
+def test_label_while_no_transaction(caplog, elasticapm_client):
     with caplog.at_level(logging.WARNING, "elasticapm.errors"):
         elasticapm.label(foo="bar")
-    assert_any_record_contains(caplog.records, "foo", "elasticapm.errors")
+    is_present = any_record_contains(caplog.records, "foo", "elasticapm.errors")
+    assert is_present is elasticapm_client.config.enabled
 
 
 def test_label_with_allowed_non_string_value():

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -29,8 +29,12 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-def assert_any_record_contains(records, message, logger=None):
-    assert any(
+def any_record_contains(records, message, logger=None):
+    return any(
         message in record.message
         for record in (record for record in records if logger is None or record.name == logger)
     )
+
+
+def assert_any_record_contains(records, message, logger=None):
+    assert any_record_contains(records, message, logger=logger)


### PR DESCRIPTION
## What does this pull request do?

This change conditionally logs a warning, based on the state of the APM integration (`ELASTIC_APM_ENABLED`), if no transaction is present and adding labels. It still warns developers when data is discarded and at the same time doesn't spam the log with unnecessary log lines in case the integration is disabled.
