### PR TITLE
fix extract_signature dbapi2: handling square brakets in table name

### DIFF
--- a/elasticapm/instrumentation/packages/dbapi2.py
+++ b/elasticapm/instrumentation/packages/dbapi2.py
@@ -76,8 +76,8 @@ def _scan_for_table_with_tokens(tokens, keyword):
 
 
 def tokenize(sql):
-    # split on anything that is not a word character, excluding dots
-    return [t for t in re.split(r"([^\w.])", sql) if t != ""]
+    # split on anything that is not a word character or a square bracket, excluding dots
+    return [t for t in re.split(r"([^\w.\[\]])", sql) if t != ""]
 
 
 def scan(tokens):

--- a/tests/instrumentation/dbapi2_tests.py
+++ b/tests/instrumentation/dbapi2_tests.py
@@ -154,3 +154,18 @@ def test_extract_signature_for_procedure_call(sql, expected):
 def test_extract_action_from_signature(sql, expected):
     actual = extract_action_from_signature(sql, "query")
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["sql", "expected"],
+    [
+        ("SELECT username FROM user", "SELECT FROM user"),
+        ("SELECT username FROM [user]", "SELECT FROM [user]"),
+        ("SELECT username FROM [db].[user]", "SELECT FROM [db].[user]"),
+        ("SELECT username FROM db.[user]", "SELECT FROM db.[user]"),
+        ("SELECT username FROM [db].user", "SELECT FROM [db].user"),
+    ],
+)
+def test_extract_signature_when_using_square_brackets(sql, expected):
+    actual = extract_signature(sql)
+    assert actual == expected


### PR DESCRIPTION
## What does this pull request do?

This PR should fixes how dbapi2 extract the signature if a table name has square brackets.
I added some tests to check if the fix actually solved the problem. I hope that the test cases are enough  and cover all the possibilities. 
Please let me know if I'm missing a possible usage of the method.

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

Closes #1929 
