### PR TITLE
Correct links to Lambda extension docs

### DIFF
--- a/docs/lambda/configure-lambda.asciidoc
+++ b/docs/lambda/configure-lambda.asciidoc
@@ -11,6 +11,7 @@ To configure APM through the AWS Management Console:
 ----
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
+ELASTIC_APM_SEND_STRATEGY     = background                # recommended for steady load scenarios
 ----
 
 --
@@ -47,6 +48,7 @@ Resources:
           Variables:
             ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
             ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
+            ELASTIC_APM_SEND_STRATEGY: background
 ...
 ----
 
@@ -65,6 +67,7 @@ functions:
     environment:
       ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
       ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
+      ELASTIC_APM_SEND_STRATEGY: background
 ...
 ----
 
@@ -82,6 +85,7 @@ resource "aws_lambda_function" "your_lambda_function" {
     variables = {
       ELASTIC_APM_LAMBDA_APM_SERVER = "<YOUR-APM-SERVER-URL>"
       ELASTIC_APM_SECRET_TOKEN      = "<YOUR-APM-SECRET-TOKEN>"
+      ELASTIC_APM_SEND_STRATEGY     = "background"
     }
   }
 }
@@ -98,6 +102,7 @@ You can use one of the other options (through AWS Web Console, AWS CLI, etc.) to
 ----
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
+ELASTIC_APM_SEND_STRATEGY     = background
 ----
 
 // end::container-extension-only[]

--- a/docs/lambda/configure-lambda.asciidoc
+++ b/docs/lambda/configure-lambda.asciidoc
@@ -11,7 +11,7 @@ To configure APM through the AWS Management Console:
 ----
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
-ELASTIC_APM_SEND_STRATEGY     = background                # recommended for steady load scenarios
+ELASTIC_APM_SEND_STRATEGY     = background                <1>
 ----
 
 --
@@ -27,7 +27,7 @@ To configure APM through the AWS command line interface execute the following co
 [source,bash]
 ----
 aws lambda update-function-configuration --function-name yourLambdaFunctionName \
-    --environment "Variables={ELASTIC_APM_LAMBDA_APM_SERVER=<YOUR-APM-SERVER-URL>,ELASTIC_APM_SECRET_TOKEN=<YOUR-APM-SECRET-TOKEN>}"
+    --environment "Variables={ELASTIC_APM_LAMBDA_APM_SERVER=<YOUR-APM-SERVER-URL>,ELASTIC_APM_SECRET_TOKEN=<YOUR-APM-SECRET-TOKEN>,ELASTIC_APM_SEND_STRATEGY=background}" <1>
 ----
 
 // end::cli-extension-only[]
@@ -48,7 +48,7 @@ Resources:
           Variables:
             ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
             ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
-            ELASTIC_APM_SEND_STRATEGY: background
+            ELASTIC_APM_SEND_STRATEGY: background <1>
 ...
 ----
 
@@ -67,7 +67,7 @@ functions:
     environment:
       ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
       ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
-      ELASTIC_APM_SEND_STRATEGY: background
+      ELASTIC_APM_SEND_STRATEGY: background <1>
 ...
 ----
 
@@ -85,7 +85,7 @@ resource "aws_lambda_function" "your_lambda_function" {
     variables = {
       ELASTIC_APM_LAMBDA_APM_SERVER = "<YOUR-APM-SERVER-URL>"
       ELASTIC_APM_SECRET_TOKEN      = "<YOUR-APM-SECRET-TOKEN>"
-      ELASTIC_APM_SEND_STRATEGY     = "background"
+      ELASTIC_APM_SEND_STRATEGY     = "background" <1>
     }
   }
 }
@@ -102,7 +102,7 @@ You can use one of the other options (through AWS Web Console, AWS CLI, etc.) to
 ----
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
-ELASTIC_APM_SEND_STRATEGY     = background
+ELASTIC_APM_SEND_STRATEGY     = background <1>
 ----
 
 // end::container-extension-only[]

--- a/docs/serverless.asciidoc
+++ b/docs/serverless.asciidoc
@@ -57,6 +57,7 @@ If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the
 For production environments, we recommend {apm-lambda-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
 
 include::./lambda/configure-lambda-widget.asciidoc[]
+<1> The {apm-lambda-ref}/aws-lambda-config-options.html#_elastic_apm_send_strategy[`ELASTIC_APM_SEND_STRATEGY`] defines when APM data is sent to your Elastic APM backend. To reduce the execution time of your lambda functions, we recommend to use the `background` strategy in production environments with steady load scenarios.
 
 You can optionally <<configuration,fine-tune the Python agent>> or the {apm-lambda-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 

--- a/docs/serverless.asciidoc
+++ b/docs/serverless.asciidoc
@@ -16,7 +16,7 @@ You need an APM Server to send APM data to. Follow the {apm-guide-ref}/apm-quick
 
 include::{apm-aws-lambda-root}/docs/lambda-selector/lambda-attributes-selector.asciidoc[]
 
-Add the {apm-guide-ref}/aws-lambda-arch.html[{apm-lambda-ext}] as an https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layer] to your AWS Lambda function.
+Add the {apm-lambda-ref}/aws-lambda-arch.html[{apm-lambda-ext}] as an https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layer] to your AWS Lambda function.
 
 include::{apm-aws-lambda-root}/docs/lambda-selector/extension-arn-replacement.asciidoc[]
 include::{apm-aws-lambda-root}/docs/add-extension/add-extension-layer-widget.asciidoc[]
@@ -54,11 +54,11 @@ The {apm-lambda-ext} and the APM Python agent are configured through environment
 For the minimal configuration, you will need the _APM Server URL_ to set the destination for APM data and an _{apm-guide-ref}/secret-token.html[APM Secret Token]_.
 If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the APM secret token, use the `ELASTIC_APM_API_KEY` environment variable instead of `ELASTIC_APM_SECRET_TOKEN` in the following configuration.
 
-For production environments, we recommend {apm-guide-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
+For production environments, we recommend {apm-lambda-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
 
 include::./lambda/configure-lambda-widget.asciidoc[]
 
-You can optionally <<configuration,fine-tune the Python agent>> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
+You can optionally <<configuration,fine-tune the Python agent>> or the {apm-lambda-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 
 That's it; Once the agent is installed and working, spans will be captured for
 <<supported-technologies,supported technologies>>. You can also use


### PR DESCRIPTION
- AWS Lambda extension docs moved from the APM Guide to their own docs. Fixing links.
- added `background` as recommended send strategy in the docs
