### PR TITLE
Fix tests for urllib3 v2.0.1+

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 * Add S3 bucket and key name to OTel attributes {pull}1790[#1790]
 * Implement partial transaction support in AWS lambda {pull}1784[#1784]
 * Add instrumentation for redis.asyncio {pull}1807[#1807]
+* Add support for urllib3 v2.0.1+ {pull}1822[#1822]
 
 [float]
 ===== Bug fixes

--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -61,7 +61,12 @@ def update_headers(args, kwargs, instance, transaction, trace_parent):
     :param trace_parent: the TraceParent object
     :return: an (args, kwargs) tuple
     """
-    if len(args) >= 4 and args[3]:
+    from urllib3._version import __version__ as urllib3_version
+
+    if urllib3_version.startswith("2") and len(args) >= 5 and args[4]:
+        headers = args[4].copy()
+        args = tuple(itertools.chain((args[:4]), (headers,), args[5:]))
+    elif len(args) >= 4 and args[3]:
         headers = args[3].copy()
         args = tuple(itertools.chain((args[:3]), (headers,), args[4:]))
     elif "headers" in kwargs and kwargs["headers"]:

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 install_requires =
-    urllib3<2.0
+    urllib3!=2.0.0,<3.0.0
     certifi
     wrapt>=1.14.1
 test_suite=tests
@@ -71,7 +71,7 @@ tests_require =
     py-cpuinfo==3.3.0
     statistics==1.0.3.5
 
-    urllib3<2.0
+    urllib3!=2.0.0,<3.0.0
     certifi
     Jinja2
     Logbook

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -530,7 +530,7 @@ def test_check_server_version(elasticapm_client):
     indirect=["elasticapm_client"],
 )
 def test_user_agent(elasticapm_client, expected):
-    assert elasticapm_client.get_user_agent() == "apm-agent-python/unknown (myapp{})".format(expected)
+    assert elasticapm_client.get_user_agent() == "apm-agent-python/{} (myapp{})".format(elasticapm.VERSION, expected)
 
 
 def test_label_without_client():

--- a/tests/client/exception_tests.py
+++ b/tests/client/exception_tests.py
@@ -122,7 +122,12 @@ def test_message_event(elasticapm_client):
     assert "stacktrace" in event["log"]
     # check that only frames from `tests` module are not marked as library frames
     for frame in event["log"]["stacktrace"]:
-        assert frame["library_frame"] or frame["module"].startswith(("tests", "__main__")), (
+        # vscode's python extension runs tests using libraries from the
+        # extension's dir, which results in false positives here. This is where
+        # runpy, _pydevd, and debugpy come from.
+        assert frame["library_frame"] or frame["module"].startswith(
+            ("tests", "__main__", "runpy", "_pydevd", "debugpy")
+        ), (
             frame["module"],
             frame["abs_path"],
         )

--- a/tests/instrumentation/urllib3_tests.py
+++ b/tests/instrumentation/urllib3_tests.py
@@ -31,6 +31,7 @@ import urllib.parse
 
 import pytest
 import urllib3
+from urllib3._version import __version__ as urllib3_version
 
 from elasticapm.conf import constants
 from elasticapm.conf.constants import SPAN, TRANSACTION
@@ -273,7 +274,10 @@ def test_instance_headers_are_respected(
         headers={"instance": "true"} if instance_headers else None,
     )
     if header_arg:
-        args = ("GET", url, None, {"args": "true"})
+        if urllib3_version.startswith("2"):
+            args = ("GET", url, None, None, {"args": "true"})
+        else:
+            args = ("GET", url, None, {"args": "true"})
     else:
         args = ("GET", url)
     if header_kwarg:

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -18,7 +18,7 @@ jsonschema==3.2.0 ; python_version == '3.6'
 jsonschema==4.17.3 ; python_version > '3.6'
 
 
-urllib3<2.0
+urllib3!=2.0.0,<3.0.0
 certifi
 Logbook
 mock


### PR DESCRIPTION
## What does this pull request do?

urllib3 v2.0+ introduced a change to args ordering that broke some tests. This fixes those tests (plus a stack frame test that was failing under a new version of VSCode's python extension).

The hangs that were breaking test runs for urllib3 v2.0.0 were due to a regression that has been [fixed](https://github.com/urllib3/urllib3/pull/2992) in v2.0.1. Big thanks to @pquentin, @sethmlarson, and @graingert for help with this!

## Related issues

Closes #1816 