### PR TITLE
fix: setup middleware without client argument for starlette

### DIFF
--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -105,7 +105,7 @@ class ElasticAPM:
     >>> elasticapm.capture_message('hello, world!')
     """
 
-    def __init__(self, app: ASGIApp, client: Optional[Client], **kwargs) -> None:
+    def __init__(self, app: ASGIApp, client: Optional[Client] = None, **kwargs) -> None:
         """
 
         Args:

--- a/tests/contrib/asyncio/starlette_tests.py
+++ b/tests/contrib/asyncio/starlette_tests.py
@@ -534,3 +534,11 @@ def test_transaction_active_in_base_exception_handler(app, elasticapm_client):
         assert exc.transaction_id
 
     assert len(elasticapm_client.events[constants.TRANSACTION]) == 1
+
+
+def test_middleware_without_client_arg():
+    with mock.patch.dict("os.environ", {"ELASTIC_APM_SERVICE_NAME": "foo"}):
+        app = Starlette()
+        elasticapm = ElasticAPM(app)
+
+    assert elasticapm.client.config.service_name == "foo"


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Fix TypeError when using the starlette middleware without explicitly providing a client
-->

## Related issues

Closes #1951
