### PR TITLE
Fix error with elasticsearch(sniff_on_start=True)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ endif::[]
 
 * Differentiate Lambda URLs from API Gateway in AWS Lambda integration {pull}#1609[#1609]
 * Restrict the size of Django request bodies to prevent APM Server rejection {pull}#1610[#1610]
+* Fix error when using elasticsearch(sniff_on_start=True) {pull}#1618[#1618]
 
 
 

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -52,7 +52,7 @@ class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
 
     def call(self, module, method, wrapped, instance, args, kwargs):
         span = execution_context.get_span()
-        if isinstance(span, DroppedSpan):
+        if not span or isinstance(span, DroppedSpan):
             return wrapped(*args, **kwargs)
 
         self._update_context_by_request_data(span.context, instance, args, kwargs)

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -41,6 +41,7 @@ from elasticsearch.serializer import JSONSerializer
 
 import elasticapm
 from elasticapm.conf.constants import TRANSACTION
+from elasticapm.traces import execution_context
 
 pytestmark = [pytest.mark.elasticsearch]
 
@@ -84,6 +85,16 @@ class SpecialEncoder(JSONSerializer):
 def elasticsearch(request):
     """Elasticsearch client fixture."""
     client = Elasticsearch(hosts=os.environ["ES_URL"], serializer=SpecialEncoder())
+    try:
+        yield client
+    finally:
+        client.indices.delete(index="*")
+
+
+@pytest.fixture
+def elasticsearch_sniff_on_start(request):
+    """Elasticsearch client fixture."""
+    client = Elasticsearch(hosts=os.environ["ES_URL"], serializer=SpecialEncoder(), sniff_on_start=True)
     try:
         yield client
     finally:
@@ -564,3 +575,14 @@ def test_dropped_span(instrument, elasticapm_client, elasticsearch):
     assert len(spans) == 1
     span = spans[0]
     assert span["name"] == "test"
+
+
+@pytest.mark.integrationtest
+def test_sniff_on_start(instrument, elasticapm_client, elasticsearch_sniff_on_start):
+    elasticapm_client.begin_transaction("test")
+    elasticsearch_sniff_on_start.ping()
+    elasticapm_client.end_transaction("test", "OK")
+
+    transaction = elasticapm_client.events[TRANSACTION][0]
+    spans = elasticapm_client.spans_for_transaction(transaction)
+    assert len(spans) == 1


### PR DESCRIPTION
## What does this pull request do?

Checks if the span object is non-`None` before trying to access its context.

No test attached. I've been unable to get one to fail even without the fix....it may be that we're missing something in the user's edge case. In any case, I think this is a change that should fix the user's issue, and is extremely low-risk. So I think we can forgo the test.

## Related issues
Closes #1615 
