### PR TITLE
add pkg-config to test image

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -198,3 +198,6 @@ exclude:
     FRAMEWORK: grpc-1.24
   - VERSION: python-3.11
     FRAMEWORK: grpc-1.24
+  # temporary, see https://github.com/elastic/apm-agent-python/pull/1863
+  - VERSION: python-3.11
+    FRAMEWORK: mysqlclient-newest

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,9 +7,10 @@ RUN apt-get -qq update && apt-get -qq -y --no-install-recommends install \
     curl \
     gnupg2 \
     libmariadb-dev \
+    pkg-config \
     libpq-dev \
     make \
-    netcat \
+    netcat-traditional \
     odbc-postgresql \
     unixodbc-dev \
     freetds-dev \


### PR DESCRIPTION
newest release of mysqlclient requires pkg-config to build.

I also had to switch netcat to netcat-traditional, as the netcat package isn't available in the Python 3.11 base image
