### PR TITLE
Backend dependency granularity for nosql databases

### DIFF
--- a/elasticapm/instrumentation/packages/pymongo.py
+++ b/elasticapm/instrumentation/packages/pymongo.py
@@ -83,13 +83,16 @@ class PyMongoInstrumentation(AbstractInstrumentedModule):
             "address": host,
             "port": port,
         }
+        context = {"destination": destination_info}
+        if instance.database.name:
+            context["db"] = {"instance": instance.database.name}
         with capture_span(
             signature,
             span_type="db",
             span_subtype="mongodb",
             span_action="query",
             leaf=True,
-            extra={"destination": destination_info},
+            extra=context,
         ):
             return wrapped(*args, **kwargs)
 
@@ -121,6 +124,9 @@ class PyMongoCursorInstrumentation(AbstractInstrumentedModule):
     def call(self, module, method, wrapped, instance, args, kwargs):
         collection = instance.collection
         signature = ".".join([collection.full_name, "cursor.refresh"])
+        context = {"destination": {}}
+        if instance.collection.database.name:
+            context["db"] = {"instance": instance.collection.database.name}
         with capture_span(
             signature,
             span_type="db",

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -41,6 +41,8 @@ services:
 
   mongodb36:
     image: mongo:3.6
+    ports:
+      - "27017:27017"
     volumes:
       - pymongodata36:/data/db
 

--- a/tests/instrumentation/pymongo_tests.py
+++ b/tests/instrumentation/pymongo_tests.py
@@ -121,8 +121,10 @@ def test_collection_count_documents(instrument, elasticapm_client, mongo_databas
     assert span["context"]["destination"] == {
         "address": os.environ.get("MONGODB_HOST", "localhost"),
         "port": int(os.environ.get("MONGODB_PORT", 27017)),
-        "service": {"name": "", "resource": "mongodb", "type": ""},
+        "service": {"name": "", "resource": "mongodb/elasticapm_test", "type": ""},
     }
+    assert span["context"]["service"]["target"]["type"] == "mongodb"
+    assert span["context"]["service"]["target"]["name"] == "elasticapm_test"
 
 
 @pytest.mark.skipif(pymongo.version_tuple < (3, 7), reason="New in 3.7")
@@ -143,8 +145,10 @@ def test_collection_estimated_document_count(instrument, elasticapm_client, mong
     assert span["context"]["destination"] == {
         "address": os.environ.get("MONGODB_HOST", "localhost"),
         "port": int(os.environ.get("MONGODB_PORT", 27017)),
-        "service": {"name": "", "resource": "mongodb", "type": ""},
+        "service": {"name": "", "resource": "mongodb/elasticapm_test", "type": ""},
     }
+    assert span["context"]["service"]["target"]["type"] == "mongodb"
+    assert span["context"]["service"]["target"]["name"] == "elasticapm_test"
 
 
 @pytest.mark.integrationtest
@@ -254,7 +258,7 @@ def test_collection_find(instrument, elasticapm_client, mongo_database):
         assert span["context"]["destination"] == {
             "address": os.environ.get("MONGODB_HOST", "localhost"),
             "port": int(os.environ.get("MONGODB_PORT", 27017)),
-            "service": {"name": "", "resource": "mongodb", "type": ""},
+            "service": {"name": "", "resource/elasticapm_test": "mongodb", "type": ""},
         }
 
 
@@ -276,7 +280,7 @@ def test_collection_find_one(instrument, elasticapm_client, mongo_database):
     assert span["context"]["destination"] == {
         "address": os.environ.get("MONGODB_HOST", "localhost"),
         "port": int(os.environ.get("MONGODB_PORT", 27017)),
-        "service": {"name": "", "resource": "mongodb", "type": ""},
+        "service": {"name": "", "resource": "mongodb/elasticapm_test", "type": ""},
     }
 
 


### PR DESCRIPTION
## What does this pull request do?
Implement service target fields for

- [x] Cassandra
- [x] MongoDB/pymongo
- [ ] Elasticsearch

## Related issues

Closes #1586
