### PR TITLE
when running run_tests.sh locally, make sure to use the user uid/gid

### DIFF
--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -19,6 +19,8 @@ fi
 pip_cache="$HOME/.cache"
 docker_pip_cache="/tmp/cache/pip"
 TEST="${1}/${2}"
+LOCAL_USER_ID=${LOCAL_USER_ID:=$(id -u)}
+LOCAL_GROUP_ID=${LOCAL_GROUP_ID:=$(id -g)}
 
 cd tests
 


### PR DESCRIPTION
## What does this pull request do?

I was starting to get permission errors when running `./tests/scripts/docker/run_tests.sh` locally. This should take care of it.


