### PR TITLE
Fix:Update starlette.asciidoc, incorrect middleware order

### DIFF
--- a/docs/starlette.asciidoc
+++ b/docs/starlette.asciidoc
@@ -43,7 +43,7 @@ app.add_middleware(ElasticAPM)
 ----
 
 WARNING: If you are using any `BaseHTTPMiddleware` middleware, you must add them
-*before* the ElasticAPM middleware. This is because `BaseHTTPMiddleware` breaks
+*after* the ElasticAPM middleware. This is because `BaseHTTPMiddleware` breaks
 `contextvar` propagation, as noted
 https://www.starlette.io/middleware/#limitations[here].
 


### PR DESCRIPTION
## What does this pull request do?
The documentation contains an error, you need to put the APM middleware before BaseHTTPMiddleware.
