### PR TITLE
properly set transaction outcome

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ endif::[]
 
 * Fix Django's `manage.py check` when agent is disabled {pull}1632[#1632]
 * Fix an issue with long body truncation for Starlette {pull}1635[#1635]
+* Fix an issue with transaction outcomes in Flask for uncaught exceptions {pull}1637[#1637]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -111,6 +111,7 @@ class ElasticAPM(object):
         #
         # Unfortunately, that also means that we can't capture any response data,
         # as the response isn't ready at this point in time.
+        elasticapm.set_transaction_outcome(outcome=constants.OUTCOME.FAILURE, override=False)
         self.client.end_transaction(result="HTTP 5xx")
 
     def init_app(self, app, **defaults):


### PR DESCRIPTION
## What does this pull request do?
properly set transaction outcome for flask instrumentation when an exception occurs

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

Closes [#1636](https://github.com/elastic/apm-agent-python/issues/1636)
