### PR TITLE
Add AWS Request ID to botocore span context

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ endif::[]
 ===== Features
 
 * Add redis query to context data for redis instrumentation {pull}1406[#1406]
+* Add AWS request ID to all botocore spans (at `span.context.http.request.id`) {pull}1625[#1625]
 
 [float]
 ===== Bug fixes

--- a/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiobotocore.py
@@ -53,4 +53,7 @@ class AioBotocoreInstrumentation(BotocoreInstrumentation):
             result = await wrapped(*args, **kwargs)
             if service in post_span_modifiers:
                 post_span_modifiers[service](span, args, kwargs, result)
+            request_id = result.get("ResponseMetadata", {}).get("RequestId")
+            if request_id:
+                span.update_context("http", {"request": {"id": request_id}})
             return result

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -106,6 +106,9 @@ class BotocoreInstrumentation(AbstractInstrumentedModule):
             result = wrapped(*args, **kwargs)
             if service in post_span_modifiers:
                 post_span_modifiers[service](span, args, kwargs, result)
+            request_id = result.get("ResponseMetadata", {}).get("RequestId")
+            if request_id:
+                span.update_context("http", {"request": {"id": request_id}})
             return result
 
 

--- a/tests/instrumentation/botocore_tests.py
+++ b/tests/instrumentation/botocore_tests.py
@@ -97,6 +97,7 @@ def test_botocore_instrumentation(instrument, elasticapm_client):
     assert span["type"] == "aws"
     assert span["subtype"] == "ec2"
     assert span["action"] == "DescribeInstances"
+    assert span["context"]["http"]["request"]["id"]
 
 
 def test_s3(instrument, elasticapm_client):
@@ -117,6 +118,7 @@ def test_s3(instrument, elasticapm_client):
         assert span["context"]["destination"]["service"]["name"] == "s3"
         assert span["context"]["destination"]["service"]["resource"] == "xyz"
         assert span["context"]["destination"]["service"]["type"] == "storage"
+        assert span["context"]["http"]["request"]["id"]
     assert spans[0]["name"] == "S3 CreateBucket xyz"
     assert spans[0]["action"] == "CreateBucket"
     assert spans[1]["name"] == "S3 PutObject xyz"
@@ -175,6 +177,7 @@ def test_dynamodb(instrument, elasticapm_client, dynamodb):
         assert span["context"]["destination"]["service"]["name"] == "dynamodb"
         assert span["context"]["destination"]["service"]["resource"] == "Movies"
         assert span["context"]["destination"]["service"]["type"] == "db"
+        assert span["context"]["http"]["request"]["id"]
     assert spans[0]["name"] == "DynamoDB PutItem Movies"
     assert spans[1]["name"] == "DynamoDB Query Movies"
     assert spans[1]["context"]["db"]["statement"] == "title = :v1 and #y = :v2"
@@ -200,6 +203,7 @@ def test_sns(instrument, elasticapm_client):
     assert spans[2]["context"]["destination"]["service"]["name"] == "sns"
     assert spans[2]["context"]["destination"]["service"]["resource"] == "sns/mytopic"
     assert spans[2]["context"]["destination"]["service"]["type"] == "messaging"
+    assert spans[2]["context"]["http"]["request"]["id"]
 
 
 def test_sqs_send(instrument, elasticapm_client, sqs_client_and_queue):
@@ -222,6 +226,7 @@ def test_sqs_send(instrument, elasticapm_client, sqs_client_and_queue):
     assert span["context"]["destination"]["service"]["name"] == "sqs"
     assert span["context"]["destination"]["service"]["resource"] == "sqs/myqueue"
     assert span["context"]["destination"]["service"]["type"] == "messaging"
+    assert span["context"]["http"]["request"]["id"]
 
     messages = sqs.receive_message(
         QueueUrl=queue_url,


### PR DESCRIPTION
## What does this pull request do?

Adds `span.context.http.request.id` with the AWS request ID to all botocore requests.

This field is not in the intake yet, but [will be in 8.5.0](https://github.com/elastic/apm-server/issues/7871)

## Related issues

Closes #1524 
