### PR TITLE
[GRPC] Handle non-existent transaction in server interceptor

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+
+[float]
+===== Bug fixes
+
+* Fix a bug in the GRPC instrumentation when the agent is disabled or not recording {pull}1761[#1761]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 


### PR DESCRIPTION
## What does this pull request do?

This change handles the case when APM is not recording/disabled and `client.begin_transaction()` just returns `None`. I wasn't able to figure out how to add a test for this. Do you have an advice/hint?

## Related issues

* https://github.com/elastic/apm-agent-python/issues/1739
* Introduced in the initial gRPC instrumentation (https://github.com/elastic/apm-agent-python/pull/1703)
