### PR TITLE
No issue: Fix APP_NAME references

### DIFF
--- a/docs/sanitizing-data.asciidoc
+++ b/docs/sanitizing-data.asciidoc
@@ -36,7 +36,7 @@ To use this processor, update your `ELASTIC_APM` settings like this:
 [source,python]
 ----
 ELASTIC_APM = {
-    'APP_NAME': '<APP-NAME>',
+    'SERVICE_NAME': '<SERVICE-NAME>',
     'SECRET_TOKEN': '<SECRET-TOKEN>',
     'PROCESSORS': (
         'path.to.my_processor',
@@ -56,7 +56,7 @@ The default set of processors sanitize fields based on a set of defaults defined
 [source,python]
 ----
 ELASTIC_APM = {
-    'APP_NAME': '<APP-NAME>',
+    'SERVICE_NAME': '<SERVICE-NAME>',
     'SECRET_TOKEN': '<SECRET-TOKEN>',
     'SANITIZE_FIELD_NAMES': (
         "password",

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -55,12 +55,12 @@ class ElasticAPM(object):
     """
     Flask application for Elastic APM.
 
-    Look up configuration from ``os.environ.get('ELASTIC_APM_APP_NAME')`` and
+    Look up configuration from ``os.environ.get('ELASTIC_APM_SERVICE_NAME')`` and
     ``os.environ.get('ELASTIC_APM_SECRET_TOKEN')``::
 
     >>> elasticapm = ElasticAPM(app)
 
-    Pass an arbitrary APP_NAME and SECRET_TOKEN::
+    Pass an arbitrary SERVICE_NAME and SECRET_TOKEN::
 
     >>> elasticapm = ElasticAPM(app, service_name='myapp', secret_token='asdasdasd')
 

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -85,7 +85,7 @@ class ElasticAPM:
 
     >>> app.add_middleware(ElasticAPM, client=apm)
 
-    Pass an arbitrary APP_NAME and SECRET_TOKEN::
+    Pass an arbitrary SERVICE_NAME and SECRET_TOKEN::
 
     >>> elasticapm = ElasticAPM(app, service_name='myapp', secret_token='asdasdasd')
 


### PR DESCRIPTION
## What does this pull request do?
In this PR some references to APP_NAME env/config variable are taken out from the documentation. According to [the code](https://github.com/elastic/apm-agent-python/blob/77c2c0d01a86a4904b669172424c926f9245beec/elasticapm/conf/__init__.py#L542) and the [elastic docs](https://www.elastic.co/guide/en/apm/agent/python/current/configuration.html#config-service-name).
This should be some leftovers of the [v2.0.0 release](https://github.com/elastic/apm-agent-python/blob/main/CHANGELOG.asciidoc#v200---20180206)
