### PR TITLE
Pin urllib3==1.26.16 for AWS Lambda compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
       interval: "weekly"
     reviewers:
       - "elastic/apm-agent-python"
+    ignore:
+      - dependency-name: "urllib3" # ignore until lambda runtimes use OpenSSL 1.1.1+
+        versions: [">=2.0.0"]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix compatibility issue with older versions of OpenSSL in lambda runtimes {pull}1847[#1847]
+* Add `latest` tag to docker images {pull}1848[#1848]
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,18 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+[float]
+===== Bug fixes
+
+* Fix compatibility issue with older versions of OpenSSL in lambda runtimes {pull}1847[#1847]
+
 [[release-notes-6.x]]
 === Python Agent version 6.x
 

--- a/dev-utils/requirements.txt
+++ b/dev-utils/requirements.txt
@@ -1,4 +1,4 @@
 # These are the pinned requirements for the lambda layer/docker image
 certifi==2023.5.7
-urllib3==2.0.2
+urllib3==1.26.16
 wrapt==1.15.0


### PR DESCRIPTION
## What does this pull request do?

When testing a lambda container image against our new docker image, I found that the 3.8 base images they provide are using an older version of OpenSSL (`1.0.2k-fips`). `urllib3` v2.0 requires OpenSSL 1.1.1+. This PR downgrades urllib3 in our lambda layer and docker image for maximum compatibility.
