### PR TITLE
Add ecs_logging to dependencies

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -46,6 +46,7 @@ endif::[]
 * Add instrumentation for redis.asyncio {pull}1807[#1807]
 * Add support for urllib3 v2.0.1+ {pull}1822[#1822]
 * Add `service.environment` to log correlation {pull}1833[#1833]
+* Add `ecs_logging` as a dependency {pull}1840[#1840]
 
 [float]
 ===== Bug fixes

--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -181,7 +181,9 @@ Then, you could use a grok pattern like this (for the
 [[log-reformatting]]
 === Log reformatting (experimental)
 
-The agent can automatically reformat application to ECS format when the application includes the `ecs-logging-python` library in its dependencies.
+Starting in version 6.16.0, the agent can automatically reformat application
+logs to ECS format with no changes to dependencies. Prior versions must install
+the `ecs_logging` dependency.
 
 Log reformatting is controlled by the <<config-log_ecs_reformatting, `log_ecs_reformatting`>> configuration option, and is disabled by default.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     urllib3!=2.0.0,<3.0.0
     certifi
     wrapt>=1.14.1
+    ecs_logging
 test_suite=tests
 
 [options.entry_points]


### PR DESCRIPTION
## What does this pull request do?

Adds [`ecs_logging`](https://github.com/elastic/ecs-logging-python) as a dependency, for easier log correlation setup.

## Related issues

Ref #1837 
