### PR TITLE
update localstack setup to conform to 1.x changes

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       - HOST_TMP_FOLDER=${TMPDIR}
       - START_WEB=0
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   zookeeper:


### PR DESCRIPTION
## What does this pull request do?

Localstack introduced some internal filesystem changes with 1.0 and deprecated the old setup with the newly released 1.3, breaking our test suite. This adapts our docker-compose setup to work with the new system.


