### PR TITLE
More py3.12 CI fixup

### DIFF
--- a/tests/contrib/grpc/grpc_client_tests.py
+++ b/tests/contrib/grpc/grpc_client_tests.py
@@ -239,13 +239,13 @@ def test_grpc_client_unsampled_transaction(instrument, sending_elasticapm_client
     assert len(payloads) == 1  # only the server_version request
 
 
-@pytest.mark.parametrize("sending_elasticapm_client", [{"transaction_max_spans": 1}], indirect=True)
-def test_grpc_client_max_spans(instrument, sending_elasticapm_client, grpc_client_and_server_url):
+@pytest.mark.parametrize("elasticapm_client", [{"transaction_max_spans": 1}], indirect=True)
+def test_grpc_client_max_spans(instrument, elasticapm_client, grpc_client_and_server_url):
     grpc_client, _ = grpc_client_and_server_url
-    transaction = sending_elasticapm_client.begin_transaction("request")
+    transaction = elasticapm_client.begin_transaction("request")
     _ = grpc_client.GetServerResponse(Message(message="foo"))
     _ = grpc_client.GetServerResponse(Message(message="bar"))
-    sending_elasticapm_client.end_transaction("grpc-test")
+    elasticapm_client.end_transaction("grpc-test")
     assert transaction.dropped_spans == 1
 
 


### PR DESCRIPTION
Switches to non-sending client fixture in `test_grpc_client_max_spans`. The test appeared to be causing a flakey segfault in py3.12, perhaps due to [the client being short-lived](https://github.com/elastic/apm-agent-python/issues/1916) (as it wasn't waiting for anything to be sent to the sending_elasticapm_client, or closing it in-test). It didn't actually need the sending version, so hopefully this fixes that issue 🤞