### PR TITLE
Re-enable the mysqlclient-newest 3.11 tests

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -198,6 +198,3 @@ exclude:
     FRAMEWORK: grpc-1.24
   - VERSION: python-3.11
     FRAMEWORK: grpc-1.24
-  # temporary, see https://github.com/elastic/apm-agent-python/pull/1863
-  - VERSION: python-3.11
-    FRAMEWORK: mysqlclient-newest


### PR DESCRIPTION
I assume that the docker images are built on the nightly job so I'm guessing this won't be green until tomorrow.

## Related issues

https://github.com/elastic/apm-agent-python/pull/1863
