### PR TITLE
updatecli: link to the original Pull Request

### DIFF
--- a/.ci/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli.d/update-gherkin-specs.yml
@@ -23,7 +23,15 @@ sources:
     transformers:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
-
+  pull_request:
+    kind: shell
+    dependson:
+      - sha
+    spec:
+      command: gh api /repos/elastic/apm/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      environments:
+        - name: GITHUB_TOKEN
+        - name: PATH
   api_key.feature:
     kind: file
     spec:
@@ -65,6 +73,7 @@ actions:
         ### Why
         *Changeset*
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
+        * {{ source "pull_request" }}
 
 targets:
   api_key.feature:

--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -23,7 +23,15 @@ sources:
     transformers:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
-
+  pull_request:
+    kind: shell
+    dependson:
+      - sha
+    spec:
+      command: gh api /repos/elastic/apm/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      environments:
+        - name: GITHUB_TOKEN
+        - name: PATH
   container_metadata_discovery.json:
     kind: file
     spec:
@@ -69,6 +77,7 @@ actions:
         ### Why
         *Changeset*
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
+        * {{ source "pull_request" }}
 
 targets:
   container_metadata_discovery.json:

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -23,6 +23,15 @@ sources:
     transformers:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
+  pull_request:
+    kind: shell
+    dependson:
+      - sha
+    spec:
+      command: gh api /repos/elastic/apm-data/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      environments:
+        - name: GITHUB_TOKEN
+        - name: PATH
   error.json:
     kind: file
     spec:
@@ -60,6 +69,7 @@ actions:
         ### Why
         *Changeset*
         * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
+        * {{ source "pull_request" }}
 
 targets:
   error.json:


### PR DESCRIPTION
### What

Add the original Pull Request that contains the changes in the specs to be in the description of the Pull Request created with the `updatecli` automation. This will help with track what APM Agents use it.


### Test

Given the updatecli and gh cli

When running

```bash
$ GIT_USER=foo \
GIT_EMAIL=1 \
GITHUB_TOKEN=*** \
updatecli apply --config .ci/updatecli.d/update-specs.yml --push=false --debug
```

Then

```
...
✔ content: found from file "https://github.com/elastic/apm-data/commit/main.patch":
From 5d596b8bb0cbf31aac8ea65e611a8d5d7d5b482d 
...
----
https://github.com/elastic/apm-data/pull/178
----
...
```