### PR TITLE
implement span links for SQS ReceiveMessage

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ endif::[]
 * Add instrumentation for https://github.com/aio-libs/aiobotocore[`aiobotocore`] {pull}1520[#1520]
 * Add instrumentation for https://kafka-python.readthedocs.io/en/master/[`kafka-python`] {pull}1555[#1555]
 * Add API for span links, and implement span link support for OpenTelemetry bridge {pull}1562[#1562]
+* Add span links to SQS ReceiveMessage call {pull}1575[#1575]
 * Add specific instrumentation for SQS delete/batch-delete {pull}1567[#1567]
 * Add `trace_continuation_strategy` setting {pull}1564[#1564]
 

--- a/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
@@ -29,7 +29,11 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from elasticapm.contrib.asyncio.traces import async_capture_span
-from elasticapm.instrumentation.packages.botocore import BotocoreInstrumentation, span_modifiers
+from elasticapm.instrumentation.packages.botocore import (
+    BotocoreInstrumentation,
+    post_span_modifiers,
+    pre_span_modifiers,
+)
 
 
 class AioBotocoreInstrumentation(BotocoreInstrumentation):
@@ -44,6 +48,9 @@ class AioBotocoreInstrumentation(BotocoreInstrumentation):
 
         ctx = self._call(service, instance, args, kwargs)
         async with ctx as span:
-            if service in span_modifiers:
-                span_modifiers[service](span, args, kwargs)
-            return await wrapped(*args, **kwargs)
+            if service in pre_span_modifiers:
+                pre_span_modifiers[service](span, args, kwargs)
+            result = await wrapped(*args, **kwargs)
+            if service in post_span_modifiers:
+                post_span_modifiers[service](span, args, kwargs, result)
+            return result


### PR DESCRIPTION
## What does this pull request do?

For SQS, span links are implemented by instrumenting ReceiveMessage and attaching a reference to each messages TraceParent as a span link to the ReceiveMessage span.

## Related issues
closes #1473
