### PR TITLE
Fix race condition with extra metadata + partial transaction extra span

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ endif::[]
 * Fix url argument fetching in aiohttp_client instrumentation {pull}1890[#1890]
 * Fix a bug in the AWS Lambda instrumentation when `event["headers"] is None` {pull}1907[#1907]
 * Fix a bug in AWS Lambda where metadata could be incomplete, causing validation errors with the APM Server {pull}1914[#1914]
+* Fix a bug in AWS Lambda where sending the partial transaction would be recorded as an extra span {pull}1914[#1914]
 
 
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ endif::[]
 
 * Fix url argument fetching in aiohttp_client instrumentation {pull}1890[#1890]
 * Fix a bug in the AWS Lambda instrumentation when `event["headers"] is None` {pull}1907[#1907]
+* Fix a bug in AWS Lambda where metadata could be incomplete, causing validation errors with the APM Server {pull}1914[#1914]
 
 
 

--- a/elasticapm/instrumentation/packages/base.py
+++ b/elasticapm/instrumentation/packages/base.py
@@ -206,7 +206,7 @@ class AbstractInstrumentedModule(object):
         transaction = execution_context.get_transaction()
         if not transaction:
             return wrapped(*args, **kwargs)
-        elif not transaction.is_sampled:
+        elif not transaction.is_sampled or transaction.pause_sampling:
             args, kwargs = self.mutate_unsampled_call_args(module, method, wrapped, instance, args, kwargs, transaction)
             return wrapped(*args, **kwargs)
         else:

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -210,7 +210,13 @@ class Transaction(BaseSpan):
         if not trace_parent:
             trace_parent = TraceParent.new(self.id, is_sampled)
 
+        # While this is set to True, underlying instrumentations will not create
+        # spans. The same outcome could be reached via `is_sampled`, but
+        # that requires a user to correctly restore the previous value. This
+        # setting works independent of the is_sampled setting, and is assumed to
+        # be False unless a user sets it to True.
         self.pause_sampling = False
+
         self.trace_parent: TraceParent = trace_parent
         self.timestamp = start if start is not None else time.time()
         self.name: Optional[str] = None

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -210,6 +210,7 @@ class Transaction(BaseSpan):
         if not trace_parent:
             trace_parent = TraceParent.new(self.id, is_sampled)
 
+        self.pause_sampling = False
         self.trace_parent: TraceParent = trace_parent
         self.timestamp = start if start is not None else time.time()
         self.name: Optional[str] = None

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -226,25 +226,6 @@ class Transport(ThreadManager):
         data = (self._json_serializer({"metadata": self._metadata}) + "\n").encode("utf-8")
         buffer.write(data)
 
-    def add_metadata(self, data):
-        """
-        Add additional metadata do the dictionary
-
-        Only used in specific instances where metadata relies on data we only
-        have at request time, such as for lambda metadata
-
-        Metadata is only merged one key deep.
-        """
-        if self._metadata is not None:
-            # Merge one key deep
-            for key, val in data.items():
-                if isinstance(val, dict) and key in self._metadata and isinstance(self._metadata[key], dict):
-                    self._metadata[key].update(val)
-                else:
-                    self._metadata[key] = val
-        else:
-            self._metadata = data
-
     def _init_event_queue(self, chill_until, max_chill_time):
         # some libraries like eventlet monkeypatch queue.Queue and switch out the implementation.
         # In those cases we can't rely on internals of queue.Queue to be there, so we simply use

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -32,14 +32,11 @@ import pytest  # isort:skip
 
 import json
 import os
-import platform
 import time
 
 from elasticapm import capture_span
 from elasticapm.conf import constants
 from elasticapm.contrib.serverless.aws import capture_serverless, get_data_from_request, get_data_from_response
-
-pytestmark = pytest.mark.skipif(platform.system() == "Windows", reason="AWS Lambda does not support Windows")
 
 
 @pytest.fixture

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -424,6 +424,11 @@ def test_partial_transaction(event_api, context, sending_elasticapm_client):
     test_func(event_api, context)
 
     assert len(sending_elasticapm_client.httpserver.requests) == 2
+
+    # There should be no spans from the partial transaction
+    for payload in sending_elasticapm_client.httpserver.payloads[1]:
+        assert "span" not in payload
+
     request = sending_elasticapm_client.httpserver.requests[0]
     assert request.full_path == "/register/transaction?"
     assert request.content_type == "application/vnd.elastic.apm.transaction+ndjson"

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -32,11 +32,14 @@ import pytest  # isort:skip
 
 import json
 import os
+import platform
 import time
 
 from elasticapm import capture_span
 from elasticapm.conf import constants
 from elasticapm.contrib.serverless.aws import capture_serverless, get_data_from_request, get_data_from_response
+
+pytestmark = pytest.mark.skipif(platform.system() == "Windows", reason="AWS Lambda does not support Windows")
 
 
 @pytest.fixture

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -392,7 +392,7 @@ def test_service_name_override(event_api, context, elasticapm_client):
 
     test_func(event_api, context)
 
-    assert elasticapm_client._transport._metadata["service"]["name"] == "override"
+    assert elasticapm_client.build_metadata()["service"]["name"] == "override"
 
 
 def test_capture_serverless_list_event(event_list, context, elasticapm_client):

--- a/tests/contrib/serverless/aws_tests.py
+++ b/tests/contrib/serverless/aws_tests.py
@@ -428,6 +428,7 @@ def test_partial_transaction(event_api, context, sending_elasticapm_client):
     assert request.full_path == "/register/transaction?"
     assert request.content_type == "application/vnd.elastic.apm.transaction+ndjson"
     assert b"metadata" in request.data
+    assert b"AWS Lambda" in request.data
     assert b"transaction" in request.data
     sending_elasticapm_client.close()
 
@@ -453,6 +454,7 @@ def test_partial_transaction_failure(event_api, context, sending_elasticapm_clie
     assert request.full_path == "/register/transaction?"
     assert request.content_type == "application/vnd.elastic.apm.transaction+ndjson"
     assert b"metadata" in request.data
+    assert b"AWS Lambda" in request.data
     assert b"transaction" in request.data
     sending_elasticapm_client.close()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -356,6 +356,7 @@ def sending_elasticapm_client(request, validating_httpserver):
     client_config.setdefault("span_compression_same_kind_max_duration", "0ms")
     client_config.setdefault("include_paths", ("*/tests/*",))
     client_config.setdefault("metrics_interval", "0ms")
+    client_config.setdefault("cloud_provider", False)
     client_config.setdefault("central_config", "false")
     client_config.setdefault("server_version", (8, 0, 0))
     client = Client(**client_config)


### PR DESCRIPTION
## What does this pull request do?

Eliminates the `add_metadata` interaction with the transport thread. We now generate our own metadata for sending the partial transaction, and also save the extra metadata in the `Client` object so that it makes it into every future metadata build.

Also, fixed the extra span being recorded when we send the partial transaction. Fixes #1902
