### PR TITLE
Add a default span name

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+
+[float]
+===== Bug fixes
+
+* Fix spans being dropped if they don't have a name {pull}1770[#1770]
+
+
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -539,7 +539,7 @@ class Span(BaseSpan):
         """
         self.id = self.get_dist_tracing_id()
         self.transaction = transaction
-        self.name = name
+        self.name = name or "unnamed"
         self.context = context if context is not None else {}
         self.leaf = leaf
         # timestamp is bit of a mix of monotonic and non-monotonic time sources.

--- a/tests/instrumentation/base_tests.py
+++ b/tests/instrumentation/base_tests.py
@@ -225,3 +225,12 @@ def test_transaction_outcome_override(elasticapm_client):
 
     elasticapm.set_transaction_outcome(constants.OUTCOME.SUCCESS, override=True)
     assert transaction.outcome == constants.OUTCOME.SUCCESS
+
+
+def test_empty_span_name(elasticapm_client):
+    transaction = elasticapm_client.begin_transaction("test")
+    with elasticapm.capture_span():
+        pass
+    elasticapm_client.end_transaction("test")
+
+    assert elasticapm_client.events[SPAN][0]["name"] == "unnamed"


### PR DESCRIPTION
## What does this pull request do?

We list `name` as a required argument in our [`capture_span` docs](https://www.elastic.co/guide/en/apm/agent/python/current/api.html#api-capture-span). However, if a span name is not provided, we silently set it to `None`, and it gets dropped by the APM Server (as it's a [required field](https://github.com/elastic/apm-data/blob/534660e4a1517a6bc2fbc58b1df22e92bcce7180/input/elasticapm/docs/spec/v2/span.json#L876)).

I didn't think this was acceptable behavior, so I copied what the Node agent does, and set the default to `"unnamed"` so we don't silently drop spans.

This also matches my spec change here: https://github.com/elastic/apm/pull/772
