### PR TITLE
Ensure that lambda headers are always a dict

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ endif::[]
 ===== Bug fixes
 
 * Fix url argument fetching in aiohttp_client instrumentation {pull}1890[#1890]
+* Fix a bug in the AWS Lambda instrumentation when `event["headers"] is None` {pull}1907[#1907]
 
 
 

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -162,7 +162,7 @@ class _lambda_transaction(object):
             # service like Step Functions, and is unlikely to be standardized
             # in any way. We just have to rely on our defaults in this case.
             self.event = {}
-        trace_parent = TraceParent.from_headers(self.event.get("headers", {}))
+        trace_parent = TraceParent.from_headers(self.event.get("headers") or {})
 
         global COLD_START
         cold_start = COLD_START
@@ -525,7 +525,7 @@ def get_url_dict(event: dict) -> dict:
     """
     Reconstruct URL from API Gateway
     """
-    headers = event.get("headers", {})
+    headers = event.get("headers") or {}
     protocol = headers.get("X-Forwarded-Proto", headers.get("x-forwarded-proto", "https"))
     host = headers.get("Host", headers.get("host", ""))
     stage = nested_key(event, "requestContext", "stage") or ""

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -455,3 +455,18 @@ def test_partial_transaction_failure(event_api, context, sending_elasticapm_clie
     assert b"metadata" in request.data
     assert b"transaction" in request.data
     sending_elasticapm_client.close()
+
+
+def test_with_headers_as_none(event_api2, context, elasticapm_client):
+    os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_func"
+
+    @capture_serverless
+    def test_func(event, context):
+        with capture_span("test_span"):
+            time.sleep(0.01)
+        return {"statusCode": 200, "headers": {"foo": "bar"}}
+
+    event_api2["headers"] = None
+
+    test_func(event_api2, context)
+    assert len(elasticapm_client.events[constants.TRANSACTION]) == 1


### PR DESCRIPTION
## What does this pull request do?

Previously, we assumed `event["headers"]` would always be formed as a dict. In some cases, it can be `None`. This handles that case gracefully.
