### PR TITLE
added include_process_args config option

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1258,6 +1258,17 @@ views.
 If set to `True`, the agent will intercept the default `sys.excepthook`, which
 allows the agent to collect all uncaught exceptions.
 
+[float]
+[[config-include-process-args]]
+==== `include_process_args`
+
+[options="header"]
+|============
+| Environment                          | Django/Flask           | Default
+| `ELASTIC_APM_INCLUDE_PROCESS_ARGS`   | `INCLUDE_PROCESS_ARGS` | `False`
+|============
+
+Whether each transaction should have the process arguments attached. Disabled by default to save disk space.
 
 [float]
 [[config-django-specific]]

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -370,12 +370,14 @@ class Client(object):
         return result
 
     def get_process_info(self):
-        return {
+        result = {
             "pid": os.getpid(),
             "ppid": os.getppid() if hasattr(os, "getppid") else None,
-            "argv": sys.argv,
             "title": None,  # Note: if we implement this, the value needs to be wrapped with keyword_field
         }
+        if self.config.include_process_args:
+            result["argv"] = sys.argv
+        return result
 
     def get_system_info(self):
         system_data = {

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -691,6 +691,7 @@ class Config(_ConfigBase):
         ],
         default=TRACE_CONTINUATION_STRATEGY.CONTINUE,
     )
+    include_process_args = _BoolConfigValue("INCLUDE_PROCESS_ARGS", default=False)
 
     @property
     def is_recording(self):

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -75,14 +75,17 @@ def test_service_info_node_name(elasticapm_client):
 
 
 def test_process_info(elasticapm_client):
-    with mock.patch.object(sys, "argv", ["a", "b", "c"]):
-        process_info = elasticapm_client.get_process_info()
+    process_info = elasticapm_client.get_process_info()
     assert process_info["pid"] == os.getpid()
     if hasattr(os, "getppid"):
         assert process_info["ppid"] == os.getppid()
     else:
         # Windows + Python 2.7
         assert process_info["ppid"] is None
+    assert "argv" not in process_info
+    elasticapm_client.config.update("1", include_process_args=True)
+    with mock.patch.object(sys, "argv", ["a", "b", "c"]):
+        process_info = elasticapm_client.get_process_info()
     assert process_info["argv"] == ["a", "b", "c"]
 
 


### PR DESCRIPTION
## What does this pull request do?

Introduce a config option to disable capturing of process args, and disable it by default.

## Related issues

Closes #1860
