### PR TITLE
Fix some deprecation warnings that were missed in the 6.0.0 release

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -660,16 +660,8 @@ class Client(object):
 
     def check_python_version(self):
         v = tuple(map(int, platform.python_version_tuple()[:2]))
-        if v == (2, 7):
-            warnings.warn(
-                (
-                    "The Elastic APM agent will stop supporting Python 2.7 starting in 6.0.0 -- "
-                    "Please upgrade to Python 3.5+ to continue to use the latest features."
-                ),
-                PendingDeprecationWarning,
-            )
-        elif v < (3, 5):
-            warnings.warn("The Elastic APM agent only supports Python 3.5+", DeprecationWarning)
+        if v < (3, 6):
+            warnings.warn("The Elastic APM agent only supports Python 3.6+", DeprecationWarning)
 
     def check_server_version(
         self, gte: Optional[Tuple[int, ...]] = None, lte: Optional[Tuple[int, ...]] = None

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -427,32 +427,26 @@ def test_server_url_joining(elasticapm_client, expected):
 
 
 @pytest.mark.parametrize(
-    "version,raises,pending",
+    "version",
     [
-        (("2", "7", "0"), True, True),
-        (("3", "3", "0"), True, False),
-        (("3", "4", "0"), True, False),
-        (("3", "5", "0"), False, False),
+        ("2", "7", "0"),
+        ("3", "3", "0"),
+        ("3", "4", "0"),
+        ("3", "5", "0"),
     ],
 )
 @mock.patch("platform.python_version_tuple")
-def test_python_version_deprecation(mock_python_version_tuple, version, raises, pending, recwarn):
+def test_python_version_deprecation(mock_python_version_tuple, version):
     warnings.simplefilter("always")
 
     mock_python_version_tuple.return_value = version
     e = None
-    try:
-        e = elasticapm.Client()
-    finally:
-        if e:
-            e.close()
-    if raises:
-        if pending:
-            w = recwarn.pop(PendingDeprecationWarning)
-            assert "will stop supporting" in w.message.args[0]
-        else:
-            w = recwarn.pop(DeprecationWarning)
-            assert "agent only supports" in w.message.args[0]
+    with pytest.warns(DeprecationWarning, match="agent only supports"):
+        try:
+            e = elasticapm.Client()
+        finally:
+            if e:
+                e.close()
 
 
 def test_recording(elasticapm_client):


### PR DESCRIPTION
## What does this pull request do?

Happened to notice these DeprecationWarnings weren't updated when we released 6.0.0. This simplifies the warnings and the tests.