### PR TITLE
Remove twine upload for (now-removed) wheels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -374,7 +374,6 @@ def releasePackages(){
     python setup.py sdist
     echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
     python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
-    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} wheelhouse/*.whl
     """)
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -374,6 +374,7 @@ def releasePackages(){
     python setup.py sdist
     echo "Uploading to ${REPO_URL} with user \${TWINE_USER}"
     python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.tar.gz
+    python -m twine upload --username "\${TWINE_USER}" --password "\${TWINE_PASSWORD}" --skip-existing --repository-url \${REPO_URL} dist/*.whl
     """)
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Should fix the upload "failure" as seen here: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/v6.13.0/1/pipeline
