### PR TITLE
fix errorhandling of LoggingHandler.emit

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,7 +47,7 @@ endif::[]
 * Fix return for `opentelemetry.Span.is_recording()` {pull}1530[#1530]
 * Fix error logging for bad SERVICE_NAME config {pull}1546[#1546]
 * Do not instrument old versions of Tornado > 6.0 due to incompatibility {pull}1566[#1566]
-
+* Fix a problem with our logging handler failing to report internal errors in its emitter {pull}1568[#1568]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/handlers/logbook.py
+++ b/elasticapm/handlers/logbook.py
@@ -75,15 +75,15 @@ class LogbookHandler(logbook.Handler):
 
         # Avoid typical config issues by overriding loggers behavior
         if record.channel.startswith("elasticapm.errors"):
-            sys.stderr.write(to_unicode(record.message + "\n"))
+            sys.stderr.write(to_unicode(record.message) + "\n")
             return
 
         try:
             return self._emit(record)
         except Exception:
             sys.stderr.write("Top level ElasticAPM exception caught - failed creating log record.\n")
-            sys.stderr.write(to_unicode(record.msg + "\n"))
-            sys.stderr.write(to_unicode(traceback.format_exc() + "\n"))
+            sys.stderr.write(to_unicode(record.message) + "\n")
+            sys.stderr.write(traceback.format_exc() + "\n")
 
             try:
                 self.client.capture("Exception")

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -40,7 +40,6 @@ from elasticapm import get_client
 from elasticapm.base import Client
 from elasticapm.traces import execution_context
 from elasticapm.utils import wrapt
-from elasticapm.utils.encoding import to_unicode
 from elasticapm.utils.stacks import iter_stack_frames
 
 
@@ -74,15 +73,15 @@ class LoggingHandler(logging.Handler):
 
         # Avoid typical config issues by overriding loggers behavior
         if record.name.startswith(("elasticapm.errors",)):
-            sys.stderr.write(to_unicode(record.message) + "\n")
+            sys.stderr.write(record.getMessage() + "\n")
             return
 
         try:
             return self._emit(record)
         except Exception:
             sys.stderr.write("Top level ElasticAPM exception caught - failed creating log record.\n")
-            sys.stderr.write(to_unicode(record.msg + "\n"))
-            sys.stderr.write(to_unicode(traceback.format_exc() + "\n"))
+            sys.stderr.write(record.getMessage() + "\n")
+            sys.stderr.write(traceback.format_exc() + "\n")
 
             try:
                 self.client.capture("Exception")

--- a/tests/handlers/logbook/logbook_tests.py
+++ b/tests/handlers/logbook/logbook_tests.py
@@ -169,6 +169,15 @@ def test_logbook_handler_emit_error(capsys, elasticapm_client):
     assert "Oops" in err
 
 
+def test_logbook_handler_emit_error_non_str_message(capsys, elasticapm_client):
+    handler = LogbookHandler(elasticapm_client)
+    handler._emit = lambda record: 1 / 0
+    handler.emit(LogRecord("x", 1, ValueError("oh no")))
+    out, err = capsys.readouterr()
+    assert "Top level ElasticAPM exception caught" in err
+    assert "oh no" in err
+
+
 def test_logbook_handler_dont_emit_elasticapm(capsys, elasticapm_client):
     handler = LogbookHandler(elasticapm_client)
     handler.emit(LogRecord("elasticapm.errors", 1, "Oops"))

--- a/tests/handlers/logging/logging_tests.py
+++ b/tests/handlers/logging/logging_tests.py
@@ -229,7 +229,7 @@ def test_logger_setup():
 def test_logging_handler_emit_error(capsys, elasticapm_client):
     handler = LoggingHandler(elasticapm_client)
     handler._emit = lambda: 1 / 0
-    handler.emit(LogRecord("x", 1, "/ab/c/", 10, "Oops", [], None))
+    handler.emit(LogRecord("x", 1, "/ab/c/", 10, "Oops", (), None))
     out, err = capsys.readouterr()
     assert "Top level ElasticAPM exception caught" in err
     assert "Oops" in err
@@ -237,9 +237,18 @@ def test_logging_handler_emit_error(capsys, elasticapm_client):
 
 def test_logging_handler_dont_emit_elasticapm(capsys, elasticapm_client):
     handler = LoggingHandler(elasticapm_client)
-    handler.emit(LogRecord("elasticapm.errors", 1, "/ab/c/", 10, "Oops", [], None))
+    handler.emit(LogRecord("elasticapm.errors", 1, "/ab/c/", 10, "Oops", (), None))
     out, err = capsys.readouterr()
     assert "Oops" in err
+
+
+def test_logging_handler_emit_error_non_str_message(capsys, elasticapm_client):
+    handler = LoggingHandler(elasticapm_client)
+    handler._emit = lambda: 1 / 0
+    handler.emit(LogRecord("x", 1, "/ab/c/", 10, ValueError("oh no"), (), None))
+    out, err = capsys.readouterr()
+    assert "Top level ElasticAPM exception caught" in err
+    assert "oh no" in err
 
 
 def test_arbitrary_object(logger):


### PR DESCRIPTION
When a LogRecord has a non-string as the `.msg` attribute,
just trying to concatenate it with `"\n"` leads to an error.

A similar problem also existed in the LogBook handler.

This error was first reported in #1340, but it wasn't obvious due to a chained exception.

closes #1340
