### PR TITLE
combine coverage data and upload a html report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,3 +140,42 @@ jobs:
       - windows
     steps:
       - run: test $(echo '${{ toJSON(needs) }}' | jq -s 'map(.[].result) | all(.=="success")') = 'true'
+
+  coverage:
+    name: Combine & check coverage.
+    needs: all
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          # Use latest Python, so it understands all syntax.
+          python-version: 3.11
+
+      - run: python -Im pip install --upgrade coverage[toml]
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage-reports
+
+      - name: Combine coverage & fail if it's <84%.
+        run: |
+          python -Im coverage combine
+          python -Im coverage html --skip-covered --skip-empty
+
+          # Report and write to summary.
+          python -Im coverage report | sed 's/^/    /' >> $GITHUB_STEP_SUMMARY
+
+          # Report again and fail if under 84%.
+          python -Im coverage report --fail-under=84
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-coverage-report
+          path: htmlcov
+      - uses: geekyeggo/delete-artifact@v2
+        with:
+            name: coverage-reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,6 @@ jobs:
         with:
           name: html-coverage-report
           path: htmlcov
-      - uses: geekyeggo/delete-artifact@v2
+      - uses: geekyeggo/delete-artifact@54ab544f12cdb7b71613a16a2b5a37a9ade990af
         with:
             name: coverage-reports

--- a/setup.cfg
+++ b/setup.cfg
@@ -186,3 +186,4 @@ source =
     ./
     /app/
     C:\Users\jenkins\workspace\*\src\github.com\elastic\apm-agent-python
+    D:\a\apm-agent-python\apm-agent-python


### PR DESCRIPTION
## What does this pull request do?

So far, we generate coverage data for every step of the build matrix. To be useful, these coverage files have to be combined and reported on.

As an added benefit, we can then delete the large coverage files and only keep the relatively small HTML report.


