### PR TITLE
Disable checks when elastic_apm is disabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+
+[float]
+===== Bug fixes
+
+* Fix Django's `manage.py check` when agent is disabled {pull}1632[#1632]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -181,6 +181,9 @@ class Command(BaseCommand):
         passed = True
         client = DjangoClient(metrics_interval="0ms")
 
+        if not client.config.enabled:
+            return True
+
         def is_set(x):
             return x and x != "None"
 

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1215,6 +1215,14 @@ def test_subcommand_not_known(argv_mock):
     assert 'No such command "foo"' in output
 
 
+def test_settings_not_enabled_no_checks():
+    stdout = io.StringIO()
+    with override_settings(ELASTIC_APM={"ENABLED": False}):
+        call_command("elasticapm", "check", stdout=stdout)
+    output = stdout.getvalue()
+    assert "" == output
+
+
 def test_settings_missing_secret_token_no_https():
     stdout = io.StringIO()
     with override_settings(ELASTIC_APM={"SERVER_URL": "http://foo"}):


### PR DESCRIPTION
Avoids warning about an incorrect SERVER_URL when the tool is not in use.