### PR TITLE
Use span.update_context to avoid DroppedSpan issues in Elasticsearch instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,18 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Fix error in Elasticsearch instrumentation when spans are dropped {pull}1690[#1690]
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -163,7 +163,7 @@ class ElasticsearchTransportInstrumentation(AbstractInstrumentedModule):
 
             hits = self._get_hits(result_data)
             if hits:
-                span.context["db"]["rows_affected"] = hits
+                span.update_context("db", {"rows_affected": hits})
 
             return result_data
 


### PR DESCRIPTION
## What does this pull request do?

We were setting the context directly instead of using `span.update_context` -- which meant if the span was dropped, it would throw a `KeyError`

## Related issues

Closes #1689 
