### PR TITLE
Fix lost db context in elasticsearch instrumentation + Elastic Cloud

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,9 +38,10 @@ endif::[]
 
 * Add support for grpc aio server interceptor {pull}1870[#1870]
 
-//[float]
-//===== Bug fixes
-//
+[float]
+===== Bug fixes
+
+* Fix a bug in the Elasticsearch client instrumentation which was causing loss of database context (including statement) when interacting with Elastic Cloud {pull}1878[#1878]
 
 
 [[release-notes-6.x]]

--- a/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/asyncio/elasticsearch.py
@@ -63,10 +63,14 @@ class ElasticSearchAsyncConnection(ElasticsearchConnectionInstrumentation, Async
         result = await wrapped(*args, **kwargs)
         if hasattr(result, "meta"):  # elasticsearch-py 8.x+
             status_code = result.meta.status
+            cluster = result.meta.headers.get("x-found-handling-cluster")
         else:
             status_code = result[0]
+            cluster = result[1].get("x-found-handling-cluster")
 
-        span.context["http"] = {"status_code": status_code}
+        span.update_context("http", {"status_code": status_code})
+        if cluster:
+            span.update_context("db", {"instance": cluster})
 
         return result
 

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -75,9 +75,9 @@ class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
         else:
             status_code = result[0]
             cluster = result[1].get("x-found-handling-cluster")
-        span.context["http"] = {"status_code": status_code}
+        span.update_context("http", {"status_code": status_code})
         if cluster:
-            span.context["db"] = {"instance": cluster}
+            span.update_context("db", {"instance": cluster})
 
         return result
 


### PR DESCRIPTION
## What does this pull request do?

When cluster information was added to elasticsearch db context, it was overwriting all other `"db"` context. This fixes that issue, while finishing up #1673's work by adding `instance` to the async elasticsearch instrumentation.

I also switched to `update_context()` for the `http` context right above the bug, just for consistency. 

## Related issues

Ref https://github.com/elastic/apm-agent-python/pull/1673
