### PR TITLE
Fix broken links from APM-Server 10874

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -72,7 +72,7 @@ except ValueError:
  * `exc_info`: A `(type, value, traceback)` tuple as returned by https://docs.python.org/3/library/sys.html#sys.exc_info[`sys.exc_info()`]. If not provided, it will be captured automatically.
  * `date`: A `datetime.datetime` object representing the occurrence time of the error. If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the
-    {apm-guide-ref}/events-api.html#events-api-errors[Context] schema definition.
+    {apm-guide-ref}/events-api.html[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
  * `handled`: A boolean to indicate if this exception was handled or not.
 
@@ -112,7 +112,7 @@ client.capture_message(param_message={
  * `date`: A `datetime.datetime` object representing the occurrence time of the error.
    If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the
-    {apm-guide-ref}/events-api.html#events-api-errors[Context] schema definition.
+    {apm-guide-ref}/events-api.html[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
 
 Returns the id of the message as a string.

--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -72,7 +72,7 @@ except ValueError:
  * `exc_info`: A `(type, value, traceback)` tuple as returned by https://docs.python.org/3/library/sys.html#sys.exc_info[`sys.exc_info()`]. If not provided, it will be captured automatically.
  * `date`: A `datetime.datetime` object representing the occurrence time of the error. If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the
-    {apm-guide-ref}/events-api.html[Context] schema definition.
+    {apm-guide-ref}/api-error.html[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
  * `handled`: A boolean to indicate if this exception was handled or not.
 
@@ -112,7 +112,7 @@ client.capture_message(param_message={
  * `date`: A `datetime.datetime` object representing the occurrence time of the error.
    If left empty, it defaults to `datetime.datetime.utcnow()`.
  * `context`: A dictionary with contextual information. This dictionary must follow the
-    {apm-guide-ref}/events-api.html[Context] schema definition.
+    {apm-guide-ref}/api-error.html[Context] schema definition.
  * `custom`: A dictionary of custom data you want to attach to the event.
 
 Returns the id of the message as a string.


### PR DESCRIPTION
This is an attempt to fix some broken links in the current docs build:

```
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/python/5.x/api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/events-api.html#events-api-errors
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/python/6.x/api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/events-api.html#events-api-errors
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/python/current/api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/events-api.html#events-api-errors
08:57:42 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/python/master/api.html contains broken links to:
08:57:42 INFO:build_docs:   - en/apm/guide/8.8/events-api.html#events-api-errors
```

The change would need to be backported from `main` into `6.x` and `5.x`.
