### PR TITLE
Remove psycopg2 2.7 testing/support

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -1,8 +1,8 @@
 exclude:
-  - PYTHON_VERSION: pypy-3  # pypy3 currently fails on CI, e.g. https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-1099/2/pipeline#step-3497-log-1
+  - PYTHON_VERSION: pypy-3 # pypy3 currently fails on CI, e.g. https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-1099/2/pipeline#step-3497-log-1
     FRAMEWORK: none
   # Django
-    # Django 4.0 requires Python 3.8+
+  # Django 4.0 requires Python 3.8+
   - PYTHON_VERSION: pypy-3 # current pypy-3 is compatible with Python 3.7
     FRAMEWORK: django-4.0
   - PYTHON_VERSION: python-3.6
@@ -129,15 +129,6 @@ exclude:
     FRAMEWORK: pymssql-newest
   - PYTHON_VERSION: python-3.10 # currently fails with error on python 3.8 due to cython issues
     FRAMEWORK: pymssql-newest
-  # psycopg2
-  - PYTHON_VERSION: python-3.8 # see https://github.com/psycopg/psycopg2/issues/858
-    FRAMEWORK: psycopg2-2.7
-  - PYTHON_VERSION: python-3.9 # see https://github.com/psycopg/psycopg2/issues/858
-    FRAMEWORK: psycopg2-2.7
-  - PYTHON_VERSION: python-3.10 # see https://github.com/psycopg/psycopg2/issues/858
-    FRAMEWORK: psycopg2-2.7
-  - PYTHON_VERSION: pypy-3  # async keyword clash in old version of psycopg2cffi
-    FRAMEWORK: psycopg2-2.7
   # pyodbc
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: pyodbc-newest
@@ -221,21 +212,21 @@ exclude:
     FRAMEWORK: sanic-20.12
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: sanic-newest
-  - PYTHON_VERSION: python-3.10  # install of uvloop 0.14 fails: https://github.com/MagicStack/uvloop/issues/356
+  - PYTHON_VERSION: python-3.10 # install of uvloop 0.14 fails: https://github.com/MagicStack/uvloop/issues/356
     FRAMEWORK: sanic-20.12
   - PYTHON_VERSION: pypy-3
-  # aioredis
+    # aioredis
     FRAMEWORK: aioredis-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aioredis-newest
-  - PYTHON_VERSION: python-3.10  # getting "loop argument must agree with lock" error
+  - PYTHON_VERSION: python-3.10 # getting "loop argument must agree with lock" error
     FRAMEWORK: aioredis-newest
   # aiomysql
   - PYTHON_VERSION: pypy-3
     FRAMEWORK: aiomysql-newest
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: aiomysql-newest
-  - PYTHON_VERSION: python-3.10  # getting "loop argument must agree with lock" error
+  - PYTHON_VERSION: python-3.10 # getting "loop argument must agree with lock" error
     FRAMEWORK: aiomysql-newest
   # aiobotocore
   - PYTHON_VERSION: pypy-3

--- a/.ci/.jenkins_framework_full.yml
+++ b/.ci/.jenkins_framework_full.yml
@@ -47,7 +47,6 @@ FRAMEWORK:
   - redis-3
   - redis-2
   - redis-newest
-  - psycopg2-2.7
   - psycopg2-newest
   - pymssql-newest
   - memcached-1.51

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -231,7 +231,7 @@ Collected trace data:
 [[automatic-instrumentation-db-postgres]]
 ==== PostgreSQL
 
-Library: `psycopg2`, `psycopg2-binary` (`>=2.7`)
+Library: `psycopg2`, `psycopg2-binary` (`>=2.9`)
 
 Instrumented methods:
 

--- a/tests/requirements/reqs-aiopg-newest.txt
+++ b/tests/requirements/reqs-aiopg-newest.txt
@@ -1,4 +1,4 @@
 aiopg
-psycopg2>=2.7 ; platform_python_implementation == 'CPython'
-psycopg2cffi>=2.7 ; platform_python_implementation == 'PyPy'
+psycopg2>=2.9 ; platform_python_implementation == 'CPython'
+psycopg2cffi>=2.9 ; platform_python_implementation == 'PyPy'
 -r reqs-base.txt

--- a/tests/requirements/reqs-psycopg2-2.7.txt
+++ b/tests/requirements/reqs-psycopg2-2.7.txt
@@ -1,3 +1,0 @@
-psycopg2>=2.7,<2.8 ; platform_python_implementation == 'CPython'
-psycopg2cffi>=2.7,<2.8 ; platform_python_implementation == 'PyPy'
--r reqs-base.txt


### PR DESCRIPTION
No barriers to upgrade `psycopg2` that I can detect, and the old version was
failing DB granularity tests.

This fixes the failing tests on `main`.

Ref #1585