### PR TITLE
Lambda support for `event` formed as list

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix spans being dropped if they don't have a name {pull}1770[#1770]
+* Fix AWS Lambda support when `event` is a list {pull}1775[#1775]
 
 
 

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -144,6 +144,11 @@ class _lambda_transaction(object):
         """
         Transaction setup
         """
+        if isinstance(self.event, list):
+            # When `event` is a list, it's likely the output of another AWS
+            # service like Step Functions, and is unlikely to be standardized
+            # in any way. We just have to rely on our defaults in this case.
+            self.event = {}
         trace_parent = TraceParent.from_headers(self.event.get("headers", {}))
 
         global COLD_START


### PR DESCRIPTION
## What does this pull request do?

Lambda functions can be invoked by other AWS services, such as Step Functions. In this case, the `event` will be the JSON object received from the invoking service. This means that `event` could be a list, instead of a dict, which would cause an exception to be raised. This fixes that issue, and is also a useful test of our `event` defaults.

I manually tested this with Step Functions in AWS, and also wrote a unit test.

## Related issues

Closes #1746 
