### PR TITLE
github-action: use wildcards for discovering all the workflows

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,17 +1,15 @@
 ---
+# Look up results at https://ela.st/oblt-ci-cd-stats.
+# There will be one service per GitHub repository, including the org name, and one Transaction per Workflow.
 name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows:
-      - pre-commit
-      - test
-      - test-reporter
-      - snapshoty
-      - release
-      - packages
-      - updatecli
+    workflows: [ "*" ]
     types: [completed]
+
+permissions:
+  contents: read
 
 jobs:
   otel-export-trace:


### PR DESCRIPTION
## What does this pull request do?

No need to maintain the static list of GitHub Workflows to be monitored with the CI/CD Observability using Opentelemetry


## Related issues

Closes #ISSUE
