### PR TITLE
Added the psutil command with the elastic-apm[flask] installation to avoid metrics error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         exclude: "(elasticapm/utils/wrapt/.*|tests/utils/stacks/linenos.py|tests/utils/stacks/linenos2.py|tests/contrib/grpc/grpc_app/.*pb2.*.py)"

--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -23,6 +23,8 @@ NOTE: If you use Flask with uwsgi, make sure to
 http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads[enable
 threads].
 
+NOTE: If you find an error log: `Could not register elasticapm.metrics.sets.cpu.CPUMetricSet metricset: psutil not found. Install it to get system and process metrics` - Make sure to append the command `psutil` i.e. `pip install flask 'elastic-apm[flask]' psutil`
+
 [float]
 [[flask-setup]]
 ==== Setup

--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -23,7 +23,9 @@ NOTE: If you use Flask with uwsgi, make sure to
 http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads[enable
 threads].
 
-NOTE: If you find an error log: `Could not register elasticapm.metrics.sets.cpu.CPUMetricSet metricset: psutil not found. Install it to get system and process metrics` - Make sure to append the command `psutil` i.e. `pip install flask 'elastic-apm[flask]' psutil`
+NOTE: If you see an error log that mentions `psutil not found`, you can install
+`psutil` using `pip install psutil`, or add `psutil` to your `requirements.txt`
+file.
 
 [float]
 [[flask-setup]]


### PR DESCRIPTION


## What does this pull request do?

The `psutil` is required to push the elasticapm.metrics.sets otherwise, the service is not visible in the APM > Services module. Reproduced the same in my local environment and it worked fine post installation the `psutil` pkg.


<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

[Discuss Forum #223083](https://discuss.elastic.co/t/python-apm-agent-for-flask-doesnt-report-metrics/223083) 

