### PR TITLE
contrib/serverless/aws: normalize headers with v1 event format

### DIFF
--- a/tests/contrib/serverless/aws_elb_test_data.json
+++ b/tests/contrib/serverless/aws_elb_test_data.json
@@ -15,6 +15,7 @@
         "connection": "Keep-Alive",
         "host": "blabla.com",
         "user-agent": "Apache-HttpClient/4.5.13 (Java/11.0.15)",
+        "TraceParent": "00-12345678901234567890123456789012-1234567890123456-01",
         "x-amzn-trace-id": "Root=1-xxxxxxxxxxxxxx",
         "x-forwarded-for": "199.99.99.999",
         "x-forwarded-port": "443",


### PR DESCRIPTION
## What does this pull request do?

If the event has been generated from elb or api gateway and is in the v1 format normalize headers even if they already should per https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

Event discrimination logic courtesy of nodejs apm client.

## Related issues

Closes #1980 
