### PR TITLE
Correct nightly jobs

### DIFF
--- a/.ci/nightly.groovy
+++ b/.ci/nightly.groovy
@@ -163,9 +163,14 @@ def runScript(Map params = [:]){
   sh "mkdir ${env.PIP_CACHE}"
   unstash 'source'
   dir("${BASE_DIR}"){
-    retry(2){
-      sleep randomNumber(min:10, max: 30)
-      sh("./tests/scripts/docker/run_tests.sh ${python} ${framework}")
+    withEnv([
+      "LOCAL_USER_ID=${sh(script:'id -u', returnStdout: true).trim()}",
+      "LOCAL_GROUP_ID=${sh(script:'id -g', returnStdout: true).trim()}",
+      "LOCALSTACK_VOLUME_DIR=localstack_data"
+    ]) {
+      retryWithSleep(retries: 2, seconds: 5, backoff: true) {
+        sh("./tests/scripts/docker/run_tests.sh ${python} ${framework}")
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,8 +357,14 @@ def runScript(Map params = [:]){
   unstash 'source'
   filebeat(output: "${label}_${framework}.log", workdir: "${env.WORKSPACE}") {
     dir("${BASE_DIR}"){
-      retryWithSleep(retries: 2, seconds: 5, backoff: true) {
-        sh("./tests/scripts/docker/run_tests.sh ${python} ${framework}")
+      withEnv([
+        "LOCAL_USER_ID=${sh(script:'id -u', returnStdout: true).trim()}",
+        "LOCAL_GROUP_ID=${sh(script:'id -g', returnStdout: true).trim()}",
+        "LOCALSTACK_VOLUME_DIR=localstack_data"
+      ]) {
+        retryWithSleep(retries: 2, seconds: 5, backoff: true) {
+          sh("./tests/scripts/docker/run_tests.sh ${python} ${framework}")
+        }
       }
     }
   }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -218,3 +218,5 @@ volumes:
     driver: local
   kafka_data:
     driver: local
+  localstack_data:
+    driver: local

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 USER_ID=${LOCAL_USER_ID:-1001}
+GROUP_ID=${LOCAL_GROUP_ID:-1001}
 
-echo "Starting with UID: $USER_ID"
-useradd --shell /bin/bash -u $USER_ID --gid 0 --non-unique --comment "" --create-home user
+echo "Starting with UID: ${USER_ID} and GID: ${GROUP_ID}"
+groupadd -g "${GROUP_ID}" user
+useradd --shell /bin/bash -u "${USER_ID}" --gid $GROUP_ID --non-unique --comment "" --create-home user
 export HOME=/home/user
 
-exec /usr/local/bin/gosu user "$@"
+exec /usr/local/bin/gosu $USER_ID:$GROUP_ID "$@"

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -48,7 +48,8 @@ fi
 docker build --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
-  -e LOCAL_USER_ID=$UID \
+  -e LOCAL_USER_ID=$LOCAL_USER_ID \
+  -e LOCAL_GROUP_ID=$LOCAL_GROUP_ID \
   -e PYTHONDONTWRITEBYTECODE=1 -e WEBFRAMEWORK=$2 -e PIP_CACHE=${docker_pip_cache} \
   -e WITH_COVERAGE=true \
   -e CASS_DRIVER_NO_EXTENSIONS=1 \


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

## What does this pull request do?

* Correct nightly jobs.
* Ensure the test container is running with the right user and group id (same as Jenkins).
* Use a local docker volume for localstack in the CI context.

## Motivation & Context

* Nightly jobs weren't running properly for a week.
* The following change https://github.com/elastic/apm-agent-python/pull/1705 introduced a new volume mount in the current working directory.
* In the CI context, this means that we are creating a docker container running with a root user.
* This container created files with the root user permissions.
* As a result, Jenkins isn't able to clean the workspace after each test with a localstack dependency.

<img width="1641" alt="Screenshot 2022-12-05 at 21 49 35" src="https://user-images.githubusercontent.com/10237040/205740086-8cb9ba72-c339-4653-8ca8-3729c9ba5235.png">

## Status

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-python%2Fapm-agent-python-mbp/detail/PR-1707/11/pipeline

