### PR TITLE
Fix exception for bad port in Django request

### DIFF
--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -152,7 +152,10 @@ class DjangoClient(Client):
                     result["body"] = data
 
         url = get_raw_uri(request)
-        result["url"] = get_url_dict(url)
+        try:
+            result["url"] = get_url_dict(url)
+        except ValueError as exc:
+            self.logger.warning(f"URL parsing failed: {exc}")
         return result
 
     def get_data_from_response(self, response, event_type):


### PR DESCRIPTION
## What does this pull request do?

A bad value for the `port` in a django request would result in an uncaught `ValueError` when urllib tried to cast it to an `int`. This fixes that issue.

## Related issues
closes #1589
