### PR TITLE
remove print_trace option in TransportException

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -58,6 +58,7 @@ run agents both with and without this fix (for same or different languages), the
 same S3-buckets can appear twice in the service map (with and without
 s3-prefix).
 * Fix instrumentation to not bubble up exceptions during instrumentation {pull}1791[#1791]
+* Fix HTTP transport to not print useless and confusing stack trace {pull}1809[#1809]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -334,7 +334,7 @@ class Transport(ThreadManager):
         Failure handler called by the transport on send failure
         """
         message = str(exception)
-        logger.error("Failed to submit message: %r", message, exc_info=getattr(exception, "print_trace", True))
+        logger.error("Failed to submit message: %r", message, exc_info=False)
         self.state.set_fail()
 
     def handle_fork(self) -> None:

--- a/elasticapm/transport/exceptions.py
+++ b/elasticapm/transport/exceptions.py
@@ -33,7 +33,6 @@
 
 
 class TransportException(Exception):
-    def __init__(self, message, data=None, print_trace=True):
+    def __init__(self, message, data=None):
         super(TransportException, self).__init__(message)
         self.data = data
-        self.print_trace = print_trace

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -95,26 +95,22 @@ class Transport(HTTPTransportBase):
                 )
                 logger.debug("Sent request, url=%s size=%.2fkb status=%s", url, len(data) / 1024.0, response.status)
             except Exception as e:
-                print_trace = True
                 if isinstance(e, MaxRetryError) and isinstance(e.reason, TimeoutError):
                     message = "Connection to APM Server timed out " "(url: %s, timeout: %s seconds)" % (
                         self._url,
                         self._timeout,
                     )
-                    print_trace = False
                 else:
                     message = "Unable to reach APM Server: %s (url: %s)" % (e, self._url)
-                raise TransportException(message, data, print_trace=print_trace)
+                raise TransportException(message, data)
             body = response.read()
             if response.status >= 400:
                 if response.status == 429:  # rate-limited
                     message = "Temporarily rate limited: "
-                    print_trace = False
                 else:
                     message = "HTTP %s: " % response.status
-                    print_trace = True
                 message += body.decode("utf8", errors="replace")[:10000]
-                raise TransportException(message, data, print_trace=print_trace)
+                raise TransportException(message, data)
             return response.headers.get("Location")
         finally:
             if response:


### PR DESCRIPTION
## What does this pull request do?

The logging of the stack trace can be confusing, and does not add anything interesting that would help while debugging, as the stacktrace is always the same.


## Related issues

Closes #ISSUE
