### PR TITLE
Add py.typed file to indicate typing support

### DIFF
--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -30,13 +30,14 @@
 
 import functools
 from types import TracebackType
-from typing import Optional, Type, TypeVar
+from typing import Optional, Type, TypeVar, Callable, Awaitable, Any
 
 from elasticapm.conf.constants import LABEL_RE
 from elasticapm.traces import SpanType, capture_span, execution_context
 from elasticapm.utils import get_name_from_func
 
-_AnnotatedFunctionT = TypeVar("_AnnotatedFunctionT")
+FuncType = Callable[..., Awaitable[Any]]
+_AnnotatedFunctionT = TypeVar("_AnnotatedFunctionT", bound=FuncType)
 
 
 class async_capture_span(capture_span):

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -30,7 +30,7 @@
 
 import functools
 from types import TracebackType
-from typing import Optional, Type, TypeVar, Callable, Awaitable, Any
+from typing import Any, Awaitable, Callable, Optional, Type, TypeVar
 
 from elasticapm.conf.constants import LABEL_RE
 from elasticapm.traces import SpanType, capture_span, execution_context

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -39,7 +39,7 @@ import warnings
 from collections import defaultdict
 from datetime import timedelta
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union, Callable
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
 import elasticapm
 from elasticapm.conf import constants

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -39,7 +39,7 @@ import warnings
 from collections import defaultdict
 from datetime import timedelta
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, TypeVar, Union, Callable
 
 import elasticapm
 from elasticapm.conf import constants
@@ -62,7 +62,9 @@ _time_func = timeit.default_timer
 execution_context = init_execution_context()
 
 SpanType = Union["Span", "DroppedSpan"]
-_AnnotatedFunctionT = TypeVar("_AnnotatedFunctionT")
+
+FuncType = Callable[..., Any]
+_AnnotatedFunctionT = TypeVar("_AnnotatedFunctionT", bound=FuncType)
 
 
 class ChildDuration(object):


### PR DESCRIPTION
See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages for PEP-561 instructions. It looks like we need to add a `py.typed` file to export types. Without this in place, Mypy is not picking up the correct types for function params when using the `async_capture_span` and `capture_span` decorators.

\+ Making types for `async_capture_span` and `capture_span` decorator `__call__` params more specific. See https://mypy.readthedocs.io/en/latest/generics.html#declaring-decorators for MyPy docs related to types for decorators. Pandas has a good example that references these docs: https://github.com/pandas-dev/pandas/blob/main/pandas/_typing.py#L190.