### PR TITLE
Mark the old logs-as-messages shipper as deprecated

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,21 @@ endif::[]
 //===== Bug fixes
 //
 
+=== Unreleased
+
+// Unreleased changes go here
+// When the next release happens, nest these changes under the "Python Agent version 6.x" heading
+//[float]
+//===== Features
+//
+//[float]
+//===== Bug fixes
+
+[float]
+===== Pending Deprecations
+
+* The log shipping LoggingHandler will be removed in version 7.0.0 of the agent.
+
 
 [[release-notes-6.x]]
 === Python Agent version 6.x

--- a/elasticapm/contrib/django/handlers.py
+++ b/elasticapm/contrib/django/handlers.py
@@ -46,6 +46,13 @@ logger = get_logger("elasticapm.logging")
 
 class LoggingHandler(BaseLoggingHandler):
     def __init__(self, level=logging.NOTSET) -> None:
+        warnings.warn(
+            "The LoggingHandler will be deprecated in v7.0 of the agent. "
+            "Please use `log_ecs_reformatting` and ship the logs with Elastic "
+            "Agent or Filebeat instead. "
+            "https://www.elastic.co/guide/en/apm/agent/python/current/logs.html",
+            PendingDeprecationWarning,
+        )
         # skip initialization of BaseLoggingHandler
         logging.Handler.__init__(self, level=level)
 

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -46,6 +46,13 @@ from elasticapm.utils.stacks import iter_stack_frames
 
 class LoggingHandler(logging.Handler):
     def __init__(self, *args, **kwargs) -> None:
+        warnings.warn(
+            "The LoggingHandler will be deprecated in v7.0 of the agent. "
+            "Please use `log_ecs_reformatting` and ship the logs with Elastic "
+            "Agent or Filebeat instead. "
+            "https://www.elastic.co/guide/en/apm/agent/python/current/logs.html",
+            PendingDeprecationWarning,
+        )
         self.client = None
         if "client" in kwargs:
             self.client = kwargs.pop("client")


### PR DESCRIPTION
## What does this pull request do?

Finishes what was started in https://github.com/elastic/apm-agent-python/pull/1918
