### PR TITLE
Fix asyncpg tests to make it compatible with asyncpg>=0.29

### DIFF
--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -42,6 +42,7 @@ FRAMEWORK:
   - mysqlclient-newest
   - aiohttp-newest
   - aiopg-newest
+  - asyncpg-0.28
   - asyncpg-newest
   - tornado-newest
   - starlette-newest

--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -42,7 +42,6 @@ FRAMEWORK:
   - mysqlclient-newest
   - aiohttp-newest
   - aiopg-newest
-  - asyncpg-0.28
   - asyncpg-newest
   - tornado-newest
   - starlette-newest

--- a/.ci/.matrix_framework_full.yml
+++ b/.ci/.matrix_framework_full.yml
@@ -67,6 +67,7 @@ FRAMEWORK:
   - aiohttp-3.0
   - aiohttp-newest
   - aiopg-newest
+  - asyncpg-0.28
   - asyncpg-newest
   - tornado-newest
   - starlette-0.13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         language_version: python3
         exclude: "(tests/utils/stacks/linenos.py|tests/utils/stacks/linenos2.py|tests/contrib/grpc/grpc_app/.*pb2.*.py)"
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.1.0
     hooks:
     -   id: flake8
         exclude: "(tests/utils/stacks/linenos.py|tests/utils/stacks/linenos2.py|tests/contrib/grpc/grpc_app/.*pb2.*.py)"

--- a/elasticapm/contrib/asgi.py
+++ b/elasticapm/contrib/asgi.py
@@ -92,12 +92,14 @@ class ASGITracingMiddleware:
                 body = str(body_raw, errors="ignore")
 
                 # Dispatch to the ASGI callable
-                async def wrapped_receive():
+                async def new_wrapped_receive():
                     if messages:
                         return messages.pop(0)
 
                     # Once that's done we can just await any other messages.
                     return await receive()
+
+                wrapped_receive = new_wrapped_receive
 
             await set_context(lambda: self.get_data_from_request(scope, constants.TRANSACTION, body), "request")
 

--- a/tests/requirements/reqs-asyncpg-0.28.txt
+++ b/tests/requirements/reqs-asyncpg-0.28.txt
@@ -1,0 +1,2 @@
+asyncpg==0.28
+-r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

In asyncpg>=0.29, the query is passed as `kwargs["state"]` instead of as `args`.

https://github.com/MagicStack/asyncpg/commit/cbf64e18a03d69b712bab1790584fc1a4a5b2bb6

I'm not sure if all cases are tested, maybe there are untested cases to fix?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

Closes #1933
