### PR TITLE
provide better snippet for secret token generation

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -341,7 +341,7 @@ An example to generate a secure secret token is:
 
 [source,bash]
 ----
-python -c "import uuid; print(str(uuid.uuid4()))"
+python -c "import secrets; print(secrets.token_urlsafe(32))"
 ----
 
 WARNING: Secret tokens only provide any security if your APM Server uses TLS.


### PR DESCRIPTION
## What does this pull request do?
While the previous snippet wasn't necessarily bad, it used
uuid4 for something it isn't intended to. Python 3 provides
a cryptographically secure token generator, so let's tell
our users to use that instead.

