### PR TITLE
Fix default botocore handler

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+
+[float]
+===== Bug fixes
+
+* Fix issue with botocore instrumentation creating spans with an incorrect `service.name` {pull}1765[#1765]
+
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -238,15 +238,15 @@ def modify_span_sqs_post(span: SpanType, args, kwargs, result):
                 span.add_link(tp)
 
 
-def handle_default(operation_name, service, instance, args, kwargs, destination):
+def handle_default(operation_name, service, instance, args, kwargs, context):
     span_type = "aws"
     span_subtype = service.lower()
     span_action = operation_name
 
-    destination["service"] = {"name": span_subtype, "resource": span_subtype, "type": span_type}
+    context["destination"]["service"] = {"name": span_subtype, "resource": span_subtype, "type": span_type}
 
     signature = f"{service}:{operation_name}"
-    return HandlerInfo(signature, span_type, span_subtype, span_action, destination)
+    return HandlerInfo(signature, span_type, span_subtype, span_action, context)
 
 
 handlers = {


### PR DESCRIPTION
## What does this pull request do?

The `handle_default` handler was not correctly nesting its destination context, which resulted in spans with an incorrect `service.name`. This meant users would see empty services in their service list (and service map) for each AWS service type, but with no transactions attached to those services. 

## Related issues

Ref #1054 
Closes #1764
