### PR TITLE
Fix some flaky tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -168,7 +168,7 @@ markers =
     aiobotocore
     kafka
     grpc
-addopts=--random-order
+addopts=--random-order -v
 
 [isort]
 line_length=120

--- a/setup.cfg
+++ b/setup.cfg
@@ -168,7 +168,7 @@ markers =
     aiobotocore
     kafka
     grpc
-addopts=--random-order -v
+addopts=--random-order
 
 [isort]
 line_length=120

--- a/tests/instrumentation/pymemcache_tests.py
+++ b/tests/instrumentation/pymemcache_tests.py
@@ -159,7 +159,7 @@ def test_pymemcache_hash_client(instrument, elasticapm_client):
         {
             "span_compression_enabled": True,
             "span_compression_same_kind_max_duration": "5ms",
-            "span_compression_exact_match_max_duration": "5ms",
+            "span_compression_exact_match_max_duration": "50ms",
         }
     ],
     indirect=True,

--- a/tests/instrumentation/python_memcached_tests.py
+++ b/tests/instrumentation/python_memcached_tests.py
@@ -98,7 +98,7 @@ def test_memcached(instrument, elasticapm_client):
         {
             "span_compression_enabled": True,
             "span_compression_same_kind_max_duration": "5ms",
-            "span_compression_exact_match_max_duration": "5ms",
+            "span_compression_exact_match_max_duration": "50ms",
         }
     ],
     indirect=True,

--- a/tests/instrumentation/redis_tests.py
+++ b/tests/instrumentation/redis_tests.py
@@ -218,7 +218,7 @@ def test_publish_subscribe(instrument, elasticapm_client, redis_conn):
         {
             "span_compression_enabled": True,
             "span_compression_same_kind_max_duration": "5ms",
-            "span_compression_exact_match_max_duration": "5ms",
+            "span_compression_exact_match_max_duration": "50ms",
         }
     ],
     indirect=True,

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -262,6 +262,7 @@ def test_get_transaction():
     requests_store = Tracer(lambda: [], lambda: [], lambda *args: None, VersionedConfig(Config(), "1"), None)
     t = requests_store.begin_transaction("test")
     assert t == execution_context.get_transaction()
+    requests_store.end_transaction(200, "test")
 
 
 def test_get_transaction_clear():


### PR DESCRIPTION
## What does this pull request do?

I've noticed two tests that have been more flaky than usual recently, presumably due to `--random-order`:

- test_label_while_no_transaction
  - The real problem here is `test_get_transaction` was not cleaning up the execution context
- test_memcache_span_compression
  - This one is less clear. But I'm guessing that since we were testing with `5ms` span compression, performance blips on the docker containers could result in a failure. I just bumped the span compression threshold up.

I've also seen `test_flushed_arg_with_wait` fail recently but I was never able to reproduce locally.

The above tests should be less flaky now.