### PR TITLE
fix: flash buffer based on it's own size, not queue size

### DIFF
--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -168,9 +168,9 @@ class Transport(ThreadManager):
                     max_flush_time,
                 )
                 flush = True
-            elif self._max_buffer_size and queue_size > self._max_buffer_size:
+            elif self._max_buffer_size and buffer.size > self._max_buffer_size:
                 logger.debug(
-                    "flushing since queue size %d bytes > max_queue_size %d bytes", queue_size, self._max_buffer_size
+                    "flushing since buffer size %d bytes > max_queue_size %d bytes", buffer.size, self._max_buffer_size
                 )
                 flush = True
             if flush:


### PR DESCRIPTION
## What does this pull request do?

issue: https://github.com/elastic/apm-agent-python/issues/1819

## Related issues

Closes #1819
