### PR TITLE
Fix varmap to apply func before recursion

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Fixed a performance issue for local variable shortening via `varmap()` {pull}1593[#1593]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -64,10 +64,14 @@ def varmap(func, var, context=None, name=None, **kwargs):
         return func(name, "<...>", **kwargs)
     context.add(objid)
     if isinstance(var, dict):
+        # Apply func() before recursion, so that `shorten()` doesn't have to iterate over all the trimmed values
+        ret = func(name, var, **kwargs)
         # iterate over a copy of the dictionary to avoid "dictionary changed size during iteration" issues
-        ret = func(name, dict((k, varmap(func, v, context, k, **kwargs)) for k, v in var.copy().items()), **kwargs)
+        ret = dict((k, varmap(func, v, context, k, **kwargs)) for k, v in ret.copy().items())
     elif isinstance(var, (list, tuple)):
-        ret = func(name, [varmap(func, f, context, name, **kwargs) for f in var], **kwargs)
+        # Apply func() before recursion, so that `shorten()` doesn't have to iterate over all the trimmed values
+        ret = func(name, var, **kwargs)
+        ret = [varmap(func, f, context, name, **kwargs) for f in ret]
     else:
         ret = func(name, var, **kwargs)
     context.remove(objid)


### PR DESCRIPTION
## What does this pull request do?

We use `varmap()` to apply [`shorten()`](https://github.com/elastic/apm-agent-python/blob/02ed26d2b41be2cd8ba7d08f3513cddfcd06cbfe/elasticapm/utils/encoding.py#L179) recursively across a data structure. `varmap()` was recursing into the data structures, and _then_ applying the `func()` (in this case, `shorten()`) on the way back out of recursion. This meant that when shortening local variables where just recursing over the data structure was a performance issue, setting `ELASTIC_APM_LOCAL_VAR_LIST_MAX_LENGTH` wouldn't actually affect the runtime, just the output.

With this change, dictionaries and lists will be shortened and _then_ we'll iterate over their contents. Shouldn't affect `_sanitize()` at all, but will speed up `shorten()` considerably.

I think the test surface on this function is sufficient without adding tests for this fix.

## Related issues
Closes #1592
