### PR TITLE
chore(typing): Add explicit None return type

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -93,7 +93,7 @@ class Client(object):
 
     logger = get_logger("elasticapm")
 
-    def __init__(self, config=None, **inline):
+    def __init__(self, config=None, **inline) -> None:
         # configure loggers first
         cls = self.__class__
         self.logger = get_logger("%s.%s" % (cls.__module__, cls.__name__))
@@ -227,7 +227,7 @@ class Client(object):
         # Save this Client object as the global CLIENT_SINGLETON
         set_client(self)
 
-    def start_threads(self):
+    def start_threads(self) -> None:
         current_pid = os.getpid()
         if self._pid != current_pid:
             with self._thread_starter_lock:
@@ -284,7 +284,7 @@ class Client(object):
         """
         return self.capture("Exception", exc_info=exc_info, handled=handled, **kwargs)
 
-    def queue(self, event_type, data, flush=False):
+    def queue(self, event_type, data, flush=False) -> None:
         if self.config.disable_send:
             return
         self.start_threads()
@@ -330,7 +330,7 @@ class Client(object):
         transaction = self.tracer.end_transaction(result, name, duration=duration)
         return transaction
 
-    def close(self):
+    def close(self) -> None:
         if self.config.enabled:
             with self._thread_starter_lock:
                 for _, manager in sorted(self._thread_managers.items(), key=lambda item: item[1].start_stop_order):
@@ -636,7 +636,7 @@ class Client(object):
             locals_processor_func=locals_processor_func,
         )
 
-    def _excepthook(self, type_, value, traceback):
+    def _excepthook(self, type_, value, traceback) -> None:
         try:
             self.original_excepthook(type_, value, traceback)
         except Exception:
@@ -672,7 +672,7 @@ class Client(object):
                     return True
         return False
 
-    def check_python_version(self):
+    def check_python_version(self) -> None:
         v = tuple(map(int, platform.python_version_tuple()[:2]))
         if v < (3, 6):
             warnings.warn("The Elastic APM agent only supports Python 3.6+", DeprecationWarning)
@@ -707,7 +707,7 @@ class Client(object):
         return self._server_version
 
     @server_version.setter
-    def server_version(self, new_version):
+    def server_version(self, new_version) -> None:
         if new_version and len(new_version) < 3:
             self.logger.debug("APM Server version is too short, padding with zeros")
             new_version = new_version + (0,) * (3 - len(new_version))
@@ -725,7 +725,7 @@ def get_client() -> Client:
     return CLIENT_SINGLETON
 
 
-def set_client(client: Client):
+def set_client(client: Client) -> None:
     global CLIENT_SINGLETON
     if CLIENT_SINGLETON:
         logger = get_logger("elasticapm")

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -61,7 +61,7 @@ logfile_set_up = False
 
 
 class ConfigurationError(ValueError):
-    def __init__(self, msg, field_name):
+    def __init__(self, msg, field_name) -> None:
         self.field_name = field_name
         super(ValueError, self).__init__(msg)
 
@@ -120,7 +120,7 @@ class _ConfigValue(object):
         callbacks_on_default=True,
         default=None,
         required=False,
-    ):
+    ) -> None:
         self.type = type
         self.dict_key = dict_key
         self.validators = validators
@@ -138,7 +138,7 @@ class _ConfigValue(object):
         else:
             return self.default
 
-    def __set__(self, config_instance, value):
+    def __set__(self, config_instance, value) -> None:
         value = self._validate(config_instance, value)
         self._callback_if_changed(config_instance, value)
         config_instance._values[self.dict_key] = value
@@ -159,7 +159,7 @@ class _ConfigValue(object):
         instance._errors.pop(self.dict_key, None)
         return value
 
-    def _callback_if_changed(self, instance, new_value):
+    def _callback_if_changed(self, instance, new_value) -> None:
         """
         If the value changed (checked against instance._values[self.dict_key]),
         then run the callback function (if defined)
@@ -184,11 +184,11 @@ class _ConfigValue(object):
 
 
 class _ListConfigValue(_ConfigValue):
-    def __init__(self, dict_key, list_separator=",", **kwargs):
+    def __init__(self, dict_key, list_separator=",", **kwargs) -> None:
         self.list_separator = list_separator
         super(_ListConfigValue, self).__init__(dict_key, **kwargs)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance, value) -> None:
         if isinstance(value, str):
             value = value.split(self.list_separator)
         elif value is not None:
@@ -200,12 +200,12 @@ class _ListConfigValue(_ConfigValue):
 
 
 class _DictConfigValue(_ConfigValue):
-    def __init__(self, dict_key, item_separator=",", keyval_separator="=", **kwargs):
+    def __init__(self, dict_key, item_separator=",", keyval_separator="=", **kwargs) -> None:
         self.item_separator = item_separator
         self.keyval_separator = keyval_separator
         super(_DictConfigValue, self).__init__(dict_key, **kwargs)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance, value) -> None:
         if isinstance(value, str):
             items = (item.split(self.keyval_separator) for item in value.split(self.item_separator))
             value = {key.strip(): self.type(val.strip()) for key, val in items}
@@ -217,12 +217,12 @@ class _DictConfigValue(_ConfigValue):
 
 
 class _BoolConfigValue(_ConfigValue):
-    def __init__(self, dict_key, true_string="true", false_string="false", **kwargs):
+    def __init__(self, dict_key, true_string="true", false_string="false", **kwargs) -> None:
         self.true_string = true_string
         self.false_string = false_string
         super(_BoolConfigValue, self).__init__(dict_key, **kwargs)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance, value) -> None:
         if isinstance(value, str):
             if value.lower() == self.true_string:
                 value = True
@@ -240,7 +240,7 @@ class _DurationConfigValue(_ConfigValue):
         ("m", 60),
     )
 
-    def __init__(self, dict_key, allow_microseconds=False, unitless_factor=None, **kwargs):
+    def __init__(self, dict_key, allow_microseconds=False, unitless_factor=None, **kwargs) -> None:
         self.type = None  # no type coercion
         used_units = self.units if allow_microseconds else self.units[1:]
         pattern = "|".join(unit[0] for unit in used_units)
@@ -258,7 +258,7 @@ class _DurationConfigValue(_ConfigValue):
         validators.insert(0, duration_validator)
         super().__init__(dict_key, validators=validators, **kwargs)
 
-    def __set__(self, config_instance, value):
+    def __set__(self, config_instance, value) -> None:
         value = self._validate(config_instance, value)
         value = timedelta(seconds=float(value))
         self._callback_if_changed(config_instance, value)
@@ -266,7 +266,7 @@ class _DurationConfigValue(_ConfigValue):
 
 
 class RegexValidator(object):
-    def __init__(self, regex, verbose_pattern=None):
+    def __init__(self, regex, verbose_pattern=None) -> None:
         self.regex = regex
         self.verbose_pattern = verbose_pattern or regex
 
@@ -279,7 +279,7 @@ class RegexValidator(object):
 
 
 class UnitValidator(object):
-    def __init__(self, regex, verbose_pattern, unit_multipliers):
+    def __init__(self, regex, verbose_pattern, unit_multipliers) -> None:
         self.regex = regex
         self.verbose_pattern = verbose_pattern
         self.unit_multipliers = unit_multipliers
@@ -307,7 +307,7 @@ class PrecisionValidator(object):
     begin with), use the minimum instead.
     """
 
-    def __init__(self, precision=0, minimum=None):
+    def __init__(self, precision=0, minimum=None) -> None:
         self.precision = precision
         self.minimum = minimum
 
@@ -329,7 +329,7 @@ size_validator = UnitValidator(
 
 
 class ExcludeRangeValidator(object):
-    def __init__(self, range_start, range_end, range_desc):
+    def __init__(self, range_start, range_end, range_desc) -> None:
         self.range_start = range_start
         self.range_end = range_end
         self.range_desc = range_desc
@@ -363,7 +363,7 @@ class EnumerationValidator(object):
     of valid string options.
     """
 
-    def __init__(self, valid_values, case_sensitive=False):
+    def __init__(self, valid_values, case_sensitive=False) -> None:
         """
         valid_values
             List of valid string values for the config value
@@ -389,7 +389,7 @@ class EnumerationValidator(object):
         return ret
 
 
-def _log_level_callback(dict_key, old_value, new_value, config_instance):
+def _log_level_callback(dict_key, old_value, new_value, config_instance) -> None:
     elasticapm_logger = logging.getLogger("elasticapm")
     elasticapm_logger.setLevel(log_levels_map.get(new_value, 100))
 
@@ -408,7 +408,7 @@ def _log_level_callback(dict_key, old_value, new_value, config_instance):
         elasticapm_logger.addHandler(filehandler)
 
 
-def _log_ecs_reformatting_callback(dict_key, old_value, new_value, config_instance):
+def _log_ecs_reformatting_callback(dict_key, old_value, new_value, config_instance) -> None:
     """
     If ecs_logging is installed and log_ecs_reformatting is set to "override", we should
     set the ecs_logging.StdlibFormatter as the formatted for every handler in
@@ -439,7 +439,7 @@ def _log_ecs_reformatting_callback(dict_key, old_value, new_value, config_instan
 class _ConfigBase(object):
     _NO_VALUE = object()  # sentinel object
 
-    def __init__(self, config_dict=None, env_dict=None, inline_dict=None, copy=False):
+    def __init__(self, config_dict=None, env_dict=None, inline_dict=None, copy=False) -> None:
         """
         config_dict
             Configuration dict as is common for frameworks such as flask and django.
@@ -467,7 +467,7 @@ class _ConfigBase(object):
         if not copy:
             self.update(config_dict, env_dict, inline_dict, initial=True)
 
-    def update(self, config_dict=None, env_dict=None, inline_dict=None, initial=False):
+    def update(self, config_dict=None, env_dict=None, inline_dict=None, initial=False) -> None:
         if config_dict is None:
             config_dict = {}
         if env_dict is None:
@@ -508,7 +508,7 @@ class _ConfigBase(object):
                 )
         self.call_pending_callbacks()
 
-    def call_pending_callbacks(self):
+    def call_pending_callbacks(self) -> None:
         """
         Call callbacks for config options matching list of tuples:
 
@@ -523,7 +523,7 @@ class _ConfigBase(object):
         return self._values
 
     @values.setter
-    def values(self, values):
+    def values(self, values) -> None:
         self._values = values
 
     @property
@@ -717,7 +717,7 @@ class VersionedConfig(ThreadManager):
         "start_stop_order",
     )
 
-    def __init__(self, config_object, version, transport=None):
+    def __init__(self, config_object, version, transport=None) -> None:
         """
         Create a new VersionedConfig with an initial Config object
         :param config_object: the initial Config object
@@ -748,7 +748,7 @@ class VersionedConfig(ThreadManager):
         else:
             return new_config.errors
 
-    def reset(self):
+    def reset(self) -> None:
         """
         Reset state to the original configuration
 
@@ -776,7 +776,7 @@ class VersionedConfig(ThreadManager):
     def __getattr__(self, item):
         return getattr(self._config, item)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name, value) -> None:
         if name not in self.__slots__:
             setattr(self._config, name, value)
         else:
@@ -812,14 +812,14 @@ class VersionedConfig(ThreadManager):
 
         return next_run
 
-    def start_thread(self, pid=None):
+    def start_thread(self, pid=None) -> None:
         self._update_thread = IntervalTimer(
             self.update_config, 1, "eapm conf updater", daemon=True, evaluate_function_interval=True
         )
         self._update_thread.start()
         super(VersionedConfig, self).start_thread(pid=pid)
 
-    def stop_thread(self):
+    def stop_thread(self) -> None:
         if self._update_thread:
             self._update_thread.cancel()
             self._update_thread = None

--- a/elasticapm/contrib/aiohttp/__init__.py
+++ b/elasticapm/contrib/aiohttp/__init__.py
@@ -35,7 +35,7 @@ from elasticapm import Client
 
 
 class ElasticAPM:
-    def __init__(self, app, client=None):
+    def __init__(self, app, client=None) -> None:
         if not client:
             config = app.get("ELASTIC_APM", {})
             config.setdefault("framework_name", "aiohttp")
@@ -45,7 +45,7 @@ class ElasticAPM:
         self.client = client
         self.install_tracing(app, client)
 
-    def install_tracing(self, app, client):
+    def install_tracing(self, app, client) -> None:
         from elasticapm.contrib.aiohttp.middleware import tracing_middleware
 
         app.middlewares.insert(0, tracing_middleware(app, client))

--- a/elasticapm/contrib/asgi.py
+++ b/elasticapm/contrib/asgi.py
@@ -45,7 +45,7 @@ from elasticapm.utils.disttracing import TraceParent
 
 def wrap_send(send, middleware):
     @functools.wraps(send)
-    async def wrapped_send(message):
+    async def wrapped_send(message) -> None:
         if message.get("type") == "http.response.start":
             await set_context(lambda: middleware.get_data_from_response(message, constants.TRANSACTION), "response")
             result = "HTTP {}xx".format(message["status"] // 100)
@@ -218,7 +218,7 @@ class ASGITracingMiddleware:
 
         return result
 
-    def set_transaction_name(self, method: str, url: str):
+    def set_transaction_name(self, method: str, url: str) -> None:
         """
         Default implementation sets transaction name to "METHOD unknown route".
         Subclasses may add framework specific naming.

--- a/elasticapm/contrib/asyncio/traces.py
+++ b/elasticapm/contrib/asyncio/traces.py
@@ -56,11 +56,11 @@ class async_capture_span(capture_span):
 
     async def __aexit__(
         self, exc_type: Optional[Type[BaseException]], exc_val: Optional[BaseException], exc_tb: Optional[TracebackType]
-    ):
+    ) -> None:
         self.handle_exit(exc_type, exc_val, exc_tb)
 
 
-async def set_context(data, key="custom"):
+async def set_context(data, key="custom") -> None:
     """
     Asynchronous copy of elasticapm.traces.set_context().
     Attach contextual data to the current transaction and errors that happen during the current transaction.

--- a/elasticapm/contrib/celery/__init__.py
+++ b/elasticapm/contrib/celery/__init__.py
@@ -46,10 +46,10 @@ class CeleryFilter(object):
             return 1
 
 
-def register_exception_tracking(client):
+def register_exception_tracking(client) -> None:
     dispatch_uid = "elasticapm-exc-tracking"
 
-    def process_failure_signal(sender, task_id, exception, args, kwargs, traceback, einfo, **kw):
+    def process_failure_signal(sender, task_id, exception, args, kwargs, traceback, einfo, **kw) -> None:
         client.capture_exception(
             extra={"task_id": task_id, "task": sender, "args": args, "kwargs": kwargs}, handled=False
         )
@@ -59,7 +59,7 @@ def register_exception_tracking(client):
     _register_worker_signals(client)
 
 
-def set_celery_headers(headers=None, **kwargs):
+def set_celery_headers(headers=None, **kwargs) -> None:
     """
     Add elasticapm specific information to celery headers
     """
@@ -94,14 +94,14 @@ def get_trace_parent(celery_task):
     return None
 
 
-def register_instrumentation(client):
-    def begin_transaction(*args, **kwargs):
+def register_instrumentation(client) -> None:
+    def begin_transaction(*args, **kwargs) -> None:
         task = kwargs["task"]
 
         trace_parent = get_trace_parent(task)
         client.begin_transaction("celery", trace_parent=trace_parent)
 
-    def end_transaction(task_id, task, *args, **kwargs):
+    def end_transaction(task_id, task, *args, **kwargs) -> None:
         name = get_name_from_func(task)
         state = kwargs.get("state", "None")
         if state == states.SUCCESS:
@@ -127,11 +127,11 @@ def register_instrumentation(client):
     _register_worker_signals(client)
 
 
-def _register_worker_signals(client):
-    def worker_shutdown(*args, **kwargs):
+def _register_worker_signals(client) -> None:
+    def worker_shutdown(*args, **kwargs) -> None:
         client.close()
 
-    def connect_worker_process_init(*args, **kwargs):
+    def connect_worker_process_init(*args, **kwargs) -> None:
         signals.worker_process_shutdown.connect(worker_shutdown, dispatch_uid="elasticapm-shutdown-worker", weak=False)
 
     signals.worker_init.connect(

--- a/elasticapm/contrib/django/apps.py
+++ b/elasticapm/contrib/django/apps.py
@@ -57,11 +57,11 @@ class ElasticAPMConfig(AppConfig):
     label = "elasticapm"
     verbose_name = "ElasticAPM"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(ElasticAPMConfig, self).__init__(*args, **kwargs)
         self.client = None
 
-    def ready(self):
+    def ready(self) -> None:
         self.client = get_client()
         if self.client.config.autoinsert_django_middleware:
             self.insert_middleware(django_settings)
@@ -72,7 +72,7 @@ class ElasticAPMConfig(AppConfig):
             self.client.logger.debug("Skipping instrumentation. INSTRUMENT is set to False.")
 
     @staticmethod
-    def insert_middleware(settings):
+    def insert_middleware(settings) -> None:
         if hasattr(settings, "MIDDLEWARE"):
             middleware_list = settings.MIDDLEWARE
             middleware_attr = "MIDDLEWARE"
@@ -97,7 +97,7 @@ class ElasticAPMConfig(AppConfig):
             setattr(settings, middleware_attr, middleware_list)
 
 
-def register_handlers(client):
+def register_handlers(client) -> None:
     from django.core.signals import got_request_exception, request_finished, request_started
 
     from elasticapm.contrib.django.handlers import exception_handler
@@ -132,7 +132,7 @@ def register_handlers(client):
         client.logger.debug("Not instrumenting Celery, couldn't import")
 
 
-def _request_started_handler(client, sender, *args, **kwargs):
+def _request_started_handler(client, sender, *args, **kwargs) -> None:
     if not _should_start_transaction(client):
         return
     # try to find trace id
@@ -160,7 +160,7 @@ def _request_started_handler(client, sender, *args, **kwargs):
     client.begin_transaction("request", trace_parent=trace_parent)
 
 
-def instrument(client):
+def instrument(client) -> None:
     """
     Auto-instruments code to get nice spans
     """

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -81,7 +81,7 @@ def get_client():
 class DjangoClient(Client):
     logger = get_logger("elasticapm.errors.client.django")
 
-    def __init__(self, config=None, **inline):
+    def __init__(self, config=None, **inline) -> None:
         if config is None:
             config = getattr(django_settings, "ELASTIC_APM", {})
         if "framework_name" not in inline:

--- a/elasticapm/contrib/django/handlers.py
+++ b/elasticapm/contrib/django/handlers.py
@@ -45,7 +45,7 @@ logger = get_logger("elasticapm.logging")
 
 
 class LoggingHandler(BaseLoggingHandler):
-    def __init__(self, level=logging.NOTSET):
+    def __init__(self, level=logging.NOTSET) -> None:
         # skip initialization of BaseLoggingHandler
         logging.Handler.__init__(self, level=level)
 
@@ -64,7 +64,7 @@ class LoggingHandler(BaseLoggingHandler):
 
 
 def exception_handler(client, request=None, **kwargs):
-    def actually_do_stuff(request=None, **kwargs):
+    def actually_do_stuff(request=None, **kwargs) -> None:
         exc_info = sys.exc_info()
         try:
             if (django_settings.DEBUG and not client.config.debug) or getattr(exc_info[1], "skip_elasticapm", False):

--- a/elasticapm/contrib/django/management/commands/elasticapm.py
+++ b/elasticapm/contrib/django/management/commands/elasticapm.py
@@ -62,12 +62,12 @@ class TestException(Exception):
 
 
 class ColoredLogger(object):
-    def __init__(self, stream):
+    def __init__(self, stream) -> None:
         self.stream = stream
         self.errors = []
         self.color = color_style()
 
-    def log(self, level, *args, **kwargs):
+    def log(self, level, *args, **kwargs) -> None:
         style = kwargs.pop("style", self.color.NOTICE)
         msg = " ".join((level.upper(), args[0] % args[1:], "\n"))
         if OutputWrapper is None:
@@ -75,16 +75,16 @@ class ColoredLogger(object):
         else:
             self.stream.write(msg, style_func=style)
 
-    def error(self, *args, **kwargs):
+    def error(self, *args, **kwargs) -> None:
         kwargs["style"] = red
         self.log("error", *args, **kwargs)
         self.errors.append((args,))
 
-    def warning(self, *args, **kwargs):
+    def warning(self, *args, **kwargs) -> None:
         kwargs["style"] = yellow
         self.log("warning", *args, **kwargs)
 
-    def info(self, *args, **kwargs):
+    def info(self, *args, **kwargs) -> None:
         kwargs["style"] = green
         self.log("info", *args, **kwargs)
 
@@ -115,7 +115,7 @@ class Command(BaseCommand):
 
     args = "test check"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser) -> None:
         parser.add_argument("subcommand")
         for args, kwargs in self.arguments:
             parser.add_argument(*args, **kwargs)
@@ -135,11 +135,11 @@ class Command(BaseCommand):
         # can't be async for testing
 
         class LogCaptureHandler(logging.Handler):
-            def __init__(self, level=logging.NOTSET):
+            def __init__(self, level=logging.NOTSET) -> None:
                 self.logs = []
                 super(LogCaptureHandler, self).__init__(level)
 
-            def handle(self, record):
+            def handle(self, record) -> None:
                 self.logs.append(record)
 
         handler = LogCaptureHandler()
@@ -303,7 +303,7 @@ class Command(BaseCommand):
         client.close()
         return passed
 
-    def handle_command_not_found(self, message):
+    def handle_command_not_found(self, message) -> None:
         self.write(message, red, ending="")
         self.write(" Please use one of the following commands:\n\n", red)
         self.write("".join(" * %s\t%s\n" % (k.ljust(8), v.__doc__) for k, v in self.dispatch.items()))
@@ -311,7 +311,7 @@ class Command(BaseCommand):
         argv = self._get_argv()
         self.write("Usage:\n\t%s elasticapm <command>" % (" ".join(argv[: argv.index("elasticapm")])))
 
-    def write(self, msg, style_func=None, ending=None, stream=None):
+    def write(self, msg, style_func=None, ending=None, stream=None) -> None:
         """
         wrapper around self.stdout/stderr to ensure Django 1.4 compatibility
         """

--- a/elasticapm/contrib/django/middleware/__init__.py
+++ b/elasticapm/contrib/django/middleware/__init__.py
@@ -133,7 +133,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
     _elasticapm_instrumented = False
     _instrumenting_lock = threading.Lock()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super(TracingMiddleware, self).__init__(*args, **kwargs)
         if not self._elasticapm_instrumented:
             with self._instrumenting_lock:
@@ -143,7 +143,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
 
                     TracingMiddleware._elasticapm_instrumented = True
 
-    def instrument_middlewares(self):
+    def instrument_middlewares(self) -> None:
         middlewares = getattr(django_settings, "MIDDLEWARE", None) or getattr(
             django_settings, "MIDDLEWARE_CLASSES", None
         )
@@ -163,7 +163,7 @@ class TracingMiddleware(MiddlewareMixin, ElasticAPMClientMiddlewareMixin):
                 except ImportError:
                     client.logger.warning("Can't instrument middleware %s", middleware_path)
 
-    def process_view(self, request: HttpRequest, view_func: FunctionType, view_args: list, view_kwargs: dict):
+    def process_view(self, request: HttpRequest, view_func: FunctionType, view_args: list, view_kwargs: dict) -> None:
         elasticapm.set_transaction_name(self.get_transaction_name(request, view_func), override=False)
         request._elasticapm_name_set = True
 
@@ -217,5 +217,5 @@ class LogMiddleware(MiddlewareMixin):
     # Create a thread local variable to store the session in for logging
     thread = threading.local()
 
-    def process_request(self, request):
+    def process_request(self, request) -> None:
         self.thread.request = request

--- a/elasticapm/contrib/django/middleware/wsgi.py
+++ b/elasticapm/contrib/django/middleware/wsgi.py
@@ -44,7 +44,7 @@ class ElasticAPM(ElasticAPMBase):
     >>> application = ElasticAPM(application)
     """
 
-    def __init__(self, application):
+    def __init__(self, application) -> None:
         self.application = application
 
     @property

--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -84,7 +84,7 @@ class ElasticAPM(object):
     >>> elasticapm.capture_message('hello, world!')
     """
 
-    def __init__(self, app=None, client=None, client_cls=Client, logging=False, **defaults):
+    def __init__(self, app=None, client=None, client_cls=Client, logging=False, **defaults) -> None:
         self.app = app
         self.logging = logging
         self.client = client or get_client()
@@ -93,7 +93,7 @@ class ElasticAPM(object):
         if app:
             self.init_app(app, **defaults)
 
-    def handle_exception(self, *args, **kwargs):
+    def handle_exception(self, *args, **kwargs) -> None:
         if not self.client:
             return
 
@@ -114,7 +114,7 @@ class ElasticAPM(object):
         elasticapm.set_transaction_outcome(outcome=constants.OUTCOME.FAILURE, override=False)
         self.client.end_transaction(result="HTTP 5xx")
 
-    def init_app(self, app, **defaults):
+    def init_app(self, app, **defaults) -> None:
         self.app = app
         if not self.client:
             config = self.app.config.get("ELASTIC_APM", {})
@@ -174,7 +174,7 @@ class ElasticAPM(object):
                 }
             return {}
 
-    def request_started(self, app):
+    def request_started(self, app) -> None:
         if (not self.app.debug or self.client.config.debug) and not self.client.should_ignore_url(request.path):
             trace_parent = TraceParent.from_headers(request.headers)
             self.client.begin_transaction("request", trace_parent=trace_parent)
@@ -185,7 +185,7 @@ class ElasticAPM(object):
             rule = build_name_with_http_method_prefix(rule, request)
             elasticapm.set_transaction_name(rule, override=False)
 
-    def request_finished(self, app, response):
+    def request_finished(self, app, response) -> None:
         if not self.app.debug or self.client.config.debug:
             elasticapm.set_context(
                 lambda: get_data_from_response(response, self.client.config, constants.TRANSACTION), "response"

--- a/elasticapm/contrib/grpc/__init__.py
+++ b/elasticapm/contrib/grpc/__init__.py
@@ -32,7 +32,7 @@ from elasticapm import Client
 
 
 class GRPCApmClient(Client):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         import grpc
 
         kwargs["framework_name"] = "grpc"

--- a/elasticapm/contrib/grpc/client_interceptor.py
+++ b/elasticapm/contrib/grpc/client_interceptor.py
@@ -45,7 +45,7 @@ class _ClientInterceptor(
     # grpc.StreamUnaryClientInterceptor,
     # grpc.StreamStreamClientInterceptor,
 ):
-    def __init__(self, host: Optional[str], port: Optional[str], secure: bool):
+    def __init__(self, host: Optional[str], port: Optional[str], secure: bool) -> None:
         self.host: str = host
         self.port: str = port
         self.secure: bool = secure

--- a/elasticapm/contrib/grpc/server_interceptor.py
+++ b/elasticapm/contrib/grpc/server_interceptor.py
@@ -76,7 +76,7 @@ def get_trace_parent(handler_call_details):
 
 
 class _ServicerContextWrapper(wrapt.ObjectProxy):
-    def __init__(self, wrapped, transaction):
+    def __init__(self, wrapped, transaction) -> None:
         self._self_transaction = transaction
         super().__init__(wrapped)
 

--- a/elasticapm/contrib/opentelemetry/span.py
+++ b/elasticapm/contrib/opentelemetry/span.py
@@ -59,7 +59,7 @@ class Span(oteltrace.Span):
         elastic_span: elasticapm.traces.BaseSpan,
         set_status_on_exception: Optional[bool] = None,
         client: Optional[elasticapm.Client] = None,
-    ):
+    ) -> None:
         self.elastic_span = elastic_span
         self.otel_context = Context({_SPAN_KEY: self})
         elastic_span.otel_wrapper = self
@@ -200,7 +200,7 @@ class Span(oteltrace.Span):
 
         self.end()
 
-    def _set_types(self):
+    def _set_types(self) -> None:
         """
         Set the types and subtypes for the underlying Elastic transaction/span
         """

--- a/elasticapm/contrib/opentelemetry/trace.py
+++ b/elasticapm/contrib/opentelemetry/trace.py
@@ -61,7 +61,7 @@ class Tracer(oteltrace.Tracer):
 
     def __init__(
         self, *args, elasticapm_client: Optional[Client] = None, config: Optional[Mapping] = None, **kwargs
-    ):  # type: ignore
+    ) -> None:  # type: ignore
         self.client = elasticapm_client
         if not self.client:
             self.client = elasticapm.get_client()

--- a/elasticapm/contrib/opentracing/span.py
+++ b/elasticapm/contrib/opentracing/span.py
@@ -50,7 +50,7 @@ logger = get_logger("elasticapm.contrib.opentracing")
 
 
 class OTSpan(OTSpanBase):
-    def __init__(self, tracer, context, elastic_apm_ref):
+    def __init__(self, tracer, context, elastic_apm_ref) -> None:
         super(OTSpan, self).__init__(tracer, context)
         self.elastic_apm_ref = elastic_apm_ref
         self.is_transaction = isinstance(elastic_apm_ref, traces.Transaction)
@@ -123,7 +123,7 @@ class OTSpan(OTSpanBase):
                 self.elastic_apm_ref.label(**{key: value})
         return self
 
-    def finish(self, finish_time=None):
+    def finish(self, finish_time=None) -> None:
         if self.is_transaction:
             self.tracer._agent.end_transaction()
         elif not self.is_dropped:
@@ -131,6 +131,6 @@ class OTSpan(OTSpanBase):
 
 
 class OTSpanContext(OTSpanContextBase):
-    def __init__(self, trace_parent, span=None):
+    def __init__(self, trace_parent, span=None) -> None:
         self.trace_parent = trace_parent
         self.span = span

--- a/elasticapm/contrib/opentracing/tracer.py
+++ b/elasticapm/contrib/opentracing/tracer.py
@@ -43,7 +43,7 @@ from elasticapm.utils import disttracing
 
 
 class Tracer(TracerBase):
-    def __init__(self, client_instance=None, config=None, scope_manager=None):
+    def __init__(self, client_instance=None, config=None, scope_manager=None) -> None:
         self._agent = client_instance or get_client() or elasticapm.Client(config=config)
         if scope_manager and not isinstance(scope_manager, ThreadLocalScopeManager):
             warnings.warn(

--- a/elasticapm/contrib/pylons/__init__.py
+++ b/elasticapm/contrib/pylons/__init__.py
@@ -42,7 +42,7 @@ def list_from_setting(config, setting):
 
 
 class ElasticAPM(Middleware):
-    def __init__(self, app, config, client_cls=None):
+    def __init__(self, app, config, client_cls=None) -> None:
         client_config = {key[11:]: val for key, val in config.items() if key.startswith("elasticapm.")}
         if client_cls is None:
             client = get_client() or Client(**client_config)

--- a/elasticapm/contrib/rq/__init__.py
+++ b/elasticapm/contrib/rq/__init__.py
@@ -29,7 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-def register_elasticapm(client, worker):
+def register_elasticapm(client, worker) -> None:
     """Given an ElasticAPM client and an RQ worker, registers exception handlers
     with the worker so exceptions are logged to the apm server.
 
@@ -44,7 +44,7 @@ def register_elasticapm(client, worker):
 
     """
 
-    def send_to_server(job, *exc_info):
+    def send_to_server(job, *exc_info) -> None:
         client.capture_exception(
             exc_info=exc_info,
             extra={

--- a/elasticapm/contrib/sanic/__init__.py
+++ b/elasticapm/contrib/sanic/__init__.py
@@ -170,7 +170,7 @@ class ElasticAPM:
         assert self._client, "capture_message called before application configuration is initialized"
         return self._client.capture_message(message=message, param_message=param_message, **kwargs)
 
-    def _setup_client_config(self, config: APMConfigType = None):
+    def _setup_client_config(self, config: APMConfigType = None) -> None:
         app_based_config = SanicAPMConfig(self._app)
         if dict(app_based_config):
             self._client_config = dict(app_based_config)
@@ -235,7 +235,7 @@ class ElasticAPM:
     async def _setup_default_custom_context(self, request: Request) -> CustomInfoType:
         return request.match_info
 
-    def setup_middleware(self, entity: ExtendableMiddlewareGroup):
+    def setup_middleware(self, entity: ExtendableMiddlewareGroup) -> None:
         """
         Adhoc registration of the middlewares for Blueprint and BlueprintGroup if you don't want to instrument
         your entire application. Only part of it can be done.
@@ -254,7 +254,7 @@ class ElasticAPM:
         """
 
         @entity.middleware("request")
-        async def _instrument_request(request: Request):
+        async def _instrument_request(request: Request) -> None:
             if not self._client.should_ignore_url(url=request.path):
                 trace_parent = TraceParent.from_headers(headers=request.headers)
                 self._client.begin_transaction("request", trace_parent=trace_parent)
@@ -277,7 +277,7 @@ class ElasticAPM:
 
         # noinspection PyUnusedLocal
         @entity.middleware("response")
-        async def _instrument_response(request: Request, response: HTTPResponse):
+        async def _instrument_response(request: Request, response: HTTPResponse) -> None:
             await set_context(
                 lambda: get_response_info(
                     config=self._client.config, response=response, event_type=constants.TRANSACTION
@@ -304,21 +304,21 @@ class ElasticAPM:
         if name:
             set_transaction_name(name, override=False)
 
-    async def _setup_custom_context(self, request: Request):
+    async def _setup_custom_context(self, request: Request) -> None:
         if self._custom_context_callback:
             set_custom_context(data=await self._custom_context_callback(request))
         else:
             set_custom_context(data=await self._setup_default_custom_context(request=request))
 
     # noinspection PyBroadException,PyProtectedMember
-    def _setup_exception_manager(self):
+    def _setup_exception_manager(self) -> None:
         """
         Setup global exception handler where all unhandled exception can be caught and tracked to APM server
         :return:
         """
 
         # noinspection PyUnusedLocal
-        async def _handler(request: Request, exception: BaseException):
+        async def _handler(request: Request, exception: BaseException) -> None:
             if not self._client:
                 return
 

--- a/elasticapm/contrib/sanic/patch.py
+++ b/elasticapm/contrib/sanic/patch.py
@@ -45,18 +45,18 @@ class ElasticAPMPatchedErrorHandler(ErrorHandler):
     chain the exception down to the original handler so that we don't get in the way of standard exception handling.
     """
 
-    def __init__(self, current_handler: ErrorHandler):
+    def __init__(self, current_handler: ErrorHandler) -> None:
         super(ElasticAPMPatchedErrorHandler, self).__init__()
         self._current_handler = current_handler  # type: ErrorHandler
         self._apm_handler = None  # type: ApmHandlerType
 
-    def add(self, exception, handler, *args, **kwargs):
+    def add(self, exception, handler, *args, **kwargs) -> None:
         self._current_handler.add(exception, handler, *args, **kwargs)
 
     def lookup(self, exception, *args, **kwargs):
         return self._current_handler.lookup(exception, *args, **kwargs)
 
-    def setup_apm_handler(self, apm_handler: ApmHandlerType, force: bool = False):
+    def setup_apm_handler(self, apm_handler: ApmHandlerType, force: bool = False) -> None:
         if self._apm_handler is None or force:
             self._apm_handler = apm_handler
 

--- a/elasticapm/contrib/sanic/utils.py
+++ b/elasticapm/contrib/sanic/utils.py
@@ -44,7 +44,7 @@ from elasticapm.utils import get_url_dict
 
 
 class SanicAPMConfig(dict):
-    def __init__(self, app: Sanic):
+    def __init__(self, app: Sanic) -> None:
         super(SanicAPMConfig, self).__init__()
         for _key, _v in app.config.items():
             if _key.startswith("ELASTIC_APM_"):

--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -237,7 +237,7 @@ class _lambda_transaction(object):
         self.send_partial_transaction()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """
         Transaction teardown
         """
@@ -419,7 +419,7 @@ class _lambda_transaction(object):
             elasticapm.set_context(message_context, "message")
         self.client._transport.add_metadata(metadata)
 
-    def send_partial_transaction(self):
+    def send_partial_transaction(self) -> None:
         """
         We synchronously send the (partial) transaction to the Lambda Extension
         so that the transaction can be reported even if the lambda runtime times

--- a/elasticapm/contrib/serverless/azure.py
+++ b/elasticapm/contrib/serverless/azure.py
@@ -86,14 +86,14 @@ class ElasticAPMExtension(AppExtensionBase):
     client = None
 
     @classmethod
-    def init(cls):
+    def init(cls) -> None:
         """The function will be executed when the extension is loaded.
         Happens when Azure Functions customers import the extension module.
         """
         elasticapm.instrument()
 
     @classmethod
-    def configure(cls, client_class=AzureFunctionsClient, **kwargs):
+    def configure(cls, client_class=AzureFunctionsClient, **kwargs) -> None:
         client = elasticapm.get_client()
         if not client:
             kwargs["metrics_interval"] = "0ms"
@@ -120,7 +120,7 @@ class ElasticAPMExtension(AppExtensionBase):
         cls.client = client
 
     @classmethod
-    def pre_invocation_app_level(cls, logger, context, func_args: Dict[str, object] = None, *args, **kwargs):
+    def pre_invocation_app_level(cls, logger, context, func_args: Dict[str, object] = None, *args, **kwargs) -> None:
         """
         This must be implemented as a @staticmethod. It will be called right
         before a customer's function is being executed.
@@ -158,7 +158,7 @@ class ElasticAPMExtension(AppExtensionBase):
     @classmethod
     def post_invocation_app_level(
         cls, logger, context, func_args: Dict[str, object] = None, func_ret=Optional[object], *args, **kwargs
-    ):
+    ) -> None:
         client = cls.client
         if isinstance(func_ret, func.HttpResponse):
             elasticapm.set_context(lambda: get_data_from_response(func_ret, client.config.capture_headers), "response")

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -105,7 +105,7 @@ class ElasticAPM:
     >>> elasticapm.capture_message('hello, world!')
     """
 
-    def __init__(self, app: ASGIApp, client: Optional[Client], **kwargs):
+    def __init__(self, app: ASGIApp, client: Optional[Client], **kwargs) -> None:
         """
 
         Args:
@@ -139,7 +139,7 @@ class ElasticAPM:
             return
 
         @functools.wraps(send)
-        async def wrapped_send(message):
+        async def wrapped_send(message) -> None:
             if message.get("type") == "http.response.start":
                 await set_context(
                     lambda: get_data_from_response(message, self.client.config, constants.TRANSACTION), "response"
@@ -202,7 +202,7 @@ class ElasticAPM:
 
             raise
 
-    async def capture_exception(self, *args, **kwargs):
+    async def capture_exception(self, *args, **kwargs) -> None:
         """Captures your exception.
 
         Args:
@@ -211,7 +211,7 @@ class ElasticAPM:
         """
         self.client.capture_exception(*args, **kwargs)
 
-    async def capture_message(self, *args, **kwargs):
+    async def capture_message(self, *args, **kwargs) -> None:
         """Captures your message.
 
         Args:
@@ -220,7 +220,7 @@ class ElasticAPM:
         """
         self.client.capture_message(*args, **kwargs)
 
-    async def _request_started(self, request: Request):
+    async def _request_started(self, request: Request) -> None:
         """Captures the begin of the request processing to APM.
 
         Args:

--- a/elasticapm/contrib/starlette/utils.py
+++ b/elasticapm/contrib/starlette/utils.py
@@ -96,7 +96,7 @@ async def get_data_from_response(message: dict, config: Config, event_type: str)
     return result
 
 
-async def set_body(request: Request, body: bytes):
+async def set_body(request: Request, body: bytes) -> None:
     """Overwrites body in Starlette.
 
     Args:

--- a/elasticapm/contrib/tornado/__init__.py
+++ b/elasticapm/contrib/tornado/__init__.py
@@ -41,7 +41,7 @@ from elasticapm import Client
 
 
 class ElasticAPM:
-    def __init__(self, app, client=None, **config):
+    def __init__(self, app, client=None, **config) -> None:
         """
         Create the elasticapm Client object and store in the app for later
         use.

--- a/elasticapm/contrib/twisted/__init__.py
+++ b/elasticapm/contrib/twisted/__init__.py
@@ -54,10 +54,10 @@ class LogObserver(object):
         log.failure("Math is hard!")
     """
 
-    def __init__(self, client=None, **kwargs):
+    def __init__(self, client=None, **kwargs) -> None:
         self.client = client or Client(**kwargs)
 
-    def __call__(self, event):
+    def __call__(self, event) -> None:
         failure = event.get("log_failure")
         if failure is not None:
             self.client.capture_exception(

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -45,7 +45,7 @@ from elasticapm.utils.stacks import iter_stack_frames
 
 
 class LoggingHandler(logging.Handler):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.client = None
         if "client" in kwargs:
             self.client = kwargs.pop("client")
@@ -260,7 +260,7 @@ class Formatter(logging.Formatter):
                                       "span.id=%(elasticapm_span_id)s"
     """
 
-    def __init__(self, fmt=None, datefmt=None, style="%"):
+    def __init__(self, fmt=None, datefmt=None, style="%") -> None:
         if fmt is None:
             fmt = "%(message)s"
         fmt = (

--- a/elasticapm/instrumentation/control.py
+++ b/elasticapm/instrumentation/control.py
@@ -36,7 +36,7 @@ from elasticapm.instrumentation import register
 _lock = threading.Lock()
 
 
-def instrument():
+def instrument() -> None:
     """
     Instruments all registered methods/functions with a wrapper
     """
@@ -45,7 +45,7 @@ def instrument():
             obj.instrument()
 
 
-def uninstrument():
+def uninstrument() -> None:
     """
     If present, removes instrumentation and replaces it with the original method/function
     """

--- a/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
+++ b/elasticapm/instrumentation/packages/asyncio/aiohttp_client.py
@@ -88,7 +88,7 @@ class AioHttpClientInstrumentation(AsyncAbstractInstrumentedModule):
         kwargs["headers"] = headers
         return args, kwargs
 
-    def _set_disttracing_headers(self, headers, trace_parent, transaction):
+    def _set_disttracing_headers(self, headers, trace_parent, transaction) -> None:
         trace_parent_str = trace_parent.to_string()
         headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent_str
         if transaction.tracer.config.use_elastic_traceparent_header:

--- a/elasticapm/instrumentation/packages/base.py
+++ b/elasticapm/instrumentation/packages/base.py
@@ -98,7 +98,7 @@ class AbstractInstrumentedModule(object):
         # ("requests.sessions", "Session.send"),
     ]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.originals = {}
         self.instrumented = False
 
@@ -121,7 +121,7 @@ class AbstractInstrumentedModule(object):
     def get_instrument_list(self):
         return self.instrument_list
 
-    def instrument(self):
+    def instrument(self) -> None:
         if self.instrumented:
             return
 
@@ -170,7 +170,7 @@ class AbstractInstrumentedModule(object):
             logger.debug("Skipping instrumentation of %s. %s", self.name, ex)
         self.instrumented = True
 
-    def uninstrument(self):
+    def uninstrument(self) -> None:
         if not self.instrumented or not self.originals:
             return
         uninstrumented_methods = []

--- a/elasticapm/instrumentation/packages/botocore.py
+++ b/elasticapm/instrumentation/packages/botocore.py
@@ -205,7 +205,7 @@ def handle_sqs(operation_name, service, instance, args, kwargs, context):
     return HandlerInfo(signature, span_type, span_subtype, op["span_action"], context)
 
 
-def modify_span_sqs_pre(span, args, kwargs):
+def modify_span_sqs_pre(span, args, kwargs) -> None:
     operation_name = kwargs.get("operation_name", args[0])
     if span.id:
         trace_parent = span.transaction.trace_parent.copy_from(span_id=span.id)
@@ -235,7 +235,7 @@ def modify_span_sqs_pre(span, args, kwargs):
                 message_attributes.extend([constants.TRACEPARENT_HEADER_NAME, constants.TRACESTATE_HEADER_NAME])
 
 
-def modify_span_sqs_post(span: SpanType, args, kwargs, result):
+def modify_span_sqs_post(span: SpanType, args, kwargs, result) -> None:
     operation_name = kwargs.get("operation_name", args[0])
     if operation_name == "ReceiveMessage" and "Messages" in result:
         for message in result["Messages"][:1000]:  # only up to 1000 span links are recorded

--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -43,7 +43,7 @@ from elasticapm.utils.encoding import force_text, shorten
 
 
 class Literal(object):
-    def __init__(self, literal_type, content):
+    def __init__(self, literal_type, content) -> None:
         self.literal_type = literal_type
         self.content = content
 
@@ -200,7 +200,7 @@ class CursorProxy(wrapt.ObjectProxy):
     provider_name = None
     DML_QUERIES = ("INSERT", "DELETE", "UPDATE")
 
-    def __init__(self, wrapped, destination_info=None):
+    def __init__(self, wrapped, destination_info=None) -> None:
         super(CursorProxy, self).__init__(wrapped)
         self._self_destination_info = destination_info or {}
 
@@ -259,7 +259,7 @@ class CursorProxy(wrapt.ObjectProxy):
 class ConnectionProxy(wrapt.ObjectProxy):
     cursor_proxy = CursorProxy
 
-    def __init__(self, wrapped, destination_info=None):
+    def __init__(self, wrapped, destination_info=None) -> None:
         super(ConnectionProxy, self).__init__(wrapped)
         self._self_destination_info = destination_info
 

--- a/elasticapm/instrumentation/packages/django/__init__.py
+++ b/elasticapm/instrumentation/packages/django/__init__.py
@@ -41,7 +41,7 @@ class DjangoAutoInstrumentation(AbstractInstrumentedModule):
 
     creates_transactions = True
 
-    def call(self, module, method, wrapped, instance, args, kwargs):
+    def call(self, module, method, wrapped, instance, args, kwargs) -> None:
         installed_apps = list(args[0] if args else kwargs["installed_apps"])
         if (
             "elasticapm.contrib.django" not in installed_apps

--- a/elasticapm/instrumentation/packages/elasticsearch.py
+++ b/elasticapm/instrumentation/packages/elasticsearch.py
@@ -81,7 +81,7 @@ class ElasticsearchConnectionInstrumentation(AbstractInstrumentedModule):
 
         return result
 
-    def _update_context_by_request_data(self, context, instance, args, kwargs):
+    def _update_context_by_request_data(self, context, instance, args, kwargs) -> None:
         args_len = len(args)
         url = args[1] if args_len > 1 else kwargs.get("url")
         params = args[2] if args_len > 2 else kwargs.get("params")

--- a/elasticapm/instrumentation/packages/flask.py
+++ b/elasticapm/instrumentation/packages/flask.py
@@ -40,7 +40,7 @@ class FlaskInstrumentation(AbstractInstrumentedModule):
 
     creates_transactions = True
 
-    def call(self, module, method, wrapped, instance, args, kwargs):
+    def call(self, module, method, wrapped, instance, args, kwargs) -> None:
         from elasticapm.contrib.flask import ElasticAPM
 
         wrapped(*args, **kwargs)
@@ -48,7 +48,7 @@ class FlaskInstrumentation(AbstractInstrumentedModule):
         instance.elasticapm_client = client
         self.instance = instance
 
-    def uninstrument(self):
+    def uninstrument(self) -> None:
         """
         This is mostly here for testing. If we want to support live
         instrumenting and uninstrumenting, we'll need to also extend the

--- a/elasticapm/instrumentation/packages/httplib2.py
+++ b/elasticapm/instrumentation/packages/httplib2.py
@@ -110,7 +110,7 @@ class Httplib2Instrumentation(AbstractInstrumentedModule):
         self._set_disttracing_headers(params["headers"], trace_parent, transaction)
         return args, kwargs
 
-    def _set_disttracing_headers(self, headers, trace_parent, transaction):
+    def _set_disttracing_headers(self, headers, trace_parent, transaction) -> None:
         trace_parent_str = trace_parent.to_string()
         headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent_str
         if transaction.tracer.config.use_elastic_traceparent_header:

--- a/elasticapm/instrumentation/packages/httpx/utils.py
+++ b/elasticapm/instrumentation/packages/httpx/utils.py
@@ -77,7 +77,7 @@ def get_status(response) -> int:
     return status_code
 
 
-def set_disttracing_headers(headers, trace_parent, transaction):
+def set_disttracing_headers(headers, trace_parent, transaction) -> None:
     trace_parent_str = trace_parent.to_string()
     headers.append((bytes(constants.TRACEPARENT_HEADER_NAME, "utf-8"), bytes(trace_parent_str, "utf-8")))
     if transaction.tracer.config.use_elastic_traceparent_header:

--- a/elasticapm/instrumentation/packages/tornado.py
+++ b/elasticapm/instrumentation/packages/tornado.py
@@ -41,7 +41,7 @@ logger = get_logger("elasticapm.instrument")
 
 
 class TornadoBaseInstrumentedModule(AbstractInstrumentedModule):
-    def instrument(self):
+    def instrument(self) -> None:
         try:
             import tornado
 

--- a/elasticapm/instrumentation/packages/urllib.py
+++ b/elasticapm/instrumentation/packages/urllib.py
@@ -113,7 +113,7 @@ class UrllibInstrumentation(AbstractInstrumentedModule):
         self._set_disttracing_headers(request_object, trace_parent, transaction)
         return args, kwargs
 
-    def _set_disttracing_headers(self, request_object, trace_parent, transaction):
+    def _set_disttracing_headers(self, request_object, trace_parent, transaction) -> None:
         trace_parent_str = trace_parent.to_string()
         request_object.add_header(constants.TRACEPARENT_HEADER_NAME, trace_parent_str)
         if transaction.tracer.config.use_elastic_traceparent_header:

--- a/elasticapm/instrumentation/packages/urllib3.py
+++ b/elasticapm/instrumentation/packages/urllib3.py
@@ -37,7 +37,7 @@ from elasticapm.utils import default_ports
 from elasticapm.utils.disttracing import TracingOptions
 
 
-def _set_disttracing_headers(headers, trace_parent, transaction):
+def _set_disttracing_headers(headers, trace_parent, transaction) -> None:
     trace_parent_str = trace_parent.to_string()
     headers[constants.TRACEPARENT_HEADER_NAME] = trace_parent_str
     if transaction.tracer.config.use_elastic_traceparent_header:

--- a/elasticapm/instrumentation/register.py
+++ b/elasticapm/instrumentation/register.py
@@ -107,11 +107,11 @@ _wrapper_register = {
 }
 
 
-def register(cls):
+def register(cls) -> None:
     _cls_register.add(cls)
 
 
-def register_wrapper_instrumentations():
+def register_wrapper_instrumentations() -> None:
     _cls_register.update(_wrapper_register)
 
 

--- a/elasticapm/instrumentation/wrapper/__init__.py
+++ b/elasticapm/instrumentation/wrapper/__init__.py
@@ -35,7 +35,7 @@ import shutil
 import elasticapm
 
 
-def setup():
+def setup() -> None:
     parser = argparse.ArgumentParser(
         prog="elasticapm-run",
         description="""

--- a/elasticapm/instrumentation/wrapper/sitecustomize.py
+++ b/elasticapm/instrumentation/wrapper/sitecustomize.py
@@ -33,7 +33,7 @@ from elasticapm.conf import WrapperConfig
 from elasticapm.instrumentation.register import register_wrapper_instrumentations
 
 
-def setup():
+def setup() -> None:
     config = WrapperConfig()
     register_wrapper_instrumentations()
     if config.instrument and config.enabled:

--- a/elasticapm/metrics/sets/cpu_linux.py
+++ b/elasticapm/metrics/sets/cpu_linux.py
@@ -66,7 +66,7 @@ logger = logging.getLogger("elasticapm.metrics.cpu_linux")
 
 
 class CGroupFiles(object):
-    def __init__(self, limit, usage, stat):
+    def __init__(self, limit, usage, stat) -> None:
         self.limit = limit if os.access(limit, os.R_OK) else None
         self.usage = usage if os.access(usage, os.R_OK) else None
         self.stat = stat if os.access(stat, os.R_OK) else None
@@ -81,7 +81,7 @@ class CPUMetricSet(MetricSet):
         memory_stats_file=MEM_STATS,
         proc_self_cgroup=PROC_SELF_CGROUP,
         mount_info=PROC_SELF_MOUNTINFO,
-    ):
+    ) -> None:
         self.page_size = resource.getpagesize()
         self.previous = {}
         self._read_data_lock = threading.Lock()
@@ -175,7 +175,7 @@ class CPUMetricSet(MetricSet):
         except IOError:
             pass
 
-    def before_collect(self):
+    def before_collect(self) -> None:
         new = self.read_process_stats()
         new.update(self.read_system_stats())
         with self._read_data_lock:

--- a/elasticapm/metrics/sets/cpu_psutil.py
+++ b/elasticapm/metrics/sets/cpu_psutil.py
@@ -37,13 +37,13 @@ except ImportError:
 
 
 class CPUMetricSet(MetricSet):
-    def __init__(self, registry):
+    def __init__(self, registry) -> None:
         psutil.cpu_percent(interval=None)
         self._process = psutil.Process()
         self._process.cpu_percent(interval=None)
         super(CPUMetricSet, self).__init__(registry)
 
-    def before_collect(self):
+    def before_collect(self) -> None:
         self.gauge("system.cpu.total.norm.pct").val = psutil.cpu_percent(interval=None) / 100.0
         self.gauge("system.memory.actual.free").val = psutil.virtual_memory().available
         self.gauge("system.memory.total").val = psutil.virtual_memory().total

--- a/elasticapm/metrics/sets/prometheus.py
+++ b/elasticapm/metrics/sets/prometheus.py
@@ -37,18 +37,18 @@ from elasticapm.metrics.base_metrics import MetricSet
 
 
 class PrometheusMetrics(MetricSet):
-    def __init__(self, registry):
+    def __init__(self, registry) -> None:
         super(PrometheusMetrics, self).__init__(registry)
         self._prometheus_registry = prometheus_client.REGISTRY
 
-    def before_collect(self):
+    def before_collect(self) -> None:
         for metric in self._prometheus_registry.collect():
             metric_type = self.METRIC_MAP.get(metric.type, None)
             if not metric_type:
                 continue
             metric_type(self, metric.name, metric.samples, metric.unit)
 
-    def _prom_counter_handler(self, name, samples, unit):
+    def _prom_counter_handler(self, name, samples, unit) -> None:
         # Counters can be converted 1:1 from Prometheus to our
         # format. Each pair of samples represents a distinct labelset for a
         # given name. The pair consists of the value, and a "created" timestamp.
@@ -58,7 +58,7 @@ class PrometheusMetrics(MetricSet):
                 self._registry.client.config.prometheus_metrics_prefix + name, **total_sample.labels
             ).val = total_sample.value
 
-    def _prom_gauge_handler(self, name, samples, unit):
+    def _prom_gauge_handler(self, name, samples, unit) -> None:
         # Counters can be converted 1:1 from Prometheus to our
         # format. Each sample represents a distinct labelset for a
         # given name
@@ -67,7 +67,7 @@ class PrometheusMetrics(MetricSet):
                 self._registry.client.config.prometheus_metrics_prefix + name, **sample.labels
             ).val = sample.value
 
-    def _prom_summary_handler(self, name, samples, unit):
+    def _prom_summary_handler(self, name, samples, unit) -> None:
         # Prometheus Summaries are analogous to our Timers, having
         # a count and a sum. A prometheus summary is represented by
         # three values. The list of samples for a given name can be
@@ -79,7 +79,7 @@ class PrometheusMetrics(MetricSet):
                 count_sample.value,
             )
 
-    def _prom_histogram_handler(self, name, samples, unit):
+    def _prom_histogram_handler(self, name, samples, unit) -> None:
         # Prometheus histograms are structured as a series of counts
         # with an "le" label. The count of each label signifies all
         # observations with a lower-or-equal value with respect to

--- a/elasticapm/middleware.py
+++ b/elasticapm/middleware.py
@@ -44,7 +44,7 @@ class ElasticAPM(object):
     >>> application = ElasticAPM(application, Client())
     """
 
-    def __init__(self, application, client):
+    def __init__(self, application, client) -> None:
         self.application = application
         self.client = client
 

--- a/elasticapm/processors.py
+++ b/elasticapm/processors.py
@@ -86,7 +86,7 @@ def sanitize_stacktrace_locals(client, event):
     :return: The modified event
     """
 
-    def func(frame):
+    def func(frame) -> None:
         if "vars" in frame:
             frame["vars"] = varmap(_sanitize, frame["vars"], sanitize_field_names=client.config.sanitize_field_names)
 

--- a/elasticapm/traces.py
+++ b/elasticapm/traces.py
@@ -894,7 +894,9 @@ class DroppedSpan(BaseSpan):
 
 
 class Tracer(object):
-    def __init__(self, frames_collector_func, frames_processing_func, queue_func, config, agent: "elasticapm.Client") -> None:
+    def __init__(
+        self, frames_collector_func, frames_processing_func, queue_func, config, agent: "elasticapm.Client"
+    ) -> None:
         self.config = config
         self.queue_func = queue_func
         self.frames_processing_func = frames_processing_func

--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -66,7 +66,7 @@ class Transport(ThreadManager):
         queue_chill_time=1.0,
         processors=None,
         **kwargs
-    ):
+    ) -> None:
         """
         Create a new Transport instance
 
@@ -99,7 +99,7 @@ class Transport(ThreadManager):
     def _max_buffer_size(self):
         return self.client.config.api_request_size if self.client else None
 
-    def queue(self, event_type, data, flush=False):
+    def queue(self, event_type, data, flush=False) -> None:
         try:
             self._flushed.clear()
             kwargs = {"chill": not (event_type == "close" or flush)} if self._is_chilled_queue else {}
@@ -108,7 +108,7 @@ class Transport(ThreadManager):
         except _queue.Full:
             logger.debug("Event of type %s dropped due to full event queue", event_type)
 
-    def _process_queue(self):
+    def _process_queue(self) -> None:
         # Rebuild the metadata to capture new process information
         if self.client:
             self._metadata = self.client.build_metadata()
@@ -222,11 +222,11 @@ class Transport(ThreadManager):
         buffer = gzip.GzipFile(fileobj=io.BytesIO(), mode="w", compresslevel=self._compress_level)
         return buffer
 
-    def _write_metadata(self, buffer):
+    def _write_metadata(self, buffer) -> None:
         data = (self._json_serializer({"metadata": self._metadata}) + "\n").encode("utf-8")
         buffer.write(data)
 
-    def add_metadata(self, data):
+    def add_metadata(self, data) -> None:
         """
         Add additional metadata do the dictionary
 
@@ -262,7 +262,7 @@ class Transport(ThreadManager):
         else:
             return _queue.Queue(maxsize=10000)
 
-    def _flush(self, buffer, forced_flush=False):
+    def _flush(self, buffer, forced_flush=False) -> None:
         """
         Flush the queue. This method should only be called from the event processing queue
         :return: None
@@ -280,7 +280,7 @@ class Transport(ThreadManager):
             except Exception as e:
                 self.handle_transport_fail(e)
 
-    def start_thread(self, pid=None):
+    def start_thread(self, pid=None) -> None:
         super(Transport, self).start_thread(pid=pid)
         if (not self._thread or self.pid != self._thread.pid) and not self._closed:
             self.handle_fork()
@@ -299,7 +299,7 @@ class Transport(ThreadManager):
         """
         raise NotImplementedError
 
-    def close(self):
+    def close(self) -> None:
         """
         Cleans up resources and closes connection
         :return:
@@ -323,13 +323,13 @@ class Transport(ThreadManager):
         if not self._flushed.wait(timeout=self._max_flush_time_seconds):
             raise ValueError("flush timed out")
 
-    def handle_transport_success(self, **kwargs):
+    def handle_transport_success(self, **kwargs) -> None:
         """
         Success handler called by the transport on successful send
         """
         self.state.set_success()
 
-    def handle_transport_fail(self, exception=None, **kwargs):
+    def handle_transport_fail(self, exception=None, **kwargs) -> None:
         """
         Failure handler called by the transport on send failure
         """
@@ -350,7 +350,7 @@ class TransportState(object):
     ONLINE = 1
     ERROR = 0
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.status = self.ONLINE
         self.last_check = None
         self.retry_number = -1
@@ -363,12 +363,12 @@ class TransportState(object):
 
         return timeit.default_timer() - self.last_check > interval
 
-    def set_fail(self):
+    def set_fail(self) -> None:
         self.status = self.ERROR
         self.retry_number += 1
         self.last_check = timeit.default_timer()
 
-    def set_success(self):
+    def set_success(self) -> None:
         self.status = self.ONLINE
         self.last_check = None
         self.retry_number = -1
@@ -385,7 +385,7 @@ class ChilledQueue(_queue.Queue, object):
     be removed once we stop support for Python 2
     """
 
-    def __init__(self, maxsize=0, chill_until=100, max_chill_time=1.0):
+    def __init__(self, maxsize=0, chill_until=100, max_chill_time=1.0) -> None:
         self._chill_until = chill_until
         self._max_chill_time = max_chill_time
         self._last_unchill = time.time()

--- a/elasticapm/transport/exceptions.py
+++ b/elasticapm/transport/exceptions.py
@@ -33,6 +33,6 @@
 
 
 class TransportException(Exception):
-    def __init__(self, message, data=None):
+    def __init__(self, message, data=None) -> None:
         super(TransportException, self).__init__(message)
         self.data = data

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -200,12 +200,12 @@ class Transport(HTTPTransportBase):
                 logger.debug("Could not parse Cache-Control header: %s", response_headers["Cache-Control"])
         return max_age
 
-    def _process_queue(self):
+    def _process_queue(self) -> None:
         if not self.client.server_version:
             self.fetch_server_info()
         super()._process_queue()
 
-    def fetch_server_info(self):
+    def fetch_server_info(self) -> None:
         headers = self._headers.copy() if self._headers else {}
         headers.update(self.auth_headers)
         headers[b"accept"] = b"text/plain"

--- a/elasticapm/transport/http_base.py
+++ b/elasticapm/transport/http_base.py
@@ -46,7 +46,7 @@ class HTTPTransportBase(Transport):
         server_cert=None,
         server_ca_cert_file=None,
         **kwargs
-    ):
+    ) -> None:
         self._url = url
         self._verify_server_cert = verify_server_cert
         self._server_cert = server_cert

--- a/elasticapm/utils/compat.py
+++ b/elasticapm/utils/compat.py
@@ -46,7 +46,7 @@ def noop_decorator(func: _AnnotatedFunctionT) -> _AnnotatedFunctionT:
     return wrapped
 
 
-def atexit_register(func):
+def atexit_register(func) -> None:
     """
     Uses either uwsgi's atexit mechanism, or atexit from the stdlib.
 
@@ -59,7 +59,7 @@ def atexit_register(func):
 
         orig = getattr(uwsgi, "atexit", None)
 
-        def uwsgi_atexit():
+        def uwsgi_atexit() -> None:
             if callable(orig):
                 orig()
             func()

--- a/elasticapm/utils/disttracing.py
+++ b/elasticapm/utils/disttracing.py
@@ -52,7 +52,7 @@ class TraceParent(object):
         trace_options: "TracingOptions",
         tracestate: Optional[str] = None,
         is_legacy: bool = False,
-    ):
+    ) -> None:
         self.version: int = version
         self.trace_id: str = trace_id
         self.span_id: str = span_id
@@ -244,7 +244,7 @@ class TraceParent(object):
             else:
                 return elastic_state
 
-    def add_tracestate(self, key, val):
+    def add_tracestate(self, key, val) -> None:
         """
         Add key/value pair to the tracestate.
 
@@ -285,7 +285,7 @@ class TracingOptions(ctypes.Union):
     _anonymous_ = ("bit",)
     _fields_ = [("bit", TracingOptions_bits), ("asByte", ctypes.c_uint8)]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super(TracingOptions, self).__init__()
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/elasticapm/utils/threading.py
+++ b/elasticapm/utils/threading.py
@@ -47,7 +47,7 @@ class IntervalTimer(threading.Thread):
 
     def __init__(
         self, function, interval, name=None, args=(), kwargs=None, daemon=None, evaluate_function_interval=False
-    ):
+    ) -> None:
         """
 
         :param function: the function to run
@@ -68,7 +68,7 @@ class IntervalTimer(threading.Thread):
         self._interval_done = threading.Event()
         self._evaluate_function_interval = evaluate_function_interval
 
-    def run(self):
+    def run(self) -> None:
         execution_time = 0
         interval_override = None
         while True:
@@ -91,16 +91,16 @@ class IntervalTimer(threading.Thread):
 
             execution_time = default_timer() - start
 
-    def cancel(self):
+    def cancel(self) -> None:
         self._interval_done.set()
 
 
 class ThreadManager(object):
-    def __init__(self):
+    def __init__(self) -> None:
         self.pid = None
         self.start_stop_order = 100
 
-    def start_thread(self, pid=None):
+    def start_thread(self, pid=None) -> None:
         if not pid:
             pid = os.getpid()
         self.pid = pid

--- a/elasticapm/utils/time.py
+++ b/elasticapm/utils/time.py
@@ -55,7 +55,7 @@ def time_to_perf_counter(timestamp: float) -> float:
     return timestamp + CLOCK_DIFF
 
 
-def _calculate_clock_diff():
+def _calculate_clock_diff() -> None:
     """
     Calculate the difference between `time.perf_counter()` and `time.time()`
 

--- a/setup.py
+++ b/setup.py
@@ -67,16 +67,16 @@ pkg_resources.require("setuptools>=39.2")
 class PyTest(TestCommand):
     user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         TestCommand.initialize_options(self)
         self.pytest_args = []
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         TestCommand.finalize_options(self)
         self.test_args = []
         self.test_suite = True
 
-    def run_tests(self):
+    def run_tests(self) -> None:
         # import here, cause outside the eggs aren't loaded
         import pytest
 

--- a/tests/contrib/asgi/app.py
+++ b/tests/contrib/asgi/app.py
@@ -52,7 +52,7 @@ async def foo():
 
 
 @app.route("/boom")
-async def boom():
+async def boom() -> None:
     assert False
 
 

--- a/tests/contrib/django/fixtures.py
+++ b/tests/contrib/django/fixtures.py
@@ -38,7 +38,7 @@ from elasticapm.contrib.django.client import DjangoClient
 
 
 class TempStoreClient(DjangoClient):
-    def __init__(self, **inline):
+    def __init__(self, **inline) -> None:
         inline.setdefault("transport_class", "tests.fixtures.DummyTransport")
         super(TempStoreClient, self).__init__(**inline)
 

--- a/tests/contrib/django/testapp/middleware.py
+++ b/tests/contrib/django/testapp/middleware.py
@@ -52,7 +52,7 @@ class BrokenViewMiddleware(MiddlewareMixin):
 
 
 class SetTransactionUnsampled(MiddlewareMixin):
-    def process_request(self, request):
+    def process_request(self, request) -> None:
         from elasticapm.traces import execution_context
 
         transaction = execution_context.get_transaction()

--- a/tests/contrib/flask/utils.py
+++ b/tests/contrib/flask/utils.py
@@ -37,7 +37,7 @@ from flask import template_rendered
 def captured_templates(app):
     recorded = []
 
-    def record(sender, template, context, **extra):
+    def record(sender, template, context, **extra) -> None:
         recorded.append((template, context))
 
     template_rendered.connect(record, app)

--- a/tests/contrib/grpc/grpc_app/server.py
+++ b/tests/contrib/grpc/grpc_app/server.py
@@ -46,7 +46,7 @@ elasticapm.instrument()
 
 
 class TestService(pb2_grpc.TestServiceServicer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
     def GetServerResponse(self, request, context):
@@ -56,7 +56,7 @@ class TestService(pb2_grpc.TestServiceServicer):
 
         return pb2.MessageResponse(**result)
 
-    def GetServerResponseAbort(self, request, context):
+    def GetServerResponseAbort(self, request, context) -> None:
         context.abort(grpc.StatusCode.INTERNAL, "foo")
 
     def GetServerResponseUnavailable(self, request, context):
@@ -70,7 +70,7 @@ class TestService(pb2_grpc.TestServiceServicer):
 
 
 class TestServiceAsync(pb2_grpc.TestServiceServicer):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
     async def GetServerResponse(self, request, context):
@@ -80,7 +80,7 @@ class TestServiceAsync(pb2_grpc.TestServiceServicer):
 
         return pb2.MessageResponse(**result)
 
-    async def GetServerResponseAbort(self, request, context):
+    async def GetServerResponseAbort(self, request, context) -> None:
         await context.abort(grpc.StatusCode.INTERNAL, "foo")
 
     async def GetServerResponseUnavailable(self, request, context):
@@ -93,7 +93,7 @@ class TestServiceAsync(pb2_grpc.TestServiceServicer):
         raise Exception("oh no")
 
 
-def serve(port):
+def serve(port) -> None:
     apm_client = GRPCApmClient(
         service_name="grpc-server", disable_metrics="*", api_request_time="100ms", central_config="False"
     )
@@ -104,7 +104,7 @@ def serve(port):
     server.wait_for_termination()
 
 
-async def serve_async(port):
+async def serve_async(port) -> None:
     apm_client = GRPCApmClient(
         service_name="grpc-server", disable_metrics="*", api_request_time="100ms", central_config="False"
     )

--- a/tests/contrib/sanic/fixtures.py
+++ b/tests/contrib/sanic/fixtures.py
@@ -53,7 +53,7 @@ class CustomException(Exception):
 
 
 class CustomErrorHandler(ErrorHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super(CustomErrorHandler, self).__init__()
 
     def default(self, request, exception):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -149,7 +149,7 @@ def validate_span_type_subtype(item: dict) -> Optional[str]:
 
 
 class ValidatingWSGIApp(ContentServer):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.skip_validate = kwargs.pop("skip_validate", False)
         super(ValidatingWSGIApp, self).__init__(**kwargs)
         self.payloads = []
@@ -368,12 +368,12 @@ def sending_elasticapm_client(request, validating_httpserver):
 
 
 class DummyTransport(HTTPTransportBase):
-    def __init__(self, url, *args, **kwargs):
+    def __init__(self, url, *args, **kwargs) -> None:
         super(DummyTransport, self).__init__(url, *args, **kwargs)
         self.events = defaultdict(list)
         self.validation_errors = defaultdict(list)
 
-    def queue(self, event_type, data, flush=False):
+    def queue(self, event_type, data, flush=False) -> None:
         self._flushed.clear()
         data = self._process_event(event_type, data)
         self.events[event_type].append(data)
@@ -389,11 +389,11 @@ class DummyTransport(HTTPTransportBase):
                 if result:
                     self.validation_errors[event_type].append(result)
 
-    def start_thread(self, pid=None):
+    def start_thread(self, pid=None) -> None:
         # don't call the parent method, but the one from ThreadManager
         ThreadManager.start_thread(self, pid=pid)
 
-    def stop_thread(self):
+    def stop_thread(self) -> None:
         pass
 
     def get_config(self, current_version=None, keys=None):
@@ -401,7 +401,7 @@ class DummyTransport(HTTPTransportBase):
 
 
 class TempStoreClient(Client):
-    def __init__(self, config=None, **inline):
+    def __init__(self, config=None, **inline) -> None:
         inline.setdefault("transport_class", "tests.fixtures.DummyTransport")
         super(TempStoreClient, self).__init__(config, **inline)
 

--- a/tests/instrumentation/broken_class.py
+++ b/tests/instrumentation/broken_class.py
@@ -40,5 +40,5 @@ class B(A):
 
 
 class C(A, B):  # raises TypeError
-    def foo(self):
+    def foo(self) -> None:
         pass

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -36,5 +36,5 @@ def any_record_contains(records, message, logger=None):
     )
 
 
-def assert_any_record_contains(records, message, logger=None):
+def assert_any_record_contains(records, message, logger=None) -> None:
     assert any_record_contains(records, message, logger=logger)


### PR DESCRIPTION
## What does this pull request do?

If a function doesn't return anything, annotate its return type as None. It will make sure that the callee doesn't try to assign the function result to a variable.

> It is recommended but not required that checked functions have annotations for all arguments and the return type. For a checked function, the default annotation for arguments and for the return type is Any.
>
> https://peps.python.org/pep-0484/#the-meaning-of-annotations

## Related issues

-