### PR TITLE
Optimise handling PostgreSQL dollar quotes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ endif::[]
 ===== Features
 
 * Collect the `configured_hostname` and `detected_hostname` separately, and switch to FQDN for the `detected_hostname`. {pull}1891[#1891]
+* Improve postgres dollar-quote detection to be much faster {pull}1905[#1905]
 
 [float]
 ===== Bug fixes


### PR DESCRIPTION
Helps with https://github.com/elastic/apm-agent-python/issues/1851

This avoids slowly looping in Python, relying more on optimised C methods. For this toy benchmark:

```python
from elasticapm.instrumentation.packages.dbapi2 import tokenize, scan
import time

sql = f"Hello $q${'Peter Pan $ ' * 1000000}$q$ at Disney World"
tokens = tokenize(sql)
start = time.time()
list(scan(tokens))
end = time.time()
print(end - start)
```

it's about 3-4x faster with this PR, and about 10x faster if there's no inner `$`.

This is nice, but probably not enough. Both with and without this PR, the code assumes that anything between 2 dollar signs is potentially a dollar quote. But according to https://www.postgresql.org/docs/15/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING:

> The tag, if any, of a dollar-quoted string follows the same rules as an unquoted identifier, except that it cannot contain a dollar sign

From further up:

> SQL identifiers and key words must begin with a letter **(a-z, but also letters with diacritical marks and non-Latin letters)** or an underscore (_). Subsequent characters in an identifier or key word can be letters, underscores, digits (0-9), or dollar signs ($).

Checking that the dollar quote is valid should avoid a lot of pointless searching for a closing quote, which should resolve the use case in the issue. It also seems important for correctness.