### PR TITLE
[doc] add missing 6.x release notes link

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -5,6 +5,7 @@
 
 All notable changes to this project will be documented here.
 
+* <<release-notes-6.x>>
 * <<release-notes-5.x>>
 * <<release-notes-4.x>>
 * <<release-notes-3.x>>


### PR DESCRIPTION
## What does this pull request do?

The [release notes](https://www.elastic.co/guide/en/apm/agent/python/current/release-notes.html) page seem to have a missing link to 6.x versions.

The 6.x versions are visible in the menu on the left

![Screenshot from 2023-05-31 11-37-24](https://github.com/elastic/apm-agent-python/assets/763082/f7f9c1f9-d6e9-4bb2-9554-7e9fbb228e0f)


But are currently missing in the page body

![Screenshot from 2023-05-31 11-37-32](https://github.com/elastic/apm-agent-python/assets/763082/7b410ca0-b522-4f08-811c-41c9dd23ddd7)
