### PR TITLE
Add update-specs updatcli workflow

### DIFF
--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -69,7 +69,7 @@ targets:
     sourceid: error.json
     kind: file
     spec:
-      file: upstream/json-specs/error.json
+      file: tests/upstream/json-specs/error.json
       forcecreate: true
   metadata.json:
     name: metadata.json
@@ -77,7 +77,7 @@ targets:
     sourceid: metadata.json
     kind: file
     spec:
-      file: upstream/json-specs/metadata.json
+      file: tests/upstream/json-specs/metadata.json
       forcecreate: true
   metricset.json:
     name: metricset.json
@@ -85,7 +85,7 @@ targets:
     sourceid: metricset.json
     kind: file
     spec:
-      file: upstream/json-specs/metricset.json
+      file: tests/upstream/json-specs/metricset.json
       forcecreate: true
   span.json:
     name: span.json
@@ -93,7 +93,7 @@ targets:
     sourceid: span.json
     kind: file
     spec:
-      file: upstream/json-specs/span.json
+      file: tests/upstream/json-specs/span.json
       forcecreate: true
   transaction.json:
     name: transaction.json
@@ -101,5 +101,5 @@ targets:
     sourceid: transaction.json
     kind: file
     spec:
-      file: upstream/json-specs/transaction.json
+      file: tests/upstream/json-specs/transaction.json
       forcecreate: true

--- a/.ci/update-specs.yml
+++ b/.ci/update-specs.yml
@@ -1,0 +1,105 @@
+name: update-specs
+
+title: synchronize schema specs
+
+scms:
+  apm-agent-python:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm-agent-python
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+sources:
+  sha:
+    kind: file
+    spec:
+      file: 'https://github.com/elastic/apm-data/commit/main.patch'
+      matchpattern: "^From\\s([0-9a-f]{40})\\s"
+  error.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/error.json
+  metadata.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metadata.json
+  metricset.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metricset.json
+  span.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/span.json
+  transaction.json:
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/transaction.json
+
+
+
+
+
+actions:
+  pr:
+    kind: "github/pullrequest"
+    scmid: "apm-agent-python"
+    sourceid: sha
+    spec:
+      automerge: false
+      draft: false
+      labels:
+        - "automation"
+      description: |-
+        ### What
+        APM agent json schema automatic sync
+        ### Why
+        *Changeset*
+        * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
+
+targets:
+  error.json:
+    name: error.json
+    scmid: apm-agent-python
+    sourceid: error.json
+    kind: file
+    spec:
+      file: upstream/json-specs/error.json
+      forcecreate: true
+  metadata.json:
+    name: metadata.json
+    scmid: apm-agent-python
+    sourceid: metadata.json
+    kind: file
+    spec:
+      file: upstream/json-specs/metadata.json
+      forcecreate: true
+  metricset.json:
+    name: metricset.json
+    scmid: apm-agent-python
+    sourceid: metricset.json
+    kind: file
+    spec:
+      file: upstream/json-specs/metricset.json
+      forcecreate: true
+  span.json:
+    name: span.json
+    scmid: apm-agent-python
+    sourceid: span.json
+    kind: file
+    spec:
+      file: upstream/json-specs/span.json
+      forcecreate: true
+  transaction.json:
+    name: transaction.json
+    scmid: apm-agent-python
+    sourceid: transaction.json
+    kind: file
+    spec:
+      file: upstream/json-specs/transaction.json
+      forcecreate: true

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -10,6 +10,7 @@ on:
       - snapshoty
       - release
       - packages
+      - update-specs
     types: [completed]
 
 jobs:

--- a/.github/workflows/update-specs.yml
+++ b/.github/workflows/update-specs.yml
@@ -1,0 +1,32 @@
+name: update-specs
+
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+      - name: Run Updatecli
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: updatecli apply --config ./.ci/update-specs.yml
+      - if: failure()
+        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-agent-python"


### PR DESCRIPTION
## What does this pull request do?

Moves the update specs workflow from apm-server to the consumer using updatecli to have a "dependabot"-like experience.

## How to test

```
GITHUB_TOKEN=<token>\
GIT_USER=<username> \
GIT_EMAIL=j<email> \
updatecli diff -c .ci/update-specs.yml
```

## Related issues

- https://github.com/elastic/observability-robots/issues/1516
