### PR TITLE
Add lambda url granularity to lambda integration

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,18 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Differentiate Lambda URLs from API Gateway in AWS Lambda integration {pull}#1609[#1609]
+
 
 
 [[release-notes-6.x]]

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -254,6 +254,8 @@ class capture_serverless(object):
             service_context["origin"]["version"] = self.event.get("version", "1.0")
             cloud_context["origin"] = {}
             cloud_context["origin"]["service"] = {"name": "api gateway"}
+            if ".lambda-url." in self.event["requestContext"]["domainName"]:
+                cloud_context["origin"]["service"]["name"] = "lambda url"
             cloud_context["origin"]["account"] = {"id": self.event["requestContext"]["accountId"]}
             cloud_context["origin"]["provider"] = "aws"
         elif self.source == "elb":

--- a/tests/contrib/serverless/aws_lurl_test_data.json
+++ b/tests/contrib/serverless/aws_lurl_test_data.json
@@ -1,0 +1,35 @@
+{
+    "version": "2.0",
+    "routeKey": "ANY /fetch_all",
+    "rawPath": "/dev/fetch_all",
+    "rawQueryString": "",
+    "headers": {
+        "accept": "*/*",
+        "content-length": "0",
+        "host": "myurl.lambda-url.us-west-2.on.aws",
+        "user-agent": "curl/7.64.1",
+        "x-amzn-trace-id": "Root=1-618018c5-763ade2b18f5734547c93e98",
+        "x-forwarded-for": "67.171.184.49",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+        "accountId": "627286350134",
+        "apiId": "02plqthge2",
+        "domainName": "myurl.lambda-url.us-west-2.on.aws",
+        "domainPrefix": "02plqthge2",
+        "http": {
+            "method": "GET",
+            "path": "/dev/fetch_all",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "67.171.184.49",
+            "userAgent": "curl/7.64.1"
+        },
+        "requestId": "IIjO5hs7PHcEPIA=",
+        "routeKey": "ANY /fetch_all",
+        "stage": "dev",
+        "time": "01/Nov/2021:16:41:41 +0000",
+        "timeEpoch": 1635784901594
+    },
+    "isBase64Encoded": false
+}

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -54,6 +54,13 @@ def event_api2():
 
 
 @pytest.fixture
+def event_lurl():
+    aws_data_file = os.path.join(os.path.dirname(__file__), "aws_lurl_test_data.json")
+    with open(aws_data_file) as f:
+        return json.load(f)
+
+
+@pytest.fixture
 def event_elb():
     aws_data_file = os.path.join(os.path.dirname(__file__), "aws_elb_test_data.json")
     with open(aws_data_file) as f:
@@ -107,7 +114,10 @@ def test_request_data(event_api, event_api2):
     data = get_data_from_request(event_api, capture_body=True, capture_headers=True)
 
     assert data["method"] == "GET"
-    assert data["url"]["full"] == "https://02plqthge2.execute-api.us-east-1.amazonaws.com/dev/fetch_all?test%40key=test%40value"
+    assert (
+        data["url"]["full"]
+        == "https://02plqthge2.execute-api.us-east-1.amazonaws.com/dev/fetch_all?test%40key=test%40value"
+    )
     assert data["headers"]["Host"] == "02plqthge2.execute-api.us-east-1.amazonaws.com"
 
     data = get_data_from_request(event_api2, capture_body=True, capture_headers=True)
@@ -119,7 +129,10 @@ def test_request_data(event_api, event_api2):
     data = get_data_from_request(event_api, capture_body=False, capture_headers=False)
 
     assert data["method"] == "GET"
-    assert data["url"]["full"] == "https://02plqthge2.execute-api.us-east-1.amazonaws.com/dev/fetch_all?test%40key=test%40value"
+    assert (
+        data["url"]["full"]
+        == "https://02plqthge2.execute-api.us-east-1.amazonaws.com/dev/fetch_all?test%40key=test%40value"
+    )
     assert "headers" not in data
 
 
@@ -127,16 +140,20 @@ def test_elb_request_data(event_elb):
     data = get_data_from_request(event_elb, capture_body=True, capture_headers=True)
 
     assert data["method"] == "POST"
-    assert data["url"][
-               "full"] == "https://blabla.com/toolz/api/v2.0/downloadPDF/PDF_2020-09-11_11-06-01.pdf?test%40key=test%40value&language=en-DE"
+    assert (
+        data["url"]["full"]
+        == "https://blabla.com/toolz/api/v2.0/downloadPDF/PDF_2020-09-11_11-06-01.pdf?test%40key=test%40value&language=en-DE"
+    )
     assert data["headers"]["host"] == "blabla.com"
     assert data["body"] == "blablablabody"
 
     data = get_data_from_request(event_elb, capture_body=False, capture_headers=False)
 
     assert data["method"] == "POST"
-    assert data["url"][
-               "full"] == "https://blabla.com/toolz/api/v2.0/downloadPDF/PDF_2020-09-11_11-06-01.pdf?test%40key=test%40value&language=en-DE"
+    assert (
+        data["url"]["full"]
+        == "https://blabla.com/toolz/api/v2.0/downloadPDF/PDF_2020-09-11_11-06-01.pdf?test%40key=test%40value&language=en-DE"
+    )
     assert "headers" not in data
     assert data["body"] == "[REDACTED]"
 
@@ -202,6 +219,30 @@ def test_capture_serverless_api_gateway_v2(event_api2, context, elasticapm_clien
     assert transaction["context"]["request"]["method"] == "GET"
     assert transaction["context"]["request"]["headers"]
     assert transaction["context"]["response"]["status_code"] == 200
+    assert transaction["context"]["cloud"]["origin"]["service"]["name"] == "api gateway"
+
+
+def test_capture_serverless_lambda_url(event_lurl, context, elasticapm_client):
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
+
+    @capture_serverless(elasticapm_client=elasticapm_client)
+    def test_func(event, context):
+        with capture_span("test_span"):
+            time.sleep(0.01)
+        return {"statusCode": 200, "headers": {"foo": "bar"}}
+
+    test_func(event_lurl, context)
+
+    assert len(elasticapm_client.events[constants.TRANSACTION]) == 1
+    transaction = elasticapm_client.events[constants.TRANSACTION][0]
+
+    assert transaction["name"] == "GET /dev/fetch_all"
+    assert transaction["result"] == "HTTP 2xx"
+    assert transaction["span_count"]["started"] == 1
+    assert transaction["context"]["request"]["method"] == "GET"
+    assert transaction["context"]["request"]["headers"]
+    assert transaction["context"]["response"]["status_code"] == 200
+    assert transaction["context"]["cloud"]["origin"]["service"]["name"] == "lambda url"
 
 
 def test_capture_serverless_elb(event_elb, context, elasticapm_client):


### PR DESCRIPTION
## What does this pull request do?

Adds `lambda url` support to our aws serverless integration. Since lambda urls just use the API v2 payload, it worked fine before, but this just adds granularity in the cloud.origin.service.name field.

## Related issues
Spec: https://github.com/elastic/apm/pull/669
