### PR TITLE
build: use k8s for testing all the supported python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tests/python-agent-junit.xml
 .pytest_cache/
 .python-version
 .env
+.k8s/bin

--- a/.k8s/Makefile
+++ b/.k8s/Makefile
@@ -1,4 +1,62 @@
-BUILD_DIR?=build
-SHELL := /bin/bash
+SHELL = /bin/bash
+ARCH = $(shell uname)
+ARCH_L = $(shell uname|tr '[:upper:]' '[:lower:]')
+BIN_DIR ?= $(CURDIR)/bin
+KUBECTL_VERSION ?= $(shell curl -sSf https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTL ?= $(BIN_DIR)/kubectl
+PATH := $(BIN_DIR):$(PATH)
+MAKEFLAGS += --silent --no-print-directory
+.SHELLFLAGS = -ec
+.SILENT:
 
-.PHONY: test
+# TODO: allow dynamism so the cluster is defined in Vault maybe?
+K8S_CLUSTER ?= observability-ci-test-k8s
+K8S_NAMESPACE ?= default
+# TODO: allow dynamism so the cluster is defined in Vault maybe?
+# TODO: GCLOUD specific, maybe it wont't be needed if we are cloud agnostic?
+GCLOUD_K8S_CLUSTER_REGION ?= us-central1-c
+# TODO: allow dynamism so the cluster is defined in Vault maybe?
+# TODO: GCLOUD specific, maybe it wont't be needed if we are cloud agnostic?
+GCLOUD_K8S_CLUSTER_PROJECT ?= elastic-observability
+
+################################
+## Helper function
+################################
+.PHONY: help
+help:
+	@echo "Environment variables:"
+	@echo ""
+	@echo 'VAULT_TOKEN=$$(cat $${HOME}/.vault-token) this token is needed for local operations'
+	@echo ""
+	@echo "Main targets:"
+	@echo ""
+	@grep '^## @help' Makefile|cut -d ":" -f 2-3|( (sort|column -s ":" -t) || (sort|tr ":" "\t") || (tr ":" "\t"))
+
+################################
+## Tools helper functions
+################################
+bin:
+	mkdir -p "$(BIN_DIR)"
+
+## @help:bin/kubectl:Install kubectl CLI in the selected binary folder.
+bin/kubectl: bin
+	curl -sSLo "$(BIN_DIR)/kubectl" "https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/$(ARCH_L)/amd64/kubectl"
+	chmod +x "$(BIN_DIR)/kubectl"
+
+################################
+## K8s specific helper functions
+################################
+
+## @help:k8s-login:Get the credentials of the k8s cluster.
+.PHONY: k8s-login
+k8s-login: bin/kubectl
+	@gcloud container clusters get-credentials \
+		--zone $(GCLOUD_K8S_CLUSTER_REGION) \
+		--project $(GCLOUD_K8S_CLUSTER_PROJECT) \
+		$(K8S_CLUSTER)
+	$(KUBECTL) config set-context $$(kubectl config current-context) --namespace $(K8S_NAMESPACE)
+
+# @help:deploy-pods:Deploy the pods in the K8s cluster
+.PHONY: deploy-pods
+deploy-pods: k8s-login
+	$(KUBECTL) apply -f PythonPod.yml

--- a/.k8s/Makefile
+++ b/.k8s/Makefile
@@ -1,0 +1,4 @@
+BUILD_DIR?=build
+SHELL := /bin/bash
+
+.PHONY: test

--- a/.k8s/Makefile
+++ b/.k8s/Makefile
@@ -60,3 +60,9 @@ k8s-login: bin/kubectl
 .PHONY: deploy-pods
 deploy-pods: k8s-login
 	$(KUBECTL) apply -f PythonPod.yml
+
+# @help:get-pods:Get the deployed pods in the K8s cluster
+.PHONY: deploy-pods
+get-pods: k8s-login
+	$(KUBECTL) get pods
+	$(KUBECTL) describe pod python-versions-pod

--- a/.k8s/PythonPod.yml
+++ b/.k8s/PythonPod.yml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: python-3-6
+    image: python:3.6
+    command:
+    - sleep
+    args:
+    - infinity
+  - name: python-3-7
+    image: python:3.7
+    command:
+    - sleep
+    args:
+    - infinity
+  - name: python-3-8
+    image: python:3.8
+    command:
+    - sleep
+    args:
+    - infinity
+  - name: python-3-9
+    image: python:3.9
+    command:
+    - sleep
+    args:
+    - infinity
+  - name: python-3-10
+    image: python:3.10
+    command:
+    - sleep
+    args:
+    - infinity
+  - name: pypy-3
+    image: pypy:3.7-buster
+    command:
+    - sleep
+    args:
+    - infinity
+## TODO: Faster builds with some cached artifacts.
+##       mount a volume with the cached m2 folder in /var/lib/jenkins/.m2/repository
+##       for instance https://github.com/jenkinsci/kubernetes-plugin/blob/master/examples/maven-with-cache.groovy
+##       Maybe the infra folks already provide this caching!?

--- a/.k8s/PythonPod.yml
+++ b/.k8s/PythonPod.yml
@@ -1,5 +1,9 @@
 apiVersion: v1
 kind: Pod
+metadata:
+  name: python-versions-pod
+  labels:
+    repo: apm-agent-python
 spec:
   containers:
   - name: python-3-6
@@ -32,13 +36,3 @@ spec:
     - sleep
     args:
     - infinity
-  - name: pypy-3
-    image: pypy:3.7-buster
-    command:
-    - sleep
-    args:
-    - infinity
-## TODO: Faster builds with some cached artifacts.
-##       mount a volume with the cached m2 folder in /var/lib/jenkins/.m2/repository
-##       for instance https://github.com/jenkinsci/kubernetes-plugin/blob/master/examples/maven-with-cache.groovy
-##       Maybe the infra folks already provide this caching!?

--- a/.k8s/README.md
+++ b/.k8s/README.md
@@ -5,12 +5,30 @@ testing the APM Agent Python with
 
 ## Pre-requisites
 
+TBC
+
 Access to a Kubernetes cluster, then configure the environment variables
 
 ```bash
 
 ```
 
+## Use cases
 
-##
+### `unit-test` in all the defined pods
+
+```bash
+$ VAULT_TOKEN=$(cat ${HOME}/.vault-token) \
+    make -C .k8s unit-test
+$ VAULT_TOKEN=$(cat ${HOME}/.vault-token) \
+    make -C .k8s report-unit-test-results
+```
+
+
+### Know what you can do with the existing make
+
+```bash
+$ make -C .k8s help
+
+
 

--- a/.k8s/README.md
+++ b/.k8s/README.md
@@ -1,0 +1,16 @@
+# K8s
+
+This folder contains all the definitions regarding the different python versions used for
+testing the APM Agent Python with
+
+## Pre-requisites
+
+Access to a Kubernetes cluster, then configure the environment variables
+
+```bash
+
+```
+
+
+##
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,9 +39,9 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'Run_As_Main_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on main branch.')
-    booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks.')
-    booleanParam(name: 'tests_ci', defaultValue: true, description: 'Enable tests.')
-    booleanParam(name: 'package_ci', defaultValue: true, description: 'Enable building packages.')
+    booleanParam(name: 'bench_ci', defaultValue: false, description: 'Enable benchmarks.')
+    booleanParam(name: 'tests_ci', defaultValue: false, description: 'Enable tests.')
+    booleanParam(name: 'package_ci', defaultValue: false, description: 'Enable building packages.')
   }
   stages {
     stage('Initializing'){


### PR DESCRIPTION
> ⚠️ In Progress, so it will be changing based on the outcome while I'm iterating on this.

## What does this pull request do?

Enhance the build system to run the `unit-test` in parallel for all the supported Python versions using Kubernetes.

## Actions

- [ ] Simplify the build process so it's easy to run locally and in any given K8s cluster.
- [ ] Support to copy the current workspace to the pods so it can run the given command.
- [ ] Update docs.
- [ ] Ask for testing this PR.