### PR TITLE
Handle all non-dict `event` types in lambda

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,7 +41,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix spans being dropped if they don't have a name {pull}1770[#1770]
-* Fix AWS Lambda support when `event` is a list {pull}1775[#1775]
+* Fix AWS Lambda support when `event` is not a dict {pull}1775[#1775]
 * Fix deprecation warning with urllib3 2.0.0 pre-release versions {pull}1778[#1778]
 
 

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -144,8 +144,8 @@ class _lambda_transaction(object):
         """
         Transaction setup
         """
-        if isinstance(self.event, list):
-            # When `event` is a list, it's likely the output of another AWS
+        if not isinstance(self.event, dict):
+            # When `event` is not a dict, it's likely the output of another AWS
             # service like Step Functions, and is unlikely to be standardized
             # in any way. We just have to rely on our defaults in this case.
             self.event = {}


### PR DESCRIPTION
## What does this pull request do?

After discussing this in our meeting today I don't think there's any reason to limit our support to lists. With this change we will use our defaults for any non-dict `event` object.

## Related issues

Ref #1775 
Ref #1746 
