### PR TITLE
Merge forward from 6.x to main

### DIFF
--- a/docs/flask.asciidoc
+++ b/docs/flask.asciidoc
@@ -75,8 +75,8 @@ apm = ElasticAPM(app, service_name='<APP-ID>', secret_token='<SECRET-TOKEN>')
 [[flask-debug-mode]]
 ===== Debug mode
 
-Please note that errors and transactions will only be sent to the APM Server if your app is *not* in
-http://flask.pocoo.org/docs/0.12/quickstart/#debug-mode[debug mode].
+NOTE: Please note that errors and transactions will only be sent to the APM Server if your app is *not* in
+http://flask.pocoo.org/docs/2.3.x/quickstart/#debug-mode[Flask debug mode].
 
 To force the agent to send data while the app is in debug mode,
 set the value of `DEBUG` in the `ELASTIC_APM` dictionary to `True`:


### PR DESCRIPTION
I didn't notice that #1903 wasn't targeted to `main`. This PR makes sure that change isn't lost when we release.