### PR TITLE
action: use microbenchmark with GitHub runners

### DIFF
--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -16,32 +16,14 @@ permissions:
 jobs:
   microbenchmark:
     runs-on: ubuntu-latest
-    # wait up to 1 hour
     timeout-minutes: 60
     steps:
-      - id: buildkite
-        name: Run buildkite pipeline
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+      - uses: elastic/apm-pipeline-library/.github/actions/run-microbenchmark@current
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-microbenchmark
-          waitFor: true
-          printBuildLogs: true
-          buildEnvVars: |
-            script=.ci/bench.sh
-            repo=apm-agent-python
-            sha=${{ github.sha }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          slack-channel: "#apm-agent-python"
+          script: .ci/bench.sh
+          environments: |
             BRANCH_NAME=${{ github.ref_name }}
-
-      - if: ${{ failure() }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-python"
-          message: |
-            :ghost: [${{ github.repository }}] microbenchmark *${{ github.ref_name }}* failed to run in Buildkite.
-            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)


### PR DESCRIPTION
## What does this pull request do?

Use GitHub actions for running the microbenchmarks.

Those runners are attached in a different GitHub repository so we can then use the pool a the repository level and ensure they are busy with one APM Agent repo 

