### PR TITLE
fix starlette 0.21 tests

### DIFF
--- a/.ci/.jenkins_framework.yml
+++ b/.ci/.jenkins_framework.yml
@@ -43,7 +43,7 @@ FRAMEWORK:
   - aiopg-newest
   - asyncpg-newest
   - tornado-newest
-  # - starlette-newest # disabled for now, see https://github.com/elastic/apm-agent-python/issues/1172
+  - starlette-newest
   - pymemcache-newest
   - graphene-2
   - httpx-newest

--- a/tests/requirements/reqs-starlette-newest.txt
+++ b/tests/requirements/reqs-starlette-newest.txt
@@ -1,5 +1,5 @@
 starlette>=0.15
 aiofiles
-requests
+httpx
 flask
 -r reqs-base.txt


### PR DESCRIPTION
Starlette 0.21 moved to httpx as base for the TestClient
