### PR TITLE
Add service.agent.activation_method to metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,8 +33,10 @@ endif::[]
 
 // Unreleased changes go here
 // When the next release happens, nest these changes under the "Python Agent version 6.x" heading
-//[float]
-//===== Features
+[float]
+===== Features
+
+* Add `service.agent.activation_method` to the metadata {pull}1743[#1743]
 
 [float]
 ===== Bug fixes

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -346,13 +346,15 @@ class Client(object):
             "name": keyword_field(self.config.service_name),
             "environment": keyword_field(self.config.environment),
             "version": keyword_field(self.config.service_version),
-            "agent": {"name": "python", "version": elasticapm.VERSION},
+            "agent": {"name": "python", "version": elasticapm.VERSION, "activation_method": "unknown"},
             "language": {"name": "python", "version": keyword_field(platform.python_version())},
             "runtime": {
                 "name": keyword_field(platform.python_implementation()),
                 "version": keyword_field(runtime_version),
             },
         }
+        if self.activation_method:
+            result["agent"]["activation_method"] = self.activation_method
         if self.config.framework_name:
             result["framework"] = {
                 "name": keyword_field(self.config.framework_name),

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -109,6 +109,7 @@ class Client(object):
         self._service_info = None
         # setting server_version here is mainly used for testing
         self.server_version = inline.pop("server_version", None)
+        self.activation_method = None
 
         self.check_python_version()
 
@@ -217,8 +218,6 @@ class Client(object):
             sys.excepthook = self._excepthook
         if config.enabled:
             self.start_threads()
-
-        self.activation_method = None
 
         # Save this Client object as the global CLIENT_SINGLETON
         set_client(self)

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -59,6 +59,7 @@ def test_service_info(elasticapm_client):
     assert service_info["environment"] == elasticapm_client.config.environment == "production"
     assert service_info["language"] == {"name": "python", "version": platform.python_version()}
     assert service_info["agent"]["name"] == "python"
+    assert service_info["agent"]["activation_method"] == "unknown"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this pull request do?

Add `service.agent.activation_method` as specified in [spec](https://github.com/elastic/apm/blob/main/specs/agents/metadata.md#activation-method)

## Related issues

Closes #1698 
