### PR TITLE
synchronize schema spec

### DIFF
--- a/tests/upstream/json-specs/span.json
+++ b/tests/upstream/json-specs/span.json
@@ -147,7 +147,7 @@
                   "maxLength": 1024
                 },
                 "resource": {
-                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name'",
+                  "description": "Resource identifies the destination service resource being operated on e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name' DEPRECATED: this field will be removed in a future release",
                   "type": "string",
                   "maxLength": 1024
                 },

--- a/tests/upstream/json-specs/transaction.json
+++ b/tests/upstream/json-specs/transaction.json
@@ -756,6 +756,22 @@
               "unknown",
               null
             ]
+          },
+          "service_target_name": {
+            "description": "ServiceTargetName identifies the instance name of the target service being operated on",
+            "type": [
+              "null",
+              "string"
+            ],
+            "maxLength": 512
+          },
+          "service_target_type": {
+            "description": "ServiceTargetType identifies the type of the target service being operated on e.g. 'oracle', 'rabbitmq'",
+            "type": [
+              "null",
+              "string"
+            ],
+            "maxLength": 512
           }
         }
       },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/e909e47ae Add support for target service in metric aggregation (https://github.com/elastic/apm-server/pull/7924)