### PR TITLE
Add support for partial transaction reporting in Lambda

### DIFF
--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -273,8 +273,7 @@ class Transport(ThreadManager):
             fileobj = buffer.fileobj  # get a reference to the fileobj before closing the gzip file
             buffer.close()
 
-            # StringIO on Python 2 does not have getbuffer, so we need to fall back to getvalue
-            data = fileobj.getbuffer() if hasattr(fileobj, "getbuffer") else fileobj.getvalue()
+            data = fileobj.getbuffer()
             try:
                 self.send(data, forced_flush=forced_flush)
                 self.handle_transport_success()

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -70,7 +70,7 @@ class Transport(HTTPTransportBase):
         self._http = None
         self._url = url
 
-    def send(self, data, forced_flush=False):
+    def send(self, data, forced_flush=False, custom_url=None, extra_headers=None):
         response = None
 
         headers = self._headers.copy() if self._headers else {}
@@ -81,8 +81,10 @@ class Transport(HTTPTransportBase):
                 b"Content-Encoding": b"gzip",
             }
         )
+        if extra_headers:
+            headers.update(extra_headers)
 
-        url = self._url
+        url = custom_url or self._url
         if forced_flush:
             url = f"{url}?flushed=true"
         try:
@@ -146,7 +148,7 @@ class Transport(HTTPTransportBase):
                     }
                 }
         :return: a three-tuple of new version, config dictionary and validity in seconds.
-                 Any element of the tuple can be None.
+            Any element of the tuple can be None.
         """
         url = self._config_url
         data = json_encoder.dumps(keys).encode("utf-8")


### PR DESCRIPTION
## What does this pull request do?

The lambda extension now has support for early reporting of partial transactions. This covers the case where our lambda runtime times out before we can properly end and report the transaction. In this case, the lambda extension will report the transaction with a `timeout` result.

## Related issues

Closes #1734 
