### PR TITLE
Fix empty flushed=True request for forced flushes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ endif::[]
 * Restrict length of Starlette request bodies {pull}1549[#1549]
 * Fix error when using elasticsearch(sniff_on_start=True) {pull}1618[#1618]
 * Improve handling of ignored URLs and capture_body=off for Starlette {pull}1549[#1549]
+* Fix possible error in the transport flush for Lambda functions {pull}1628[#1628]
 
 
 

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -180,7 +180,7 @@ class Transport(ThreadManager):
                     # No data on buffer, but due to manual flush we should send
                     # an empty payload with flushed=true query param, but only
                     # to a local APM server (or lambda extension)
-                    self.send({}, forced_flush=True)
+                    self.send("", forced_flush=True)
                 self._last_flush = timeit.default_timer()
                 buffer = self._init_buffer()
                 buffer_written = False

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -176,11 +176,11 @@ class Transport(ThreadManager):
             if flush:
                 if buffer_written:
                     self._flush(buffer, forced_flush=forced_flush)
-                elif forced_flush and "/localhost:" in self.client.config.server_url:
+                elif forced_flush and any(x in self.client.config.server_url for x in ("/localhost:", "/127.0.0.1:")):
                     # No data on buffer, but due to manual flush we should send
                     # an empty payload with flushed=true query param, but only
                     # to a local APM server (or lambda extension)
-                    self.send(None, flushed=True)
+                    self.send({}, forced_flush=True)
                 self._last_flush = timeit.default_timer()
                 buffer = self._init_buffer()
                 buffer_written = False

--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -264,3 +264,13 @@ def test_flushed_arg(sending_elasticapm_client):
     sending_elasticapm_client._transport.flush()
 
     assert sending_elasticapm_client.httpserver.requests[0].args["flushed"] == "true"
+
+
+@pytest.mark.parametrize("sending_elasticapm_client", [{"api_request_time": "100ms"}], indirect=True)
+def test_flushed_arg_with_wait(sending_elasticapm_client):
+    sending_elasticapm_client.begin_transaction("test_type")
+    sending_elasticapm_client.end_transaction("test")
+    time.sleep(0.2)
+    sending_elasticapm_client._transport.flush()
+
+    assert sending_elasticapm_client.httpserver.requests[1].args["flushed"] == "true"


### PR DESCRIPTION
## What does this pull request do?

It turns out I never actually tested the functionality for sending an empty request with `flushed=True` when an explicit flush is called with no data on the buffer. The function signature was wrong (😅), and we also can't POST with a `None` body, we need an empty dict for the body.

Luckily, it should be rare to hit this issue because we usually flush before we've had a chance to send the contents of the buffer, and that `flushed=True` worked fine.

This fixes those issues and adds a test for this explicit case.

Thanks to @josef-cech-acc for catching this.

## Related issues

Closes #1627 
