### PR TITLE
Added a note on centralized agent config support for AWS Lambda

### DIFF
--- a/docs/serverless-lambda.asciidoc
+++ b/docs/serverless-lambda.asciidoc
@@ -5,6 +5,11 @@
 
 The Python APM Agent can be used with AWS Lambda to monitor the execution of your AWS Lambda functions.
 
+```
+Note: The Centralized Agent Configuration on the Elasticsearch APM currently does NOT support AWS Lambda.
+```
+
+
 [float]
 ==== Prerequisites
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

The centralized Agent configuration does not work well with the AWS Lambda because it is not supported. The problem is you will be able to add the Lambda services in the central config without an understanding of its support. So, this PR will keep an alert when creating Lambda services.
