### PR TITLE
Fixup tests for Python 3.12.0rc1

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -250,3 +250,22 @@ exclude:
     FRAMEWORK: grpc-1.24
   - VERSION: python-3.12-rc
     FRAMEWORK: grpc-1.24
+  # py3.12
+  - VERSION: python-3.12-rc
+    FRAMEWORK: pymssql-newest  # no wheels available yet
+  - VERSION: python-3.12-rc
+    FRAMEWORK: cassandra-newest  # no wheels available yet
+  - VERSION: python-3.12-rc
+    FRAMEWORK: aiohttp-newest  # no wheels available yet
+  - VERSION: python-3.12-rc
+    FRAMEWORK: elasticsearch-7  # relies on aiohttp
+  - VERSION: python-3.12-rc
+    FRAMEWORK: elasticsearch-8  # relies on aiohttp
+  - VERSION: python-3.12-rc
+    FRAMEWORK: aiobotocore-newest  # relies on aiohttp
+  - VERSION: python-3.12-rc
+    FRAMEWORK: sanic-20.12  # no wheels available yet
+  - VERSION: python-3.12-rc
+    FRAMEWORK: sanic-newest  # no wheels available yet
+  - VERSION: python-3.12-rc
+    FRAMEWORK: grpc-newest  # no wheels available yet

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	# delete any __pycache__ folders to avoid hard-to-debug caching issues
 	find . -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 	# pypy3 should be added to the first `if` once it supports py3.7
-	if [[ "$$PYTHON_VERSION" =~ ^(3.7|3.8|3.9|3.10|3.11|nightly)$$ ]] ; then \
+	if [[ "$$PYTHON_VERSION" =~ ^(3.7|3.8|3.9|3.10|3.11|3.12|nightly)$$ ]] ; then \
 		echo "Python 3.7+, with asyncio"; \
 		pytest -v $(PYTEST_ARGS) --showlocals $(PYTEST_MARKER) $(PYTEST_JUNIT); \
 	else \

--- a/dev-utils/requirements.txt
+++ b/dev-utils/requirements.txt
@@ -1,4 +1,4 @@
 # These are the pinned requirements for the lambda layer/docker image
 certifi==2023.7.22
 urllib3==1.26.16
-wrapt==1.15.0
+wrapt==1.14.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe = false
 install_requires =
     urllib3!=2.0.0,<3.0.0
     certifi
-    wrapt>=1.14.1
+    wrapt>=1.14.1,<1.15.0  # https://github.com/elastic/apm-agent-python/issues/1894
     ecs_logging
 test_suite=tests
 

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -1,5 +1,5 @@
 pytest==7.0.1 ; python_version == '3.6'
-pytest==7.3.0 ; python_version > '3.6'
+pytest==7.4.0 ; python_version > '3.6'
 pytest-random-order==1.1.0
 pytest-django==4.4.0
 coverage==6.2 ; python_version == '3.6'
@@ -25,7 +25,7 @@ mock
 pytz
 ecs_logging
 structlog
-wrapt>=1.14.1
+wrapt>=1.14.1,<1.15.0
 
 pytest-asyncio==0.21.0 ; python_version >= '3.7'
 asynctest==0.13.0 ; python_version >= '3.7'


### PR DESCRIPTION
## What does this pull request do?

- Restrict `wrapt` version (See #1894)
- Skip some tests that have failing wheel builds
- Add 3.12 to "asyncio" list of versions
- Upgrade `pytest` for py3.12 support

Unfortunately, the PR tests won't run py3.12 tests (https://github.com/elastic/observability-robots/issues/1729), so we'll have to merge and watch what happens on `main`.