### PR TITLE
linting: use the GIT_BASE_COMMIT env variable

### DIFF
--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -4,8 +4,8 @@
 pipeline {
   agent { label 'linux && immutable' }
   environment {
-    HOME = "${env.WORKSPACE}"
     BASE_DIR = "src"
+    HOME = "${env.WORKSPACE}/${env.BASE_DIR}"
   }
   options {
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -20,11 +20,16 @@ pipeline {
   }
   stages {
     stage('Sanity checks') {
+      options { skipDefaultCheckout() }
       steps {
         script {
-          // Since gitCheckout is not used, then it's required to call the GitHub environment
-          // variables creation.
-          githubEnv()
+          // Use gitCheckout to prepare the context
+          try {
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: false)
+          } catch (err) {
+            // NOOP: avoid failing if non-elasticians, this will avoid issues when PRs comming
+            //       from non elasticians since the validation will not fail
+          }
           docker.image('python:3.7-stretch').inside(){
             // registry: '' will help to disable the docker login
             preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -48,7 +48,7 @@ def runCheckout() {
 }
 
 def runPreCommit() {
-  docker.image('python:3.7-stretch').inside(){
+  docker.image('python:3.10-bullseye').inside(){
     // registry: '' will help to disable the docker login
     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
   }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -48,7 +48,7 @@ def runCheckout() {
 }
 
 def runPreCommit() {
-  docker.image('python:3.10-bullseye').inside(){
+  docker.image('python:3.7-stretch').inside(){
     // registry: '' will help to disable the docker login
     preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
   }

--- a/.ci/linting.groovy
+++ b/.ci/linting.groovy
@@ -22,10 +22,12 @@ pipeline {
     stage('Sanity checks') {
       steps {
         script {
-          def sha = getGitCommitSha()
+          // Since gitCheckout is not used, then it's required to call the GitHub environment
+          // variables creation.
+          githubEnv()
           docker.image('python:3.7-stretch').inside(){
             // registry: '' will help to disable the docker login
-            preCommit(commit: "${sha}", junit: true, registry: '')
+            preCommit(commit: "${GIT_BASE_COMMIT}", junit: true, registry: '')
           }
         }
       }


### PR DESCRIPTION
## What does this pull request do?

Use `GIT_BASE_COMMIT` since it's the variable with the current commit therefore all the integrations should keep working as is.
