### PR TITLE
EOL table has been moved to central EOL Policy page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ If you have commit access, the process is as follows:
 
 1. Update the version in `elasticapm/version.py` according to the scale of the change. (major, minor or patch)
 1. Update `CHANGELOG.asciidoc`. Rename the `Unreleased` section to the correct version (`vX.X.X`), and nest under the appropriate sub-heading, e.g., `Python Agent version 5.x`.
-1. For Majors: Add a new row to the EOL table in `docs/upgrading.asciidoc`. The EOL date is the release date plus 18 months.
+1. For Majors: [Create an issue](https://github.com/elastic/website-requests/issues/new) to request an update of the [EOL table](https://www.elastic.co/support/eol).
 1. For Majors: Add the new major version to `conf.yaml` in the [elastic/docs](https://github.com/elastic/docs) repo.
 1. Commit changes with message `update CHANGELOG and bump version to X.Y.Z` where `X.Y.Z` is the version in `elasticapm/version.py`
 1. Tag the commit with `git tag -a vX.Y.Z`, for example `git tag -a v1.2.3`.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -17,17 +17,6 @@ Our https://www.elastic.co/support/eol[End of life policy] defines how long a gi
 as well as how long a release is considered still in active development or maintenance.
 The table below is a simplified description of this policy.
 
-[options="header"]
-|====
-|Agent version |EOL Date |Maintained until
-|1.x |2019-06-11 |2.0
-|2.x |2019-08-06 |3.0
-|3.x |2020-01-20 |4.0
-|4.x |2020-05-14 |5.0
-|5.x |2021-02-05 |6.0
-|6.x |2022-08-01 |7.0
-|====
-
 [[upgrading-6.x]]
 === Upgrading to version 6 of the agent
 

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -15,7 +15,6 @@ We love all our products, but sometimes we must say goodbye to a release so that
 forward on future development and innovation.
 Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
 as well as how long a release is considered still in active development or maintenance.
-The table below is a simplified description of this policy.
 
 [[upgrading-6.x]]
 === Upgrading to version 6 of the agent


### PR DESCRIPTION
APM Agents are listed now in the central EOL policy table: https://www.elastic.co/support/eol
