### PR TITLE
label no longer fails when called without a client

### DIFF
--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -1089,7 +1089,8 @@ def label(**labels):
     """
     transaction = execution_context.get_transaction()
     if not transaction:
-        if elasticapm.get_client().config.enabled:
+        client = elasticapm.get_client()
+        if not client or client.config.enabled:
             error_logger.warning("Ignored labels %s. No transaction currently active.", ", ".join(labels.keys()))
     else:
         transaction.label(**labels)

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -536,3 +536,7 @@ def test_check_server_version(elasticapm_client):
 )
 def test_user_agent(elasticapm_client, expected):
     assert elasticapm_client.get_user_agent() == "apm-agent-python/unknown (myapp{})".format(expected)
+
+
+def test_label_without_client():
+    elasticapm.label(foo="foo")


### PR DESCRIPTION
## What does this pull request do?

`elasticapm.label(. . .)`no longer fails when no client is present

## Related issues
closes #1595 
