### PR TITLE
Only send activation_method if server version is >= 8.7.1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ endif::[]
 * Fix spans being dropped if they don't have a name {pull}1770[#1770]
 * Fix AWS Lambda support when `event` is not a dict {pull}1775[#1775]
 * Fix deprecation warning with urllib3 2.0.0 pre-release versions {pull}1778[#1778]
+* Fix `activation_method` to only send to APM server 8.7.1+ {pull}1787[#1787]
 * Fix span.context.destination.service.resource for S3 spans to have an "s3/" prefix. {pull}1783[#1783]
 +
 *Note*: While this is considered a bugfix, it can potentially be a breaking

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -355,7 +355,7 @@ class Client(object):
                 "version": keyword_field(runtime_version),
             },
         }
-        if self.activation_method:
+        if self.activation_method and self.check_server_version(gte=(8, 7, 1)):
             result["agent"]["activation_method"] = self.activation_method
         if self.config.framework_name:
             result["framework"] = {
@@ -680,7 +680,11 @@ class Client(object):
         if not self.server_version:
             return True
         gte = gte or (0,)
+        if len(gte) < 3:
+            gte = gte + (0,) * (3 - len(gte))
         lte = lte or (2**32,)  # let's assume APM Server version will never be greater than 2^32
+        if len(lte) < 3:
+            lte = lte + (0,) * (3 - len(lte))
         return bool(gte <= self.server_version <= lte)
 
     @property

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -107,6 +107,7 @@ class Client(object):
         self.processors = []
         self.filter_exception_types_dict = {}
         self._service_info = None
+        self._server_version = None
         # setting server_version here is mainly used for testing
         self.server_version = inline.pop("server_version", None)
         self.activation_method = elasticapm._activation_method
@@ -691,6 +692,17 @@ class Client(object):
     def _metrics(self):
         warnings.warn(DeprecationWarning("Use `client.metrics` instead"))
         return self.metrics
+
+    @property
+    def server_version(self):
+        return self._server_version
+
+    @server_version.setter
+    def server_version(self, new_version):
+        if new_version and len(new_version) < 3:
+            self.logger.debug("APM Server version is too short, padding with zeros")
+            new_version = new_version + (0,) * (3 - len(new_version))
+        self._server_version = new_version
 
 
 class DummyClient(Client):

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -508,7 +508,7 @@ def test_check_server_version(elasticapm_client):
     assert elasticapm_client.check_server_version(gte=(100, 5, 10))
     assert elasticapm_client.check_server_version(lte=(100, 5, 10))
 
-    elasticapm_client.server_version = (7, 15)
+    elasticapm_client.server_version = (7, 15, 0)
     assert elasticapm_client.check_server_version(gte=(7,))
     assert not elasticapm_client.check_server_version(gte=(8,))
     assert not elasticapm_client.check_server_version(lte=(7,))

--- a/tests/client/dropped_spans_tests.py
+++ b/tests/client/dropped_spans_tests.py
@@ -113,7 +113,9 @@ def test_transaction_max_span_dropped_statistics(elasticapm_client):
         assert entry["service_target_name"] == "foo"
 
 
-@pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 1, "server_version": (7, 15)}], indirect=True)
+@pytest.mark.parametrize(
+    "elasticapm_client", [{"transaction_max_spans": 1, "server_version": (7, 15, 0)}], indirect=True
+)
 def test_transaction_max_span_dropped_statistics_not_collected_for_incompatible_server(elasticapm_client):
     elasticapm_client.begin_transaction("test_type")
     with elasticapm.capture_span("not_dropped"):

--- a/tests/client/transaction_tests.py
+++ b/tests/client/transaction_tests.py
@@ -38,7 +38,9 @@ from elasticapm.utils import encoding
 from elasticapm.utils.disttracing import TraceParent
 
 
-@pytest.mark.parametrize("elasticapm_client", [{"server_version": (7, 15)}, {"server_version": (7, 16)}], indirect=True)
+@pytest.mark.parametrize(
+    "elasticapm_client", [{"server_version": (7, 15, 0)}, {"server_version": (7, 16, 0)}], indirect=True
+)
 def test_transaction_span(elasticapm_client):
     elasticapm_client.begin_transaction("test")
     with elasticapm.capture_span("test", extra={"a": "b"}):
@@ -156,8 +158,8 @@ def test_collect_source_transactions(elasticapm_client):
 @pytest.mark.parametrize(
     "elasticapm_client",
     [
-        {"transaction_sample_rate": 0.4, "server_version": (7, 14)},
-        {"transaction_sample_rate": 0.4, "server_version": (8, 0)},
+        {"transaction_sample_rate": 0.4, "server_version": (7, 14, 0)},
+        {"transaction_sample_rate": 0.4, "server_version": (8, 0, 0)},
     ],
     indirect=True,
 )
@@ -175,7 +177,7 @@ def test_transaction_sampling(elasticapm_client, not_so_random):
 
     # seed is fixed by not_so_random fixture
     assert len([t for t in transactions if t["sampled"]]) == 3
-    if elasticapm_client.server_version < (8, 0):
+    if elasticapm_client.server_version < (8, 0, 0):
         assert len(transactions) == 10
     else:
         assert len(transactions) == 3

--- a/tests/contrib/django/django_tests.py
+++ b/tests/contrib/django/django_tests.py
@@ -1633,7 +1633,7 @@ def test_transaction_name_from_route_doesnt_have_effect_in_older_django(client, 
 
 
 @pytest.mark.parametrize(
-    "django_elasticapm_client", [{"server_version": (7, 14)}], indirect=True
+    "django_elasticapm_client", [{"server_version": (7, 14, 0)}], indirect=True
 )  # unsampled transactions are dropped with server 8.0+
 def test_outcome_is_set_for_unsampled_transactions(django_elasticapm_client, client):
     with override_settings(

--- a/tests/instrumentation/transactions_store_tests.py
+++ b/tests/instrumentation/transactions_store_tests.py
@@ -343,7 +343,7 @@ def test_labels_dedot(elasticapm_client):
 
 
 @pytest.mark.parametrize(
-    "elasticapm_client", [{"server_version": (7, 14)}], indirect=True
+    "elasticapm_client", [{"server_version": (7, 14, 0)}], indirect=True
 )  # unsampled transactions are dropped with server 8.0+
 def test_dedot_is_not_run_when_unsampled(elasticapm_client):
     for sampled in (True, False):
@@ -425,7 +425,7 @@ def test_set_user_context_merge(elasticapm_client):
 
 
 @pytest.mark.parametrize(
-    "elasticapm_client", [{"server_version": (7, 14)}], indirect=True
+    "elasticapm_client", [{"server_version": (7, 14, 0)}], indirect=True
 )  # unsampled transactions are dropped with server 8.0+
 def test_callable_context_ignored_when_not_sampled(elasticapm_client):
     callable_data = mock.Mock()


### PR DESCRIPTION
## What does this pull request do?

Only send activation_method if server version is 8.7.1+

I also noticed that we could have issues with 3-length version tuples. So I normalized our check_server_version to make sure inputs are 3-length, to solve this issue:

```python
>>> (7, 15) >= (7, 15, 0)
False
```

## Related issues

Closes #1786 
