### PR TITLE
Fix flakey pylons test

### DIFF
--- a/elasticapm/contrib/pylons/__init__.py
+++ b/elasticapm/contrib/pylons/__init__.py
@@ -42,7 +42,11 @@ def list_from_setting(config, setting):
 
 
 class ElasticAPM(Middleware):
-    def __init__(self, app, config, client_cls=Client):
+    def __init__(self, app, config, client_cls=None):
         client_config = {key[11:]: val for key, val in config.items() if key.startswith("elasticapm.")}
-        client = get_client() or client_cls(**client_config)
+        if client_cls is None:
+            client = get_client() or Client(**client_config)
+        else:
+            # Testing case
+            client = client_cls(**client_config)
         super(ElasticAPM, self).__init__(app, client)

--- a/tests/contrib/pylons/tests.py
+++ b/tests/contrib/pylons/tests.py
@@ -40,7 +40,7 @@ def example_app(environ, start_response):
     raise ValueError("hello world")
 
 
-def test_init():
+def test_init(close_client):
     config = {
         "elasticapm.server_url": "http://localhost/api/store",
         "elasticapm.service_name": "p" * 32,
@@ -52,4 +52,3 @@ def test_init():
     assert middleware.client.config.service_name == "p" * 32
     assert middleware.client.config.secret_token == "a" * 32
     assert middleware.client.config.metrics_interval.total_seconds() == 0
-    elasticapm.get_client().close()

--- a/tests/contrib/pylons/tests.py
+++ b/tests/contrib/pylons/tests.py
@@ -39,7 +39,7 @@ def example_app(environ, start_response):
     raise ValueError("hello world")
 
 
-def test_init(close_client):
+def test_init():
     config = {
         "elasticapm.server_url": "http://localhost/api/store",
         "elasticapm.service_name": "p" * 32,

--- a/tests/contrib/pylons/tests.py
+++ b/tests/contrib/pylons/tests.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import
 
+import elasticapm
 from elasticapm.contrib.pylons import ElasticAPM
 from tests.fixtures import TempStoreClient
 
@@ -51,3 +52,4 @@ def test_init():
     assert middleware.client.config.service_name == "p" * 32
     assert middleware.client.config.secret_token == "a" * 32
     assert middleware.client.config.metrics_interval.total_seconds() == 0
+    elasticapm.get_client().close()

--- a/tests/contrib/pylons/tests.py
+++ b/tests/contrib/pylons/tests.py
@@ -31,7 +31,6 @@
 
 from __future__ import absolute_import
 
-import elasticapm
 from elasticapm.contrib.pylons import ElasticAPM
 from tests.fixtures import TempStoreClient
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -481,3 +481,18 @@ def always_uninstrument():
             elasticapm.uninstrument()
         except Exception:
             pass
+
+
+@pytest.fixture()
+def close_client():
+    """
+    Use this fixture if you create a Client as part of your test. It will
+    close the Client at the end of the test, without forcing you to wrap your
+    test in an ugly try:finally: block.
+    """
+    try:
+        yield
+    finally:
+        client = elasticapm.get_client()
+        if client:
+            client.close()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -464,35 +464,24 @@ def get_free_port() -> int:
 
 
 @pytest.fixture(autouse=True)
-def always_uninstrument():
+def always_uninstrument_and_close():
     """
-    It's easy to accidentally forget to uninstrument.
+    It's easy to accidentally forget to uninstrument, or to leave a Client open.
 
     With no-code-changes instrumentations, we *really* need to make sure we
     always uninstrument. This fixture will be used on every test, should be
     applied first -- see
     https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
-    -- and thus cleanup last, which will ensure we always uninstrument.
+    -- and thus cleanup last, which will ensure we always uninstrument and close
+    the Client.
     """
     try:
         yield
     finally:
         try:
             elasticapm.uninstrument()
+            client = elasticapm.get_client()
+            if client:
+                client.close()
         except Exception:
             pass
-
-
-@pytest.fixture()
-def close_client():
-    """
-    Use this fixture if you create a Client as part of your test. It will
-    close the Client at the end of the test, without forcing you to wrap your
-    test in an ugly try:finally: block.
-    """
-    try:
-        yield
-    finally:
-        client = elasticapm.get_client()
-        if client:
-            client.close()


### PR DESCRIPTION
## What does this pull request do?

Somewhere in the test suite, we're leaking a `Client` object. I haven't been able to reproduce this, but this Pylons test in particular relies on a new `Client` being created inside of the test, and was failing because of the `get_client()` code.

This test was also leaking a `Client` object, so I fixed that too. 😅 
