### PR TITLE
Set status check to success in case it's an only-docs PR

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -5,9 +5,10 @@ name: test
 
 on:
   pull_request:
-    paths:
-      - '**/*.md'
-      - '**/*.asciidoc'
+    paths-ignore: # This expression needs to match the paths ignored on test.yml.
+      - '**'
+      - '!**/*.md'
+      - '!**/*.asciidoc'
 
 permissions:
   contents: read

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,0 +1,16 @@
+---
+# This workflow sets the test / all status check to success in case it's a docs only PR and test.yml is not triggered
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: test
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.asciidoc'
+
+jobs:
+  all:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required"'

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -9,6 +9,9 @@ on:
       - '**/*.md'
       - '**/*.asciidoc'
 
+permissions:
+  contents: read
+
 jobs:
   all:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,7 +1,7 @@
 ---
 # This workflow sets the test / all status check to success in case it's a docs only PR and test.yml is not triggered
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-name: test
+name: test # The name must be the same as in test.yml
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: test
+name: test # The name must be the same as in test-docs.yml
 
 on:
   workflow_call: ~


### PR DESCRIPTION
## What does this pull request do?


Sets the `test / all` status check to green in case it's a only-docs PR and the test.yml workflow is not triggered.

This is needed to be able to set `test / all` as required status check.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues
- #1749 
