### PR TITLE
bump python versions and use docker slim versions

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     curl \
     default-mysql-server \
     gnupg2 \
+    libmariadb-dev \
     libpq-dev \
     make \
     netcat \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     build-essential \
     ca-certificates \
     curl \
+    default-mysql-server \
     gnupg2 \
-    libmysqlclient-dev \
     libpq-dev \
     make \
     netcat \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     build-essential \
     ca-certificates \
     curl \
-    default-mysql-server \
     gnupg2 \
     libmariadb-dev \
     libpq-dev \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     unixodbc-dev \
     freetds-dev \
     libmemcached-dev \
-    make &&\
+    make \
+    gnupg2 && \
     rm -rf /var/lib/apt/lists/*
 
 # connection to ha.pool.sks-keyservers.net fails sometimes, so let's retry with couple different servers

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     ca-certificates \
     curl \
     gnupg2 \
+    libmysqlclient-dev \
     libpq-dev \
     make \
     netcat \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,16 +2,17 @@ ARG PYTHON_IMAGE
 FROM ${PYTHON_IMAGE}-slim
 
 RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
+    build-essential \
     ca-certificates \
     curl \
+    gnupg2 \
+    make \
     netcat \
     odbc-postgresql \
     unixodbc-dev \
     freetds-dev \
     libmemcached-dev \
-    make \
-    gnupg2 && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 # connection to ha.pool.sks-keyservers.net fails sometimes, so let's retry with couple different servers
 RUN for server in $(shuf -e ha.pool.sks-keyservers.net \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_IMAGE
-FROM ${PYTHON_IMAGE}
+FROM ${PYTHON_IMAGE}-slim
 
 RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     ca-certificates \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     ca-certificates \
     curl \
     gnupg2 \
+    libpq-dev \
     make \
     netcat \
     odbc-postgresql \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     odbc-postgresql \
     unixodbc-dev \
     freetds-dev \
-    libmemcached-dev &&\
+    libmemcached-dev \
+    make &&\
     rm -rf /var/lib/apt/lists/*
 
 # connection to ha.pool.sks-keyservers.net fails sometimes, so let's retry with couple different servers

--- a/tests/scripts/docker/black.sh
+++ b/tests/scripts/docker/black.sh
@@ -7,7 +7,7 @@ docker_pip_cache="/tmp/cache/pip"
 
 cd tests
 
-docker build --build-arg PYTHON_IMAGE=python:3.6 -t python-linters .
+docker build --build-arg PYTHON_IMAGE=python:3.8 -t python-linters .
 docker run \
   -e LOCAL_USER_ID=$UID \
   -e PIP_CACHE=${docker_pip_cache} \

--- a/tests/scripts/docker/flake8.sh
+++ b/tests/scripts/docker/flake8.sh
@@ -7,7 +7,7 @@ docker_pip_cache="/tmp/cache/pip"
 
 cd tests
 
-docker build --build-arg PYTHON_IMAGE=python:3.6 -t lint_flake8 .
+docker build --build-arg PYTHON_IMAGE=python:3.8 -t lint_flake8 .
 docker run \
   -e LOCAL_USER_ID=$UID \
   -e PIP_CACHE=${docker_pip_cache} \

--- a/tests/scripts/docker/isort.sh
+++ b/tests/scripts/docker/isort.sh
@@ -7,7 +7,7 @@ docker_pip_cache="/tmp/cache/pip"
 
 cd tests
 
-docker build --build-arg PYTHON_IMAGE=python:3.6 -t python-linters .
+docker build --build-arg PYTHON_IMAGE=python:3.8 -t python-linters .
 docker run \
   -e LOCAL_USER_ID=$UID \
   -e PIP_CACHE=${docker_pip_cache} \


### PR DESCRIPTION
### What does this pull request do?

Use smaller docker images (slim) and bump the version to use the supported python version for some of the scripts

### Why

<img width="1288" alt="image" src="https://user-images.githubusercontent.com/2871786/194102494-33abe8b4-9305-4820-baf9-02a147882d2d.png">

vs 

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/2871786/194103043-ba4a061e-ae2f-4b8c-a6a5-d602039b5622.png">


Then the docker image with all the tooling is about 2x smaller:

> REPOSITORY                                          TAG                                                                IMAGE ID       CREATED          SIZE
apm-agent-python                                    python-3.6                                                         50ecd8523761   51 seconds ago   462MB

vs

> REPOSITORY                                          TAG                                                                IMAGE ID       CREATED          SIZE
apm-agent-python                                    python-3.6                                                         8e23ab62a462   16 seconds ago   961MB


### Implementation details

There were some missing packages required to run some of the tests, such as:

* `libmariadb-dev` to fix `mariadb_config: not found` when using the framework `mysqlclient-newest`
* `libpq-dev` to fix `pg_config executable not found` when using the framework `psycopg2-newest`
* `build-essential` to fix `gcc executable not found` when using the framework `twisted`
* `make` to fix the run of all the tests.
* `gpg` to fix the docker image generation.

