### PR TITLE
Fix lambda performance issue

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix an async issue with long elasticsearch queries {pull}1725[#1725]
+* Fix a major performance issue with AWS Lambda Support {pull}1727[#1727]
 
 
 [[release-notes-6.x]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,7 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix an async issue with long elasticsearch queries {pull}1725[#1725]
-* Fix a major performance issue with AWS Lambda Support {pull}1727[#1727]
+* Fix a performance issue with AWS Lambda Support {pull}1727[#1727]
 
 
 [[release-notes-6.x]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,7 +42,8 @@ endif::[]
 ===== Bug fixes
 
 * Fix an async issue with long elasticsearch queries {pull}1725[#1725]
-* Fix a performance issue with AWS Lambda Support {pull}1727[#1727]
+* Fix a performance issue with our AWS Lambda integration {pull}1727[#1727]
+* Mark `**kwargs` config usage in our AWS Lambda integration as deprecated {pull}1727[#1727]
 
 
 [[release-notes-6.x]]

--- a/docs/serverless.asciidoc
+++ b/docs/serverless.asciidoc
@@ -41,7 +41,7 @@ import the `capture_serverless` decorator and apply it to your handler:
 ----
 from elasticapm import capture_serverless
 
-@capture_serverless()
+@capture_serverless
 def handler(event, context):
     return {"statusCode": r.status_code, "body": "Success!"}
 ----
@@ -55,7 +55,7 @@ see missing spans. Example:
 ----
 conn = None
 
-@capture_serverless()
+@capture_serverless
 def handler(event, context):
     global conn
     if not conn:

--- a/docs/serverless.asciidoc
+++ b/docs/serverless.asciidoc
@@ -34,6 +34,9 @@ you plan to deploy using pip:
 $ pip install -t <target_dir> elastic-apm
 ----
 
+Note: Please use the latest version of the APM Python agent. A performance
+issue was introduced in version 6.9.0 of the agent, and fixed in version 6.14.0.
+
 Once the library is included as a dependency in your function, you must
 import the `capture_serverless` decorator and apply it to your handler:
 

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -58,6 +58,8 @@ _AWSLambdaContextT = TypeVar("_AWSLambdaContextT")
 
 def capture_serverless(func: Optional[callable] = None, **kwargs) -> callable:
     if not func:
+        # This allows for `@capture_serverless()` in addition to
+        # `@capture_serverless` decorator usage
         return functools.partial(capture_serverless, **kwargs)
 
     if kwargs:

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -180,7 +180,7 @@ def test_response_data():
 def test_capture_serverless_api_gateway(event_api, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -199,10 +199,34 @@ def test_capture_serverless_api_gateway(event_api, context, elasticapm_client):
     assert transaction["context"]["response"]["status_code"] == 200
 
 
+def test_capture_serverless_api_gateway_with_args_deprecated(event_api, context, elasticapm_client):
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
+
+    with pytest.warns(PendingDeprecationWarning):
+
+        @capture_serverless(name="test_func")
+        def test_func(event, context):
+            with capture_span("test_span"):
+                time.sleep(0.01)
+            return {"statusCode": 200, "headers": {"foo": "bar"}}
+
+        test_func(event_api, context)
+
+        assert len(elasticapm_client.events[constants.TRANSACTION]) == 1
+        transaction = elasticapm_client.events[constants.TRANSACTION][0]
+
+        assert transaction["name"] == "GET /dev/fetch_all"
+        assert transaction["result"] == "HTTP 2xx"
+        assert transaction["span_count"]["started"] == 1
+        assert transaction["context"]["request"]["method"] == "GET"
+        assert transaction["context"]["request"]["headers"]
+        assert transaction["context"]["response"]["status_code"] == 200
+
+
 def test_capture_serverless_api_gateway_v2(event_api2, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -225,7 +249,7 @@ def test_capture_serverless_api_gateway_v2(event_api2, context, elasticapm_clien
 def test_capture_serverless_lambda_url(event_lurl, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -248,7 +272,7 @@ def test_capture_serverless_lambda_url(event_lurl, context, elasticapm_client):
 def test_capture_serverless_elb(event_elb, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -271,7 +295,7 @@ def test_capture_serverless_elb(event_elb, context, elasticapm_client):
 def test_capture_serverless_s3(event_s3, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -289,7 +313,7 @@ def test_capture_serverless_s3(event_s3, context, elasticapm_client):
 def test_capture_serverless_sns(event_sns, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -309,7 +333,7 @@ def test_capture_serverless_sns(event_sns, context, elasticapm_client):
 def test_capture_serverless_sqs(event_sqs, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -331,7 +355,7 @@ def test_capture_serverless_sqs(event_sqs, context, elasticapm_client):
 def test_capture_serverless_s3_batch(event_s3_batch, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)
@@ -350,7 +374,7 @@ def test_capture_serverless_s3_batch(event_s3_batch, context, elasticapm_client)
 def test_service_name_override(event_api, context, elasticapm_client):
     os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
 
-    @capture_serverless(elasticapm_client=elasticapm_client)
+    @capture_serverless
     def test_func(event, context):
         with capture_span("test_span"):
             time.sleep(0.01)

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -283,7 +283,7 @@ def test_capture_serverless_elb(event_elb, context, elasticapm_client):
     assert len(elasticapm_client.events[constants.TRANSACTION]) == 1
     transaction = elasticapm_client.events[constants.TRANSACTION][0]
 
-    assert transaction["name"] == "POST /toolz/api/v2.0/downloadPDF/PDF_2020-09-11_11-06-01.pdf"
+    assert transaction["name"] == "POST unknown route"
     assert transaction["result"] == "HTTP 2xx"
     assert transaction["span_count"]["started"] == 1
     assert transaction["context"]["request"]["method"] == "POST"


### PR DESCRIPTION
## What does this pull request do?

I still don't know why, but moving the `Client` creation inside of the function execution resulted in ~18x the billable execution time of a basic "Hello World" lambda function. Instrumentation was wayyy slower.

This PR moves the instrumentation back out to setup time, and deprecates the use of kwargs with `capture_serverless`.

The core performance fix is in the first commit: https://github.com/elastic/apm-agent-python/pull/1727/commits/ccb5b67b805008c54edafe869be78773be437941

Also implements minor spec changes from https://github.com/elastic/apm/pull/749