### PR TITLE
Handle track_total_hits=False in elasticsearch instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,18 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Fix elasticsearch for track_total_hits=False {pull}1687[#1687]
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -177,8 +177,8 @@ class ElasticsearchTransportInstrumentation(AbstractInstrumentedModule):
 
     def _get_hits(self, result) -> Optional[int]:
         if getattr(result, "body", None) and "hits" in result.body:  # ES >= 8
-            return result.body["hits"]["total"]["value"]
-        elif isinstance(result, dict) and "hits" in result:
+            return result.body["hits"].get("total", {}).get("value")
+        elif isinstance(result, dict) and "hits" in result and "total" in result["hits"]:
             return (
                 result["hits"]["total"]["value"]
                 if isinstance(result["hits"]["total"], dict)

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -399,6 +399,7 @@ def test_search_body(instrument, elasticapm_client, elasticsearch):
     assert span["context"]["http"]["status_code"] == 200
 
 
+@pytest.mark.skipif(ES_VERSION[0] < 7, reason="track_total_hits unsupported")
 @pytest.mark.integrationtest
 def test_search_track_total_hits_false(instrument, elasticapm_client, elasticsearch):
     elasticsearch.create(

--- a/tests/instrumentation/elasticsearch_tests.py
+++ b/tests/instrumentation/elasticsearch_tests.py
@@ -421,11 +421,6 @@ def test_search_track_total_hits_false(instrument, elasticapm_client, elasticsea
     assert span["subtype"] == "elasticsearch"
     assert span["action"] == "query"
     assert span["context"]["db"]["type"] == "elasticsearch"
-    assert json.loads(span["context"]["db"]["statement"]) == json.loads(
-        '{"sort": ["userid"], "query": {"term": {"user": "kimchy"}}}'
-    ) or json.loads(span["context"]["db"]["statement"]) == json.loads(
-        '{"query": {"term": {"user": "kimchy"}}, "sort": ["userid"]}'
-    )
     assert "rows_affected" not in span["context"]["db"]
     assert span["context"]["http"]["status_code"] == 200
 


### PR DESCRIPTION
## What does this pull request do?

In case `track_total_hits=False`, we weren't properly checking to make sure the total hits were available.

## Related issues

Closes #1686
