### PR TITLE
Restrict length of exception messages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ endif::[]
 
 * Differentiate Lambda URLs from API Gateway in AWS Lambda integration {pull}#1609[#1609]
 * Restrict the size of Django request bodies to prevent APM Server rejection {pull}#1610[#1610]
+* Restrict length of `exception.message` for exceptions captured by the agent {pull}#1619[#1619]
 
 
 

--- a/elasticapm/events.py
+++ b/elasticapm/events.py
@@ -33,7 +33,7 @@ import random
 import sys
 
 from elasticapm.conf.constants import EXCEPTION_CHAIN_MAX_DEPTH
-from elasticapm.utils import varmap
+from elasticapm.utils import encoding, varmap
 from elasticapm.utils.encoding import keyword_field, shorten, to_unicode
 from elasticapm.utils.logging import get_logger
 from elasticapm.utils.stacks import get_culprit, get_stack_info, iter_traceback_frames
@@ -132,6 +132,8 @@ class Exception(BaseEvent):
             message = kwargs["message"]
         else:
             message = "%s: %s" % (exc_type, to_unicode(exc_value)) if exc_value else str(exc_type)
+
+        message = encoding.long_field(message)
 
         data = {
             "id": "%032x" % random.getrandbits(128),

--- a/tests/client/exception_tests.py
+++ b/tests/client/exception_tests.py
@@ -397,3 +397,13 @@ def test_fail_on_uuid_raise(elasticapm_client):
         generate_uuid()
     except Exception:
         elasticapm_client.capture_exception()
+
+
+def test_long_message(elasticapm_client):
+    try:
+        raise Exception("t" * 1000000)
+    except:
+        elasticapm_client.capture_exception()
+
+    exception = elasticapm_client.events[ERROR][0]
+    assert exception["exception"]["message"] == f'Exception: {"t"*9988}{"…"}'


### PR DESCRIPTION
## What does this pull request do?

Restricts the length of the `message` field for exceptions captured by the agent. Continuation of the theme in #305.

## Related issues
Closes #1614 
