### PR TITLE
Add 3.10 and 3.11 to AWS lambda compatible runtimes

### DIFF
--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -46,7 +46,7 @@ for region in $ALL_AWS_REGIONS; do
     --layer-name="${FULL_LAYER_NAME}" \
     --description="AWS Lambda Extension Layer for the Elastic APM Python Agent" \
     --license-info="BSD-3-Clause" \
-    --compatible-runtimes python3.6 python3.7 python3.8 python3.9 \
+    --compatible-runtimes python3.6 python3.7 python3.8 python3.9 python3.10 python3.11\
     --zip-file="fileb://${zip_file}")
   echo "${publish_output}" > "${AWS_FOLDER}/${region}"
   layer_version=$(echo "${publish_output}" | jq '.Version')


### PR DESCRIPTION
## What does this pull request do?

I noticed when I was testing our lambda layer that we don't have 3.10 and 3.11 listed as compatible runtimes. This fixes that issue.
