### PR TITLE
Update partial transaction failure handling and add a test

### DIFF
--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -34,6 +34,7 @@ import functools
 import json
 import os
 import platform
+import re
 import time
 import urllib
 import warnings
@@ -444,7 +445,7 @@ class _lambda_transaction(object):
                     },
                 )
             except Exception as e:
-                if "HTTP 404" in str(e):
+                if re.match(r"HTTP [4,5]\d\d", str(e)):
                     REGISTER_PARTIAL_TRANSACTIONS = False
                     logger.info(
                         "APM Lambda Extension does not support partial transactions. "


### PR DESCRIPTION
## What does this pull request do?

Updates the failure behavior for partial transaction registering to match the NodeJS agent, as described [here](https://github.com/elastic/apm/issues/753#issuecomment-1527944886)

## Related issues

Ref https://github.com/elastic/apm/issues/753
Ref #1784 
