### PR TITLE
updatecli: add container_metadata_discovery

### DIFF
--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -24,10 +24,10 @@ sources:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
 
-  cgroup_parsing.json:
+  container_metadata_discovery.json:
     kind: file
     spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/cgroup_parsing.json
+      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     kind: file
     spec:
@@ -71,13 +71,13 @@ actions:
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
 targets:
-  cgroup_parsing.json:
-    name: cgroup_parsing.json
+  container_metadata_discovery.json:
+    name: container_metadata_discovery.json
     scmid: default
-    sourceid: cgroup_parsing.json
+    sourceid: container_metadata_discovery.json
     kind: file
     spec:
-      file: tests/upstream/json-specs/cgroup_parsing.json
+      file: tests/upstream/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     name: service_resource_inference.json
     scmid: default


### PR DESCRIPTION
## What does this pull request do?

Update the `updatecli` pipeline for the automation regarding the json specs. 

## Why is it important?

`container_metadata_discovery.json` is a new file while `cgroup_parsing.json` has been removed. 

Otherwise the automation fails

<img width="1238" alt="image" src="https://github.com/elastic/apm-agent-python/assets/2871786/e50f9a9a-48dc-4a19-8e01-b2323e3e34ff">

https://github.com/elastic/apm-agent-python/actions/runs/5839738941/job/15838229833#step:3:2140

## Related issues

- Relates https://github.com/elastic/apm/pull/807


## Questions

`tests/upstream/json-specs/cgroup_parsing.json` is not used, shall the tests be changed to accommodate the new specs?
