### PR TITLE
only use content-type and content-encoding headers for POSTing events

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -140,8 +140,6 @@ class Client(object):
                 logging.setLogRecordFactory(new_factory)
 
         headers = {
-            "Content-Type": "application/x-ndjson",
-            "Content-Encoding": "gzip",
             "User-Agent": self.get_user_agent(),
         }
 

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -75,6 +75,12 @@ class Transport(HTTPTransportBase):
 
         headers = self._headers.copy() if self._headers else {}
         headers.update(self.auth_headers)
+        headers.update(
+            {
+                b"Content-Type": b"application/x-ndjson",
+                b"Content-Encoding": b"gzip",
+            }
+        )
 
         url = self._url
         if forced_flush:
@@ -146,7 +152,6 @@ class Transport(HTTPTransportBase):
         data = json_encoder.dumps(keys).encode("utf-8")
         headers = self._headers.copy()
         headers[b"Content-Type"] = "application/json"
-        headers.pop(b"Content-Encoding", None)  # remove gzip content-encoding header
         headers.update(self.auth_headers)
         max_age = 300
         if current_version:
@@ -190,7 +195,7 @@ class Transport(HTTPTransportBase):
     def fetch_server_info(self):
         headers = self._headers.copy() if self._headers else {}
         headers.update(self.auth_headers)
-        headers["accept"] = "text/plain"
+        headers[b"accept"] = b"text/plain"
         try:
             response = self.http.urlopen("GET", self._server_info_url, headers=headers, timeout=self._timeout)
             body = response.data

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -50,6 +50,7 @@ except ImportError:
 
 @pytest.mark.flaky(reruns=3)  # test is flaky on Windows
 def test_send(waiting_httpserver, elasticapm_client):
+    elasticapm_client.server_version = (8, 0)  # avoid making server_info request
     waiting_httpserver.serve_content(code=202, content="", headers={"Location": "http://example.com/foo"})
     transport = Transport(
         waiting_httpserver.url, client=elasticapm_client, headers=elasticapm_client._transport._headers


### PR DESCRIPTION
## What does this pull request do?

As @trentm reported in #1634, our agent sends headers with the version sniffing request that don't really make sense. We previously fixed a similar issue for the `get-config` request (#783). To avoid similar issues in the future, these two headers are now added explicitly when POSTing new events, instead of having them as default and needing to remember to remove them for other calls.

## Related issues

closes #1634
