### PR TITLE
action: test-docs workflow should create basic junit report

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -18,3 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No build required"'
+      # As long as this workflow uses the same name than .github/workflows/test.yml and
+      # the test-reporter requires artifacts with the test results to exist.
+      # let's produce a dummy test so the test-report don't fail in this particular
+      # case
+      - name: Generate junit placeholder - to integrate with test-reporter
+        run: |-
+          cat > python-agent-junit.xml << ENDOFFILE
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuites name="apm-agent-python" tests="1" failures="0" errors="0" time="1">
+            <testsuite name="apm-agent-python-docs" errors="0" failures="3" skipped="0" time="1" tests=1">
+              <testcase classname="docs" name="Skipped test" time="0">
+                <skipped/>
+              </testcase>
+            </testsuite>
+          </testsuites>
+          ENDOFFILE
+      - if: success() || failure()
+        name: Upload JUnit Test Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: "python-agent-junit.xml"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -27,7 +27,7 @@ jobs:
           cat > python-agent-junit.xml << ENDOFFILE
           <?xml version="1.0" encoding="UTF-8"?>
           <testsuites name="apm-agent-python" tests="1" failures="0" errors="0" time="1">
-            <testsuite name="apm-agent-python-docs" errors="0" failures="0" skipped="1" time="1" tests=1">
+            <testsuite name="apm-agent-python-docs" errors="0" failures="0" skipped="1" time="1" tests="1">
               <testcase classname="docs" name="Skipped test" time="0">
                 <skipped/>
               </testcase>

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -24,7 +24,7 @@ jobs:
       # case
       - name: Generate junit placeholder - to integrate with test-reporter
         run: |-
-          cat > python-agent-junit.xml << ENDOFFILE
+          cat > docs-python-agent-junit.xml << ENDOFFILE
           <?xml version="1.0" encoding="UTF-8"?>
           <testsuites name="apm-agent-python" tests="1" failures="0" errors="0" time="1">
             <testsuite name="apm-agent-python-docs" errors="0" failures="0" skipped="1" time="1" tests="1">
@@ -39,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: "python-agent-junit.xml"
+          path: "docs-python-agent-junit.xml"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -27,7 +27,7 @@ jobs:
           cat > python-agent-junit.xml << ENDOFFILE
           <?xml version="1.0" encoding="UTF-8"?>
           <testsuites name="apm-agent-python" tests="1" failures="0" errors="0" time="1">
-            <testsuite name="apm-agent-python-docs" errors="0" failures="3" skipped="0" time="1" tests=1">
+            <testsuite name="apm-agent-python-docs" errors="0" failures="0" skipped="1" time="1" tests=1">
               <testcase classname="docs" name="Skipped test" time="0">
                 <skipped/>
               </testcase>


### PR DESCRIPTION
## What does this pull request do?

Generate junit test report file with a skipped entry for the `test-docs`

## Why 

otherwise, the test-reporter will fail as no artifacts can be found

## Issue

https://github.com/elastic/apm-pipeline-library/pull/2121 is the one testing this in isolation.


<img width="1491" alt="image" src="https://user-images.githubusercontent.com/2871786/223091316-1fce2e08-545d-4a7a-beb2-6c6086263be2.png">


See https://github.com/elastic/apm-pipeline-library/runs/11788165082