### PR TITLE
cast redis ports to int

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/aioredis.py
+++ b/elasticapm/instrumentation/packages/asyncio/aioredis.py
@@ -96,10 +96,10 @@ def _get_destination_info(connection):
     destination_info = {"service": {"name": "", "resource": "redis", "type": ""}}
 
     if hasattr(connection, "_pool_or_conn"):
-        destination_info["port"] = connection._pool_or_conn.address[1]
+        destination_info["port"] = int(connection._pool_or_conn.address[1])
         destination_info["address"] = connection._pool_or_conn.address[0]
     else:
-        destination_info["port"] = connection.address[1]
+        destination_info["port"] = int(connection.address[1])
         destination_info["address"] = connection.address[0]
 
     return destination_info

--- a/elasticapm/instrumentation/packages/redis.py
+++ b/elasticapm/instrumentation/packages/redis.py
@@ -94,7 +94,7 @@ class RedisConnectionInstrumentation(AbstractInstrumentedModule):
 def get_destination_info(connection):
     destination_info = {}
     if hasattr(connection, "port"):
-        destination_info["port"] = connection.port
+        destination_info["port"] = int(connection.port)
         destination_info["address"] = connection.host
     elif hasattr(connection, "path"):
         destination_info["port"] = None


### PR DESCRIPTION
## What does this pull request do?

It appears possible in at least come versions of the python redis libraries (redis-py and aioredis) to end up with ports that are stored as strings, whereas apm-server is expecting an int, which results in parsing issues. This preemptively casts all redis ports to ints before building the destination info.
