### PR TITLE
docs: consistent naming of APM AWS Lambda extension

### DIFF
--- a/docs/serverless.asciidoc
+++ b/docs/serverless.asciidoc
@@ -12,17 +12,17 @@ Follow the steps below to setup Elastic APM for your AWS Lambda Python functions
 You need an APM Server to send APM data to. Follow the {apm-guide-ref}/apm-quick-start.html[APM Quick start] if you have not set one up yet. For the best-possible performance, we recommend setting up APM on {ecloud} in the same AWS region as your AWS Lambda functions.
 
 [float]
-==== Step 1: Setup the APM Lambda Extension
+==== Step 1: Set up the {apm-lambda-ext}
 
 include::{apm-aws-lambda-root}/docs/lambda-selector/lambda-attributes-selector.asciidoc[]
 
-Add the {apm-guide-ref}/aws-lambda-arch.html[APM Lambda Extension] as an https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layer] to your AWS Lambda function.
+Add the {apm-guide-ref}/aws-lambda-arch.html[{apm-lambda-ext}] as an https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layer] to your AWS Lambda function.
 
 include::{apm-aws-lambda-root}/docs/lambda-selector/extension-arn-replacement.asciidoc[]
 include::{apm-aws-lambda-root}/docs/add-extension/add-extension-layer-widget.asciidoc[]
 
 [float]
-==== Step 2: Setup the APM Python Agent
+==== Step 2: Set up the APM Python Agent
 
 You need to add `elastic-apm` as a dependency for your python function.
 Depending on your deployment strategy, this could be as easy as adding
@@ -49,7 +49,7 @@ def handler(event, context):
 [float]
 ==== Step 3: Configure APM on AWS Lambda
 
-The APM Lambda Extension and the APM Python agent are configured through environment variables on the AWS Lambda function.
+The {apm-lambda-ext} and the APM Python agent are configured through environment variables on the AWS Lambda function.
 
 For the minimal configuration, you will need the _APM Server URL_ to set the destination for APM data and an _{apm-guide-ref}/secret-token.html[APM Secret Token]_.
 If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the APM secret token, use the `ELASTIC_APM_API_KEY` environment variable instead of `ELASTIC_APM_SECRET_TOKEN` in the following configuration.
@@ -58,7 +58,7 @@ For production environments, we recommend {apm-guide-ref}/aws-lambda-secrets-man
 
 include::./lambda/configure-lambda-widget.asciidoc[]
 
-You can optionally <<configuration,fine-tune the Python agent>> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the APM Lambda Extension].
+You can optionally <<configuration,fine-tune the Python agent>> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 
 That's it; Once the agent is installed and working, spans will be captured for
 <<supported-technologies,supported technologies>>. You can also use


### PR DESCRIPTION
### Summary

This PR updates the _Monitoring AWS Lambda Python Functions_ guide to refer to the `Elastic APM AWS Lambda extension` by its complete name.

For https://github.com/elastic/apm-aws-lambda/issues/209.

Note: The referenced attribute (`{apm-lambda-ext}`) is defined [here](https://github.com/elastic/docs/blob/7bd515547f91733dfd4ebe52932dfe4fc3547041/shared/attributes.asciidoc#L393). 