### PR TITLE
Report detected/configured_hostname and fix tests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,19 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+[float]
+===== Features
+
+* Collect the `configured_hostname` and `detected_hostname` separately, and switch to FQDN for the `detected_hostname`. {pull}1891[#1891]
+
+//[float]
+//===== Bug fixes
+//
+
 
 
 [[release-notes-6.x]]

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -387,6 +387,8 @@ class Client(object):
         }
         if self.config.hostname:
             system_data["configured_hostname"] = keyword_field(self.config.hostname)
+        if not self.check_server_version(gte=(7, 4, 0)):
+            system_data["hostname"] = system_data.get("configured_hostname", system_data["detected_hostname"])
         system_data.update(cgroup.get_cgroup_container_metadata())
         pod_name = os.environ.get("KUBERNETES_POD_NAME") or keyword_field(
             self.config.hostname or self.config.detected_hostname

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -391,7 +391,7 @@ class Client(object):
             system_data["hostname"] = system_data.get("configured_hostname", system_data["detected_hostname"])
         system_data.update(cgroup.get_cgroup_container_metadata())
         pod_name = os.environ.get("KUBERNETES_POD_NAME") or keyword_field(
-            self.config.hostname or self.config.detected_hostname
+            self.config.hostname or self.config.detected_hostname.split(".")[0]
         )
         changed = False
         if "kubernetes" in system_data:

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -381,12 +381,16 @@ class Client(object):
 
     def get_system_info(self):
         system_data = {
-            "hostname": keyword_field(self.config.hostname),
+            "detected_hostname": keyword_field(self.config.detected_hostname),
             "architecture": platform.machine(),
             "platform": platform.system().lower(),
         }
+        if self.config.hostname:
+            system_data["configured_hostname"] = keyword_field(self.config.hostname)
         system_data.update(cgroup.get_cgroup_container_metadata())
-        pod_name = os.environ.get("KUBERNETES_POD_NAME") or system_data["hostname"]
+        pod_name = os.environ.get("KUBERNETES_POD_NAME") or keyword_field(
+            self.config.hostname or self.config.detected_hostname
+        )
         changed = False
         if "kubernetes" in system_data:
             k8s = system_data["kubernetes"]

--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -381,7 +381,7 @@ class Client(object):
 
     def get_system_info(self):
         system_data = {
-            "detected_hostname": keyword_field(self.config.detected_hostname),
+            "detected_hostname": keyword_field(elasticapm.utils.getfqdn()),
             "architecture": platform.machine(),
             "platform": platform.system().lower(),
         }
@@ -391,7 +391,7 @@ class Client(object):
             system_data["hostname"] = system_data.get("configured_hostname", system_data["detected_hostname"])
         system_data.update(cgroup.get_cgroup_container_metadata())
         pod_name = os.environ.get("KUBERNETES_POD_NAME") or keyword_field(
-            self.config.hostname or self.config.detected_hostname.split(".")[0]
+            self.config.hostname or elasticapm.utils.getfqdn().split(".")[0]
         )
         changed = False
         if "kubernetes" in system_data:

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -38,7 +38,7 @@ import threading
 from datetime import timedelta
 
 from elasticapm.conf.constants import BASE_SANITIZE_FIELD_NAMES, TRACE_CONTINUATION_STRATEGY
-from elasticapm.utils import compat, getfqdn, starmatch_to_regex
+from elasticapm.utils import compat, starmatch_to_regex
 from elasticapm.utils.logging import get_logger
 from elasticapm.utils.threading import IntervalTimer, ThreadManager
 
@@ -572,7 +572,6 @@ class Config(_ConfigBase):
         default=5,
     )
     hostname = _ConfigValue("HOSTNAME", default=None)
-    detected_hostname = _ConfigValue("DETECTED_HOSTNAME", default=getfqdn())
     auto_log_stacks = _BoolConfigValue("AUTO_LOG_STACKS", default=True)
     transport_class = _ConfigValue("TRANSPORT_CLASS", default="elasticapm.transport.http.Transport", required=True)
     processors = _ListConfigValue(

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -34,12 +34,11 @@ import logging.handlers
 import math
 import os
 import re
-import socket
 import threading
 from datetime import timedelta
 
 from elasticapm.conf.constants import BASE_SANITIZE_FIELD_NAMES, TRACE_CONTINUATION_STRATEGY
-from elasticapm.utils import compat, starmatch_to_regex
+from elasticapm.utils import compat, getfqdn, starmatch_to_regex
 from elasticapm.utils.logging import get_logger
 from elasticapm.utils.threading import IntervalTimer, ThreadManager
 
@@ -572,7 +571,8 @@ class Config(_ConfigBase):
         ],
         default=5,
     )
-    hostname = _ConfigValue("HOSTNAME", default=socket.gethostname())
+    hostname = _ConfigValue("HOSTNAME", default=None)
+    detected_hostname = _ConfigValue("DETECTED_HOSTNAME", default=getfqdn())
     auto_log_stacks = _BoolConfigValue("AUTO_LOG_STACKS", default=True)
     transport_class = _ConfigValue("TRANSPORT_CLASS", default="elasticapm.transport.http.Transport", required=True)
     processors = _ListConfigValue(

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -31,6 +31,7 @@
 import base64
 import os
 import re
+import socket
 import urllib.parse
 from functools import partial
 from types import FunctionType
@@ -49,6 +50,7 @@ except ImportError:
 
 
 default_ports = {"https": 443, "http": 80, "postgresql": 5432, "mysql": 3306, "mssql": 1433}
+fqdn = None
 
 
 def varmap(func, var, context=None, name=None, **kwargs):
@@ -221,3 +223,28 @@ def nested_key(d: dict, *args):
             d = None
             break
     return d
+
+
+def getfqdn():
+    """
+    socket.getfqdn() has some issues. For one, it's slow (may do a DNS lookup).
+    For another, it can return `localhost.localdomain`[1], which is less useful
+    than socket.gethostname().
+
+    This function handles the fallbacks and also ensures we don't try to lookup
+    the fqdn more than once.
+
+    [1]: https://stackoverflow.com/a/43330159
+    """
+    global fqdn
+    if not fqdn:
+        fqdn = socket.getfqdn()
+        if fqdn == "localhost.localdomain":
+            fqdn = socket.gethostname()
+        if not fqdn:
+            fqdn = os.environ.get("HOSTNAME")
+        if not fqdn:
+            fqdn = os.environ.get("HOST")
+        if fqdn is None:
+            fqdn = ""
+        fqdn = fqdn.lower().strip()

--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -225,7 +225,7 @@ def nested_key(d: dict, *args):
     return d
 
 
-def getfqdn():
+def getfqdn() -> str:
     """
     socket.getfqdn() has some issues. For one, it's slow (may do a DNS lookup).
     For another, it can return `localhost.localdomain`[1], which is less useful
@@ -248,3 +248,4 @@ def getfqdn():
         if fqdn is None:
             fqdn = ""
         fqdn = fqdn.lower().strip()
+    return fqdn

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -117,7 +117,7 @@ def test_docker_kubernetes_system_info(elasticapm_client):
         mock_metadata.return_value = {"container": {"id": "123"}, "kubernetes": {"pod": {"uid": "456"}}}
         system_info = elasticapm_client.get_system_info()
     assert system_info["container"] == {"id": "123"}
-    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": elasticapm.utils.getfqdn()}}
+    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": elasticapm.utils.getfqdn().split(".")[0]}}
 
 
 @mock.patch.dict(
@@ -186,7 +186,7 @@ def test_docker_kubernetes_system_info_except_hostname_from_environ():
         system_info = elasticapm_client.get_system_info()
     assert "kubernetes" in system_info
     assert system_info["kubernetes"] == {
-        "pod": {"name": elasticapm.utils.getfqdn()},
+        "pod": {"name": elasticapm.utils.getfqdn().split(".")[0]},
         "namespace": "namespace",
     }
 

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -95,7 +95,7 @@ def test_system_info(elasticapm_client):
         mocked.return_value = {}
         system_info = elasticapm_client.get_system_info()
     assert {"detected_hostname", "architecture", "platform"} == set(system_info.keys())
-    assert system_info["detected_hostname"] == elasticapm_client.config.detected_hostname
+    assert system_info["detected_hostname"] == elasticapm.utils.getfqdn()
 
 
 @pytest.mark.parametrize("elasticapm_client", [{"hostname": "my_custom_hostname"}], indirect=True)
@@ -117,7 +117,7 @@ def test_docker_kubernetes_system_info(elasticapm_client):
         mock_metadata.return_value = {"container": {"id": "123"}, "kubernetes": {"pod": {"uid": "456"}}}
         system_info = elasticapm_client.get_system_info()
     assert system_info["container"] == {"id": "123"}
-    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": elasticapm_client.config.detected_hostname}}
+    assert system_info["kubernetes"] == {"pod": {"uid": "456", "name": elasticapm.utils.getfqdn()}}
 
 
 @mock.patch.dict(
@@ -186,7 +186,7 @@ def test_docker_kubernetes_system_info_except_hostname_from_environ():
         system_info = elasticapm_client.get_system_info()
     assert "kubernetes" in system_info
     assert system_info["kubernetes"] == {
-        "pod": {"name": elasticapm_client.config.detected_hostname},
+        "pod": {"name": elasticapm.utils.getfqdn()},
         "namespace": "namespace",
     }
 

--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -128,7 +128,6 @@ def test_config_inline_dict():
             "secret_token": "bar",
             "server_url": "http://example.com:1234",
             "service_version": "1",
-            "hostname": "localhost",
             "api_request_time": "5s",
         }
     )
@@ -137,7 +136,7 @@ def test_config_inline_dict():
     assert config.secret_token == "bar"
     assert config.server_url == "http://example.com:1234"
     assert config.service_version == "1"
-    assert config.hostname == "localhost"
+    assert config.hostname is None
     assert config.api_request_time.total_seconds() == 5
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -485,3 +485,11 @@ def always_uninstrument_and_close():
                 client.close()
         except Exception:
             pass
+
+
+@pytest.fixture()
+def invalidate_fqdn_cache():
+    fqdn = elasticapm.utils.fqdn
+    elasticapm.utils.fqdn = None
+    yield
+    elasticapm.utils.fqdn = fqdn

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -29,14 +29,17 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import socket
 from functools import partial
 
 import pytest
 
+import elasticapm.utils
 from elasticapm.conf import constants
 from elasticapm.utils import (
     get_name_from_func,
     get_url_dict,
+    getfqdn,
     nested_key,
     read_pem_file,
     sanitize_url,
@@ -259,3 +262,12 @@ def test_nested_key(data, key, expected):
         assert r is expected
     else:
         assert r == expected
+
+
+def test_getfqdn(invalidate_fqdn_cache):
+    assert getfqdn() == socket.getfqdn()
+
+
+def test_getfqdn_caches(invalidate_fqdn_cache):
+    elasticapm.utils.fqdn = "foo"
+    assert getfqdn() == "foo"


### PR DESCRIPTION
## What does this pull request do?

Removes the deprecated `hostname`, instead splitting it out into `detected_hostname` and `configured_hostname`. Ensure that `detected_hostname` is the FQDN wherever possible.

## Related issues

Closes #1824 
