### PR TITLE
Update the tests_require block to match reqs-base.txt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,39 +40,6 @@ install_requires =
     certifi
     wrapt>=1.14.1
 test_suite=tests
-tests_require =
-    pytest==7.0.1 ; python_version == '3.6'
-    pytest==7.3.0 ; python_version > '3.6'
-    pytest-random-order==1.1.0
-    pytest-django==4.4.0
-    coverage==6.2 ; python_version == '3.6'
-    coverage==7.2.3 ; python_version > '3.6'
-    pytest-cov==4.0.0
-    pytest-localserver==0.5.0
-    pytest-mock==3.6.1 ; python_version == '3.6'
-    pytest-mock==3.10.0 ; python_version > '3.6'
-    pytest-benchmark==3.4.1 ; python_version == '3.6'
-    pytest-benchmark==4.0.0 ; python_version > '3.6'
-    pytest-bdd==5.0.0 ; python_version == '3.6'
-    pytest-bdd==6.1.1 ; python_version > '3.6'
-    pytest-rerunfailures==10.2 ; python_version == '3.6'
-    pytest-rerunfailures==11.1.2 ; python_version > '3.6'
-    jsonschema==3.2.0 ; python_version == '3.6'
-    jsonschema==4.17.3 ; python_version > '3.6'
-
-
-    urllib3
-    certifi
-    Logbook
-    mock
-    pytz
-    ecs_logging
-    structlog
-    wrapt>=1.14.1
-
-    pytest-asyncio==0.21.0 ; python_version >= '3.7'
-    asynctest==0.13.0 ; python_version >= '3.7'
-    typing_extensions!=3.10.0.1 ; python_version >= '3.10' # see https://github.com/python/typing/issues/865
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,64 +41,38 @@ install_requires =
     wrapt>=1.14.1
 test_suite=tests
 tests_require =
-    pytest==6.2.5
+    pytest==7.0.1 ; python_version == '3.6'
+    pytest==7.3.0 ; python_version > '3.6'
     pytest-random-order==1.1.0
-    py==1.8.1
-    more-itertools==4.1.0
-    pluggy==0.13.1
-    pytest-django==3.8.0
-    atomicwrites==1.1.5
-    coverage==5.0.3
-    pytest-cov==2.8.1
+    pytest-django==4.4.0
+    coverage==6.2 ; python_version == '3.6'
+    coverage==7.2.3 ; python_version > '3.6'
+    pytest-cov==4.0.0
     pytest-localserver==0.5.0
-    pytest-mock==2.0.0
-    pytest-benchmark==3.2.2
-    jsonschema==2.6.0
-    configparser==4.0.2
-    contextlib2==0.6.0
-    importlib-metadata==1.5.0
-    packaging==20.1
-    Mako==1.1.0
-    glob2==0.7
-    parse==1.15.0
-    parse-type==0.5.2
-    pytest-bdd==3.2.1
-    pytest-rerunfailures==8.0
+    pytest-mock==3.6.1 ; python_version == '3.6'
+    pytest-mock==3.10.0 ; python_version > '3.6'
+    pytest-benchmark==3.4.1 ; python_version == '3.6'
+    pytest-benchmark==4.0.0 ; python_version > '3.6'
+    pytest-bdd==5.0.0 ; python_version == '3.6'
+    pytest-bdd==6.1.1 ; python_version > '3.6'
+    pytest-rerunfailures==10.2 ; python_version == '3.6'
+    pytest-rerunfailures==11.1.2 ; python_version > '3.6'
+    jsonschema==3.2.0 ; python_version == '3.6'
+    jsonschema==4.17.3 ; python_version > '3.6'
 
-
-    docutils==0.14
-    pathlib==1.0.1
-    py-cpuinfo==3.3.0
-    statistics==1.0.3.5
 
     urllib3
     certifi
-    Jinja2
     Logbook
-    MarkupSafe
-    WebOb
-    Werkzeug
-    anyjson
-    argparse
-    blinker>=1.1
-    greenlet
-    itsdangerous
     mock
-    msgpack-python
-    pep8
     pytz
-    opentelemetry-api
-    opentelemetry-sdk
+    ecs_logging
+    structlog
+    wrapt>=1.14.1
 
-    pytest-asyncio==0.10.0 ; python_version >= '3.7'
-    asynctest==0.12.2 ; python_version >= '3.7'
-    aiohttp ; python_version >= '3.7'
-    tornado ; python_version >= '3.7'
-    starlette ; python_version >= '3.7'
-    pytest-asyncio ; python_version >= '3.7'
-    pytest-mock ; python_version >= '3.7'
-    httpx ; python_version >= '3.6'
-    sanic ; python_version >= '3.7'
+    pytest-asyncio==0.21.0 ; python_version >= '3.7'
+    asynctest==0.13.0 ; python_version >= '3.7'
+    typing_extensions!=3.10.0.1 ; python_version >= '3.10' # see https://github.com/python/typing/issues/865
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
## What does this pull request do?

@sethmlarson ran into issues getting the tests running using the `tests_require` block in setup.cfg. It's way out of date, this PR just matches it to `reqs-base.txt` for now. I even took out the framework extras for simplicity.

At some point we need to figure out how to automate this. Or just drop the test_requires block altogether? If it's out of date, it's useless.
