### PR TITLE
updatecli: fix title since it caused errors

### DIFF
--- a/.ci/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli.d/update-gherkin-specs.yml
@@ -1,5 +1,6 @@
 name: update-gherkin-specs
 pipelineid: update-gherkin-specs
+title: synchronize gherkin specs
 
 scms:
   default:
@@ -52,15 +53,15 @@ actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
+    title: '[Automation] Update Gherkin specs'
     spec:
-      title: Update Gherkin specs
       automerge: false
       draft: false
       labels:
         - "automation"
       description: |-
         ### What
-        APM agent specs automatic sync
+        APM agent Gherkin specs automatic sync
         ### Why
         *Changeset*
         * https://github.com/elastic/apm/commit/{{ source "sha" }}

--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -1,5 +1,6 @@
-name: update-jsons-specs
+name: update-json-specs
 pipelineid: update-json-specs
+title: synchronize json specs
 
 scms:
   default:
@@ -51,12 +52,13 @@ sources:
     kind: file
     spec:
       file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/wildcard_matcher_tests.json
+
 actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
+    title: '[Automation] Update JSON specs'
     spec:
-      title: Update JSON specs
       automerge: false
       draft: false
       labels:

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -1,9 +1,9 @@
 name: update-specs
-
+pipelineid: update-schema-specs
 title: synchronize schema specs
 
 scms:
-  apm-agent-python:
+  default:
     kind: github
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
@@ -44,15 +44,11 @@ sources:
     spec:
       file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/transaction.json
 
-
-
-
-
 actions:
   pr:
     kind: "github/pullrequest"
-    scmid: "apm-agent-python"
-    sourceid: sha
+    scmid: default
+    title: '[Automation] Update JSON schema specs'
     spec:
       automerge: false
       draft: false

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -64,7 +64,7 @@ actions:
 targets:
   error.json:
     name: error.json
-    scmid: apm-agent-python
+    scmid: default
     sourceid: error.json
     kind: file
     spec:
@@ -72,7 +72,7 @@ targets:
       forcecreate: true
   metadata.json:
     name: metadata.json
-    scmid: apm-agent-python
+    scmid: default
     sourceid: metadata.json
     kind: file
     spec:
@@ -80,7 +80,7 @@ targets:
       forcecreate: true
   metricset.json:
     name: metricset.json
-    scmid: apm-agent-python
+    scmid: default
     sourceid: metricset.json
     kind: file
     spec:
@@ -88,7 +88,7 @@ targets:
       forcecreate: true
   span.json:
     name: span.json
-    scmid: apm-agent-python
+    scmid: default
     sourceid: span.json
     kind: file
     spec:
@@ -96,7 +96,7 @@ targets:
       forcecreate: true
   transaction.json:
     name: transaction.json
-    scmid: apm-agent-python
+    scmid: default
     sourceid: transaction.json
     kind: file
     spec:


### PR DESCRIPTION
### What

Updatecli pipelines were misconfigured hence the automation failed with

```

ACTIONS
========

WARNING: **Fallback** Please add a title to you configuration using the field 'title: <your pipeline>'
Pipeline "update-jsons-specs" failed
Skipping due to:
	action stage:	"Title is too long (maximum is 256 characters)"

```

I also changed the PR title to be within the kind definition rather than within the specs.
