### PR TITLE
[Automation] Update JSON specs

### DIFF
--- a/tests/upstream/json-specs/container_metadata_discovery.json
+++ b/tests/upstream/json-specs/container_metadata_discovery.json
@@ -60,6 +60,41 @@
     },
     "containerId": "6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6",
     "podId": null
+  },
+  "gardener": {
+    "files": {
+      "/proc/self/mountinfo": [
+        "10112 5519 0:864 / / ro,relatime master:1972 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/35235/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27346/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27345/fs:/var/lib/containerd/io.containerd.snapsh",
+        "10113 10112 0:884 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw",
+        "10301 10112 0:926 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "10302 10301 0:930 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666",
+        "10519 10301 0:820 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw",
+        "10520 10112 0:839 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro",
+        "10716 10520 0:26 /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw",
+        "10736 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/volumes/kubernetes.io~empty-dir/tmpdir /tmp rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10737 10112 0:786 / /vault/tls ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64",
+        "10738 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/etc-hosts /etc/hosts rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10739 10301 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/containers/application-search-indexer/9bf2b38c /dev/termination-log rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10740 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/hostname /etc/hostname ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10741 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/resolv.conf /etc/resolv.conf ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10761 10301 0:788 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,inode64",
+        "10762 10112 0:787 / /var/run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64",
+        "5630 10113 0:884 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5631 10113 0:884 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5632 10113 0:884 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5633 10113 0:884 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5634 10113 0:931 / /proc/acpi ro,relatime - tmpfs tmpfs ro,inode64",
+        "5635 10113 0:926 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5636 10113 0:926 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5637 10113 0:926 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5639 10520 0:932 / /sys/firmware ro,relatime - tmpfs tmpfs ro,inode64"
+      ],
+      "/proc/self/cgroup": [
+        "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope"
+      ]
+    },
+    "containerId": "1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1",
+    "podId": "121157b5-c67d-4c3e-9052-cb27bbb711fb"
   }
 }
 


### PR DESCRIPTION


### What
APM agent specs automatic sync
### Why
*Changeset*
* https://github.com/elastic/apm/commit/7ef63617e84081139e6b79b5006c035057dc42fb

---



<Actions>
    <action id="ac2f2f5613c52b74a22b99cc6b7949e09a74a2f2ed2283f7e98135ed83c6e5cd">
        <h3>update-json-specs</h3>
        <details id="51b51c35f35d91535097fd9395976b0be51211da0a6db79e48824e45a55d3156">
            <summary>container_metadata_discovery.json</summary>
            <p>1 file(s) updated with &#34;{\n  \&#34;cgroup_v1_underscores\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63\&#34;,\n    \&#34;podId\&#34;: \&#34;90d81341-92de-11e7-8cf2-507b9d4141fa\&#34;\n  },\n  \&#34;cgroup_v1_openshift\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f\&#34;,\n    \&#34;podId\&#34;: \&#34;22949dce-fd8b-11ea-8ede-98f2b32c645c\&#34;\n  },\n  \&#34;cgroup_v1_ubuntu\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: null,\n    \&#34;podId\&#34;: null\n  },\n  \&#34;cgroup_v1_awsEcs\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;03752a671e744971a862edcee6195646-4015103728\&#34;,\n    \&#34;podId\&#34;: null\n  },\n  \&#34;cgroup_v2\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;0::/\&#34;\n      ],\n      \&#34;/proc/self/mountinfo\&#34;: [\n        \&#34;3984 3905 0:73 / / rw,relatime shared:1863 master:1733 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/KEX7CWLHQCXQY2RHPGTXJ3C26N:/var/lib/docker/overlay2/l/2PVS7JRTRSTVZS4KSUAFML3BIV:/var/lib/docker/overlay2/l/52M7ARM4JDVHCJAYUI6JIKBO4B,upperdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/diff,workdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/work\&#34;,\n        \&#34;3985 3984 0:77 / /proc rw,nosuid,nodev,noexec,relatime shared:1864 - proc proc rw\&#34;,\n        \&#34;3986 3984 0:78 / /dev rw,nosuid shared:1865 - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;3987 3986 0:79 / /dev/pts rw,nosuid,noexec,relatime shared:1866 - devpts devpts rw,gid=5,mode=620,ptmxmode=666\&#34;,\n        \&#34;3988 3984 0:80 / /sys ro,nosuid,nodev,noexec,relatime shared:1870 - sysfs sysfs ro\&#34;,\n        \&#34;3989 3988 0:30 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:1871 - cgroup2 cgroup rw\&#34;,\n        \&#34;3990 3986 0:76 / /dev/mqueue rw,nosuid,nodev,noexec,relatime shared:1867 - mqueue mqueue rw\&#34;,\n        \&#34;3991 3986 0:81 / /dev/shm rw,nosuid,nodev,noexec,relatime shared:1868 - tmpfs shm rw,size=65536k,inode64\&#34;,\n        \&#34;3992 3984 253:1 /var/lib/docker/volumes/9d18ce5b36572d85358fa936afe5a4bf95cca5c822b04941aa08c6118f6e0d33/_data /var rw,relatime shared:1872 master:1 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3993 3984 0:82 / /run rw,nosuid,nodev,noexec,relatime shared:1873 - tmpfs tmpfs rw,inode64\&#34;,\n        \&#34;3994 3984 0:83 / /tmp rw,nosuid,nodev,noexec,relatime shared:1874 - tmpfs tmpfs rw,inode64\&#34;,\n        \&#34;3995 3984 253:1 /usr/lib/modules /usr/lib/modules ro,relatime shared:1875 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3996 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/resolv.conf /etc/resolv.conf rw,relatime shared:1876 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3997 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hostname /etc/hostname rw,relatime shared:1877 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3998 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hosts /etc/hosts rw,relatime shared:1878 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6\&#34;,\n    \&#34;podId\&#34;: null\n  },\n  \&#34;gardener\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/mountinfo\&#34;: [\n        \&#34;10112 5519 0:864 / / ro,relatime master:1972 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/35235/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27346/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27345/fs:/var/lib/containerd/io.containerd.snapsh\&#34;,\n        \&#34;10113 10112 0:884 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw\&#34;,\n        \&#34;10301 10112 0:926 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;10302 10301 0:930 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666\&#34;,\n        \&#34;10519 10301 0:820 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw\&#34;,\n        \&#34;10520 10112 0:839 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro\&#34;,\n        \&#34;10716 10520 0:26 /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\&#34;,\n        \&#34;10736 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/volumes/kubernetes.io~empty-dir/tmpdir /tmp rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro\&#34;,\n        \&#34;10737 10112 0:786 / /vault/tls ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64\&#34;,\n        \&#34;10738 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/etc-hosts /etc/hosts rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro\&#34;,\n        \&#34;10739 10301 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/containers/application-search-indexer/9bf2b38c /dev/termination-log rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro\&#34;,\n        \&#34;10740 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/hostname /etc/hostname ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro\&#34;,\n        \&#34;10741 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/resolv.conf /etc/resolv.conf ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro\&#34;,\n        \&#34;10761 10301 0:788 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,inode64\&#34;,\n        \&#34;10762 10112 0:787 / /var/run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64\&#34;,\n        \&#34;5630 10113 0:884 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw\&#34;,\n        \&#34;5631 10113 0:884 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw\&#34;,\n        \&#34;5632 10113 0:884 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw\&#34;,\n        \&#34;5633 10113 0:884 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw\&#34;,\n        \&#34;5634 10113 0:931 / /proc/acpi ro,relatime - tmpfs tmpfs ro,inode64\&#34;,\n        \&#34;5635 10113 0:926 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;5636 10113 0:926 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;5637 10113 0:926 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;5639 10520 0:932 / /sys/firmware ro,relatime - tmpfs tmpfs ro,inode64\&#34;\n      ],\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1\&#34;,\n    \&#34;podId\&#34;: \&#34;121157b5-c67d-4c3e-9052-cb27bbb711fb\&#34;\n  }\n}\n\n&#34;:&#xA;&#x9;* tests/upstream/json-specs/container_metadata_discovery.json&#xA;</p>
        </details>
        <a href="https://github.com/elastic/apm-agent-python/actions/runs/7028639341">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

