### PR TITLE
Finish up ELB changes from final merged spec

### DIFF
--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -261,8 +261,7 @@ class capture_serverless(object):
         elif self.source == "elb":
             elb_target_group_arn = self.event["requestContext"]["elb"]["targetGroupArn"]
             faas["trigger"]["type"] = "http"
-            faas["trigger"]["request_id"] = self.event["headers"]["x-amzn-trace-id"]
-            service_context["origin"] = {"name": elb_target_group_arn.split(":")[5]}
+            service_context["origin"] = {"name": elb_target_group_arn.split(":")[5].split("/")[1]}
             service_context["origin"]["id"] = elb_target_group_arn
             cloud_context["origin"] = {}
             cloud_context["origin"]["service"] = {"name": "elb"}

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -265,6 +265,7 @@ def test_capture_serverless_elb(event_elb, context, elasticapm_client):
     assert transaction["context"]["request"]["method"] == "POST"
     assert transaction["context"]["request"]["headers"]
     assert transaction["context"]["response"]["status_code"] == 200
+    assert transaction["context"]["service"]["origin"]["name"] == "lambda-279XGJDqGZ5rsrHC2Fjr"
 
 
 def test_capture_serverless_s3(event_s3, context, elasticapm_client):


### PR DESCRIPTION
## What does this pull request do?

The final merged [spec](https://github.com/elastic/apm/pull/669) removed the request ID for ELB triggers, and narrowed the `service.origin.name`. With this PR our implementation matches the [current spec](https://github.com/elastic/apm/blob/94f7e37b658896bd79146c036c44024caf6e0993/specs/agents/tracing-instrumentation-aws-lambda.md)

## Related issues
Closes #1622
Ref #1605 and #1609
