### PR TITLE
Optimize CI time

### DIFF
--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -19,6 +19,10 @@ jobs:
         include: ${{ fromJSON(inputs.include) }}
     steps:
       - uses: actions/checkout@v3
+      - id: image-name
+        run: |
+          IMAGE_NAME=${{ matrix.version }}
+          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v2
       - name: Build and push
         uses: docker/build-push-action@v4
@@ -27,6 +31,7 @@ jobs:
           cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
           load: true
           tags: apm-agent-python:${{ matrix.version }}
+          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -17,22 +17,10 @@ jobs:
       max-parallel: 5
       matrix:
         include: ${{ fromJSON(inputs.include) }}
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
-      - id: image-name
-        run: |
-          IMAGE_NAME=${{ matrix.version }}
-          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v2
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: tests
-          file: tests/Dockerfile
-          cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
-          load: true
-          tags: elasticobservability/apm-agent-python:${{ matrix.version }}
-          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
       matrix:
         include: ${{ fromJSON(inputs.include) }}
     env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -32,6 +32,7 @@ jobs:
           context: tests
           tags: apm-agent-python:${{ matrix.version }}
           cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
+          cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
           file: tests/Dockerfile
           load: true
           build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          file: tests/Dockerfile
           cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
           load: true
           tags: apm-agent-python:${{ matrix.version }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -17,8 +17,6 @@ jobs:
       max-parallel: 10
       matrix:
         include: ${{ fromJSON(inputs.include) }}
-    env:
-      DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
       - name: Run tests

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -21,24 +21,6 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
-
-#      - id: image-name
-#        run: |
-#          IMAGE_NAME=${{ matrix.version }}
-#          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
-#      - uses: docker/setup-buildx-action@v2
-#      - uses: docker/build-push-action@v2
-#        with:
-#          context: tests
-#          tags: apm-agent-python:${{ matrix.version }}
-#          cache-from: type=gha
-#          cache-to: type=gha,mode=max
-#          # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
-#          # cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
-#          file: tests/Dockerfile
-#          load: true
-#          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
-
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
+          load: true
+          tags: apm-agent-python:${{ matrix.version }}
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -30,9 +30,7 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           context: tests
-          tags: |
-            apm-agent-python:${{ matrix.version }}
-            elasticobservability/apm-agent-python:${{ matrix.version }}
+          tags: apm-agent-python:${{ matrix.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -31,8 +31,10 @@ jobs:
         with:
           context: tests
           tags: apm-agent-python:${{ matrix.version }}
-          cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
-          cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
+          # cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
           file: tests/Dockerfile
           load: true
           build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
+          context: tests
           file: tests/Dockerfile
           cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
           load: true

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -21,7 +21,21 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
-      - run: docker --version
+
+      - id: image-name
+        run: |
+          IMAGE_NAME=${{ matrix.version }}
+          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/build-push-action@v4
+        with:
+          context: tests
+          tags: apm-agent-python:${{ matrix.version }}
+          cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
+          file: tests/Dockerfile
+          load: true
+          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
+
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -22,22 +22,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - id: image-name
-        run: |
-          IMAGE_NAME=${{ matrix.version }}
-          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/build-push-action@v4
-        with:
-          context: tests
-          tags: apm-agent-python:${{ matrix.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
-          # cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
-          file: tests/Dockerfile
-          load: true
-          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
+#      - id: image-name
+#        run: |
+#          IMAGE_NAME=${{ matrix.version }}
+#          echo "image_name=${IMAGE_NAME/-/:}" >> "$GITHUB_OUTPUT"
+#      - uses: docker/setup-buildx-action@v2
+#      - uses: docker/build-push-action@v2
+#        with:
+#          context: tests
+#          tags: apm-agent-python:${{ matrix.version }}
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#          # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}
+#          # cache-to: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }},mode=max
+#          file: tests/Dockerfile
+#          load: true
+#          build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
 
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -30,7 +30,9 @@ jobs:
       - uses: docker/build-push-action@v4
         with:
           context: tests
-          tags: apm-agent-python:${{ matrix.version }}
+          tags: |
+            apm-agent-python:${{ matrix.version }}
+            elasticobservability/apm-agent-python:${{ matrix.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # cache-from: type=registry,ref=elasticobservability/apm-agent-python-testing:${{ matrix.version }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -19,6 +19,7 @@ jobs:
         include: ${{ fromJSON(inputs.include) }}
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -31,7 +31,7 @@ jobs:
           file: tests/Dockerfile
           cache-from: elasticobservability/apm-agent-python:${{ matrix.version }}
           load: true
-          tags: apm-agent-python:${{ matrix.version }}
+          tags: elasticobservability/apm-agent-python:${{ matrix.version }}
           build-args: PYTHON_IMAGE=${{ steps.image-name.outputs.image_name }}
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -21,6 +21,7 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
+      - run: docker --version
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,24 +16,6 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - run: >-
-          DOCKER_BUILDKIT=1 docker buildx build
-          --progress=plain
-          --cache-from="elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
-          --cache-to=type=inline
-          --file "tests/Dockerfile"
-          --build-arg PYTHON_IMAGE="${PYTHON_VERSION/-/:}"
-          --tag "elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
-          --load
-          "tests"
-        env:
-          PYTHON_VERSION: python-3.6
   create-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           DOCKER_BUILDKIT=1 docker buildx build
           --progress=plain
           --cache-from="elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
+          --cache-to=type=inline
           --file "tests/Dockerfile"
           --build-arg PYTHON_IMAGE="${PYTHON_VERSION/-/:}"
           --tag "elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - run: >-
           DOCKER_BUILDKIT=1 docker buildx build
           --progress=plain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
           --file "tests/Dockerfile"
           --build-arg PYTHON_IMAGE="${PYTHON_VERSION/-/:}"
           --tag "elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
+          --load
           "tests"
         env:
           PYTHON_VERSION: python-3.6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - run: >-
           DOCKER_BUILDKIT=1 docker buildx build
           --progress=plain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,19 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: >-
+          DOCKER_BUILDKIT=1 docker buildx build
+          --progress=plain
+          --cache-from="elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
+          --file "tests/Dockerfile"
+          --build-arg PYTHON_IMAGE="${PYTHON_VERSION/-/:}"
+          --tag "elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}"
+          "tests"
+        env:
+          PYTHON_VERSION: python-3.6
   create-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - zookeeper
 
   run_tests:
-    image: apm-agent-python:${PYTHON_VERSION}
+    image: elasticobservability/apm-agent-python:${PYTHON_VERSION}
     environment:
       ES_8_URL: 'http://elasticsearch8:9200'
       ES_7_URL: 'http://elasticsearch7:9200'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - zookeeper
 
   run_tests:
-    image: elasticobservability/apm-agent-python:${PYTHON_VERSION}
+    image: apm-agent-python:${PYTHON_VERSION}
     environment:
       ES_8_URL: 'http://elasticsearch8:9200'
       ES_7_URL: 'http://elasticsearch7:9200'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - zookeeper
 
   run_tests:
-    image: elasticobservability/apm-agent-python:${PYTHON_VERSION}
+    image: elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}
     environment:
       ES_8_URL: 'http://elasticsearch8:9200'
       ES_7_URL: 'http://elasticsearch7:9200'

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,12 +47,14 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
+
 DOCKER_BUILDKIT=1 docker build \
+  --progress=plain \
   --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
-  --build-arg BUILDKIT_INLINE_CACHE=1 \
   --build-arg PYTHON_IMAGE="${1/-/:}" \
-  -t "apm-agent-python:${1}" \
+  --tag "apm-agent-python-testing:${1}"
   .
+
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -48,12 +48,14 @@ fi
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
 
-DOCKER_BUILDKIT=1 docker buildx build \
-  --progress=plain \
-  --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
-  --build-arg PYTHON_IMAGE="${1/-/:}" \
-  --tag "apm-agent-python:${1}" \
-  .
+if ! ${CI}; then
+  DOCKER_BUILDKIT=1 docker build \
+    --progress=plain \
+    --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
+    --build-arg PYTHON_IMAGE="${1/-/:}" \
+    --tag "apm-agent-python:${1}" \
+    .
+fi
 
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-DOCKER_BUILDKIT=1 docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+DOCKER_BUILDKIT=1 docker build --cache-from=elasticobservability/apm-agent-python-testing:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+DOCKER_BUILDKIT=1 docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -48,9 +48,9 @@ fi
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
 
-DOCKER_BUILDKIT=1 docker build \
+DOCKER_BUILDKIT=1 docker build buildx \
   --progress=plain \
-  --cache-from="type=registry,ref=elasticobservability/apm-agent-python-testing:${1}" \
+  --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg PYTHON_IMAGE="${1/-/:}" \
   --tag "apm-agent-python:${1}" \
   .

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -48,7 +48,7 @@ fi
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
 
-DOCKER_BUILDKIT=1 docker build buildx \
+DOCKER_BUILDKIT=1 docker buildx build \
   --progress=plain \
   --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg PYTHON_IMAGE="${1/-/:}" \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -52,7 +52,7 @@ DOCKER_BUILDKIT=1 docker build \
   --progress=plain \
   --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg PYTHON_IMAGE="${1/-/:}" \
-  --tag "apm-agent-python-testing:${1}" \
+  --tag "apm-agent-python:${1}" \
   .
 
 PYTHON_VERSION=${1} docker-compose run \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -52,7 +52,7 @@ DOCKER_BUILDKIT=1 docker build \
   --progress=plain \
   --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg PYTHON_IMAGE="${1/-/:}" \
-  --tag "apm-agent-python-testing:${1}"
+  --tag "apm-agent-python-testing:${1}" \
   .
 
 PYTHON_VERSION=${1} docker-compose run \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-
+docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t elasticobservability/apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -48,11 +48,11 @@ fi
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
 DOCKER_BUILDKIT=1 docker build \
-  --cache-from=elasticobservability/apm-agent-python-testing:${1} \
+  --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg BUILDKIT_INLINE_CACHE=1 \
-  --build-arg PYTHON_IMAGE=${1/-/:} \
-  -t apm-agent-python:${1} \
-  . # replace - with : to get the correct docker image
+  --build-arg PYTHON_IMAGE="${1/-/:}" \
+  -t "apm-agent-python:${1}" \
+  .
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,12 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-DOCKER_BUILDKIT=1 docker build --cache-from=elasticobservability/apm-agent-python-testing:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+DOCKER_BUILDKIT=1 docker build \
+  --cache-from=elasticobservability/apm-agent-python-testing:${1} \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  --build-arg PYTHON_IMAGE=${1/-/:} \
+  -t apm-agent-python:${1} \
+  . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -50,7 +50,7 @@ fi
 
 DOCKER_BUILDKIT=1 docker build \
   --progress=plain \
-  --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
+  --cache-from="type=registry,ref=elasticobservability/apm-agent-python-testing:${1}" \
   --build-arg PYTHON_IMAGE="${1/-/:}" \
   --tag "apm-agent-python:${1}" \
   .

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-docker build --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
+
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -47,7 +47,7 @@ fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
-docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t elasticobservability/apm-agent-python:${1} . # replace - with : to get the correct docker image
+docker build --cache-from=elasticobservability/apm-agent-python:${1} --build-arg PYTHON_IMAGE=${1/-/:} -t apm-agent-python:${1} . # replace - with : to get the correct docker image
 PYTHON_VERSION=${1} docker-compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \


### PR DESCRIPTION
## What does this pull request do?

~Adds the `--cache-from` option.~
~This way the build time will be shorter. If there are changes in the Dockerfile, it will still be built utilising the cache.~
~Will only work after https://github.com/elastic/apm-pipeline-library/pull/2174 is merged.~

Use daily built public docker image instead of building on every run.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

- depends on https://github.com/elastic/apm-pipeline-library/pull/2174