### PR TITLE
Pin urllib3 to <2.0 to get tests passing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    urllib3
+    urllib3<2.0
     certifi
     wrapt>=1.14.1
 test_suite=tests
@@ -71,7 +71,7 @@ tests_require =
     py-cpuinfo==3.3.0
     statistics==1.0.3.5
 
-    urllib3
+    urllib3<2.0
     certifi
     Jinja2
     Logbook

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -18,7 +18,7 @@ jsonschema==3.2.0 ; python_version == '3.6'
 jsonschema==4.17.3 ; python_version > '3.6'
 
 
-urllib3
+urllib3<2.0
 certifi
 Logbook
 mock


### PR DESCRIPTION
urllib3 v2.0 came out during pycon, and appears to be making our windows tests hang, and at least one failure in linux tests as well.

## Related issues

Ref https://github.com/elastic/apm-agent-python/issues/1816
