### PR TITLE
fixed error: "TypeError: 'str' object does not support item assignment"

### DIFF
--- a/elasticapm/handlers/structlog.py
+++ b/elasticapm/handlers/structlog.py
@@ -31,6 +31,7 @@ from __future__ import absolute_import
 from elasticapm import get_client
 from elasticapm.traces import execution_context
 
+import json
 
 def structlog_processor(logger, method_name, event_dict):
     """
@@ -51,6 +52,7 @@ def structlog_processor(logger, method_name, event_dict):
     :return:
         `event_dict`, with three new entries.
     """
+    event_dict = json.loads(event_dict) if isinstance(event_dict, str) else event_dict
     transaction = execution_context.get_transaction()
     if transaction:
         event_dict["transaction.id"] = transaction.id
@@ -62,4 +64,5 @@ def structlog_processor(logger, method_name, event_dict):
     span = execution_context.get_span()
     if span and span.id:
         event_dict["span.id"] = span.id
+    event_dict = json.dumps(event_dict)
     return event_dict


### PR DESCRIPTION
## What does this pull request do?


File "site-packages\elasticapm\handlers\structlog.py", line 63, in structlog_processor
    event_dict["service.name"] = client.config.service_name
TypeError: 'str' object does not support item assignment

I was getting above error. When i looked into code and debug I found event_dict is expected to be as dictionary object but it was 
getting passed as str object and so i put check over there and incase of str i converted to dictionary.
after the all the value assignments i converted it back to str as it is expected to return str object

below is sample configuration to generate this issue
structlog.configure(
    processors=[
        structlog.processors.add_log_level,
        structlog.processors.StackInfoRenderer(),
        structlog.dev.set_exc_info,
        structlog.processors.ExceptionPrettyPrinter(),
        structlog.processors.UnicodeDecoder(),
        structlog.processors.TimeStamper(fmt="iso"),
        structlog.processors.JSONRenderer(),
        structlog_processor
    ],
    wrapper_class=structlog.stdlib.BoundLogger,
    context_class=dict,
    logger_factory=structlog.stdlib.LoggerFactory(),
    cache_logger_on_first_use=True,
)


## Related issues
I have not found issue reported by other. I faced this problem so fixed it.
Closes #ISSUE
