### PR TITLE
Lower log level for server version problems

### DIFF
--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -218,11 +218,13 @@ class Transport(HTTPTransportBase):
             logger.debug("Fetched APM Server version %s", version)
             self.client.server_version = version_string_to_tuple(version)
         except (urllib3.exceptions.RequestError, urllib3.exceptions.HTTPError) as e:
-            logger.warning("HTTP error while fetching server information: %s", str(e))
+            logger.debug("HTTP error while fetching server information: %s", str(e))
         except json.JSONDecodeError as e:
-            logger.warning("JSON decoding error while fetching server information: %s", str(e))
+            logger.debug(
+                f"JSON decoding error while fetching server information. Error: {str(e)} Body: {body.decode('utf8')}"
+            )
         except (KeyError, TypeError):
-            logger.warning("No version key found in server response: %s", response.data)
+            logger.debug("No version key found in server response: %s", response.data)
 
     @property
     def cert_fingerprint(self):

--- a/tests/transports/test_urllib3.py
+++ b/tests/transports/test_urllib3.py
@@ -440,7 +440,7 @@ def test_fetch_server_info_no_json(waiting_httpserver, caplog, elasticapm_client
     )
     url = waiting_httpserver.url
     transport = Transport(url + "/" + constants.EVENTS_API_PATH, client=elasticapm_client)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG", logger="elasticapm.transport.http"):
         transport.fetch_server_info()
     assert elasticapm_client.server_version is None
     assert_any_record_contains(caplog.records, "JSON decoding error while fetching server information")
@@ -453,7 +453,7 @@ def test_fetch_server_info_no_version(waiting_httpserver, caplog, elasticapm_cli
     )
     url = waiting_httpserver.url
     transport = Transport(url + "/" + constants.EVENTS_API_PATH, client=elasticapm_client)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG", logger="elasticapm.transport.http"):
         transport.fetch_server_info()
     assert elasticapm_client.server_version is None
     assert_any_record_contains(caplog.records, "No version key found in server response")
@@ -466,7 +466,7 @@ def test_fetch_server_info_flat_string(waiting_httpserver, caplog, elasticapm_cl
     )
     url = waiting_httpserver.url
     transport = Transport(url + "/" + constants.EVENTS_API_PATH, client=elasticapm_client)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("DEBUG", logger="elasticapm.transport.http"):
         transport.fetch_server_info()
     assert elasticapm_client.server_version is None
     assert_any_record_contains(caplog.records, "No version key found in server response")


### PR DESCRIPTION
## What does this pull request do?

Currently our server version checks are fairly low stakes. If there are issues fetching the server version, we don't need to make them `warning` level. This sets them to `debug`.

I also added the request body to the JSON error case, as we ran into one of those recently and it was hard to debug since we didn't have the body in the logs.
