### PR TITLE
Fix nightly scheduled test

### DIFF
--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -1,0 +1,37 @@
+name: run-matrix
+
+on:
+  workflow_call:
+    inputs:
+      include:
+        required: true
+        description: Matrix include JSON string
+        type: string
+
+jobs:
+  docker:
+    name: "docker (version: ${{ matrix.version }}, framework: ${{ matrix.framework }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        include: ${{ fromJSON(inputs.include) }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
+        env:
+          LOCALSTACK_VOLUME_DIR: localstack_data
+      - if: success() || failure()
+        name: Upload JUnit Test Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: "**/*-python-agent-junit.xml"
+      - if: success() || failure()
+        name: Upload Coverage Reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-reports
+          path: "**/.coverage*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
+      data: ${{ steps.split.outputs.data }}
+      chunks: ${{ steps.split.outputs.chunks }}
     steps:
       - uses: actions/checkout@v3
       - id: generate
@@ -30,34 +32,59 @@ jobs:
           # Use .ci/.matrix_framework_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_framework.yml
           frameworksFile: .ci/.matrix_framework${{ github.event_name == 'schedule' && '_full' || '' }}.yml
           excludedFile: .ci/.matrix_exclude.yml
+      - name: Split matrix
+        shell: python
+        id: split
+        run: |
+          import os
+          import json
 
-  docker:
-    name: "docker (version: ${{ matrix.version }}, framework: ${{ matrix.framework }})"
-    needs: create-matrix
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run tests
-        run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
+          def split(lst, n):
+            return [lst[i::n] for i in range(n)]
+
+          matrix = json.loads(os.environ['GENERATED_MATRIX'])
+          chunks = split(matrix['include'], 4)
+
+          data = {
+            'one': chunks[0],
+            'two': chunks[1],
+            'three': chunks[2],
+            'four': chunks[3],
+          }
+
+          data_json = json.dumps(data)
+          chunks_json = json.dumps(chunks)
+
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+            print(f'data={data_json}', file=f)
+            print(f'chunks={chunks_json}', file=f)
+
         env:
-          LOCALSTACK_VOLUME_DIR: localstack_data
-      - if: success() || failure()
-        name: Upload JUnit Test Results
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: "**/*-python-agent-junit.xml"
-      - if: success() || failure()
-        name: Upload Coverage Reports
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-reports
-          path: "**/.coverage*"
+          GENERATED_MATRIX: ${{ steps.generate.outputs.matrix }}
 
+  chunks-0:
+    needs: create-matrix
+    uses: ./.github/workflows/run-matrix.yml
+    with:
+      include: ${{ toJSON(fromJSON(needs.create-matrix.outputs.chunks)[0]) }}
+
+  chunks-1:
+    needs: create-matrix
+    uses: ./.github/workflows/run-matrix.yml
+    with:
+      include: ${{ toJSON(fromJSON(needs.create-matrix.outputs.chunks)[1]) }}
+
+  chunks-2:
+    needs: create-matrix
+    uses: ./.github/workflows/run-matrix.yml
+    with:
+      include: ${{ toJSON(fromJSON(needs.create-matrix.outputs.chunks)[2]) }}
+
+  chunks-3:
+    needs: create-matrix
+    uses: ./.github/workflows/run-matrix.yml
+    with:
+      include: ${{ toJSON(fromJSON(needs.create-matrix.outputs.chunks)[3]) }}
 
   windows:
     name: "windows (version: ${{ matrix.version }}, framework: ${{ matrix.framework }}, asyncio: ${{ matrix.asyncio }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,19 +44,9 @@ jobs:
 
           matrix = json.loads(os.environ['GENERATED_MATRIX'])
           chunks = split(matrix['include'], 4)
-
-          data = {
-            'one': chunks[0],
-            'two': chunks[1],
-            'three': chunks[2],
-            'four': chunks[3],
-          }
-
-          data_json = json.dumps(data)
           chunks_json = json.dumps(chunks)
 
           with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            print(f'data={data_json}', file=f)
             print(f'chunks={chunks_json}', file=f)
 
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,10 @@ jobs:
             return [lst[i::n] for i in range(n)]
 
           matrix = json.loads(os.environ['GENERATED_MATRIX'])
+
+          # Using the number 4 because the full matrix has roughly 400+ items
+          # Hence, it is split into chunks of size ~100
+          # We are doing this because the matrix in GH actions has a max limit of 256
           chunks = split(matrix['include'], 4)
           chunks_json = json.dumps(chunks)
 


### PR DESCRIPTION
## What does this pull request do?

Split the matrix items into chunks and run on multiple jobs to bypass the matrix max limit of 256 when running the full matrix.

![image](https://user-images.githubusercontent.com/16325797/217590906-8c60927a-18a8-4249-b1d3-14c34ca4048d.png)

## How to test

Tested with the diff

```diff
index 2738f926..364a7cee 100644
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,9 @@ jobs:
         uses: elastic/apm-pipeline-library/.github/actions/version-framework@current
         with:
           # Use .ci/.matrix_python_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_python.yml
-          versionsFile: .ci/.matrix_python${{ github.event_name == 'schedule' && '_full' || '' }}.yml
+          versionsFile: .ci/.matrix_python_full.yml
           # Use .ci/.matrix_framework_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_framework.yml
-          frameworksFile: .ci/.matrix_framework${{ github.event_name == 'schedule' && '_full' || '' }}.yml
+          frameworksFile: .ci/.matrix_framework_full.yml
           excludedFile: .ci/.matrix_exclude.yml
       - name: Split matrix
         shell: python
```

## Related issues

Closes https://github.com/elastic/observability-robots/issues/1566
