### PR TITLE
Add dropped/missing span check to async elasticsearch

### DIFF
--- a/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
@@ -34,7 +34,7 @@ from elasticapm.instrumentation.packages.elasticsearch import (
     ElasticsearchConnectionInstrumentation,
     ElasticsearchTransportInstrumentation,
 )
-from elasticapm.traces import execution_context
+from elasticapm.traces import DroppedSpan, execution_context
 
 
 class ElasticSearchAsyncConnection(ElasticsearchConnectionInstrumentation, AsyncAbstractInstrumentedModule):
@@ -47,6 +47,8 @@ class ElasticSearchAsyncConnection(ElasticsearchConnectionInstrumentation, Async
 
     async def call(self, module, method, wrapped, instance, args, kwargs):
         span = execution_context.get_span()
+        if not span or isinstance(span, DroppedSpan):
+            return wrapped(*args, **kwargs)
 
         self._update_context_by_request_data(span.context, instance, args, kwargs)
 


### PR DESCRIPTION
## What does this pull request do?

Adds the same `Span` checks to the async version of our elasticsearch instrumentation to match the sync version.

## Related issues
Ref #1618 #1615
