### PR TITLE
fix/add excludes for grpc-1.24

### DIFF
--- a/.ci/.jenkins_exclude.yml
+++ b/.ci/.jenkins_exclude.yml
@@ -188,5 +188,13 @@ exclude:
   # grpc
   - PYTHON_VERSION: python-3.6
     FRAMEWORK: grpc-newest
-  - PYTHON_VERSION: python-3.6
+  - PYTHON_VERSION: python-3.7
+    FRAMEWORK: grpc-1.24
+  - PYTHON_VERSION: python-3.8
+    FRAMEWORK: grpc-1.24
+  - PYTHON_VERSION: python-3.9
+    FRAMEWORK: grpc-1.24
+  - PYTHON_VERSION: python-3.10
+    FRAMEWORK: grpc-1.24
+  - PYTHON_VERSION: python-3.11
     FRAMEWORK: grpc-1.24


### PR DESCRIPTION
## What does this pull request do?

Adds excludes for Python 3.7+ and removes the (mistakenly added) exclude for Python 3.6.

I tested some other versions of grpcio that we could use as lower bound, but all but the most recent versions would require excludes for newer Python versions as compilation of the package fails for some reason.

## Related issues

closes #1718
