### PR TITLE
Fix on UnicodeDecodeError on FastAPI plugin

### DIFF
--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -129,7 +129,7 @@ async def get_body(request: Request) -> str:
 
     request._stream_consumed = False
 
-    return body.decode("utf-8")
+    return body.decode("utf-8", errors="replace")
 
 
 async def query_params_to_dict(query_params: str) -> dict:


### PR DESCRIPTION
## What does this pull request do?
Fix on error when try to decode body thats was send with a binary file

## Related issues
closes #[1556](https://github.com/elastic/apm-agent-python/issues/1556)
