### PR TITLE
Deprecate Python < 3.2 logging code and and remove documentation

### DIFF
--- a/docs/logging.asciidoc
+++ b/docs/logging.asciidoc
@@ -36,7 +36,7 @@ as well as http://www.structlog.org/en/stable/[`structlog`].
 [[logging]]
 ===== `logging`
 
-For Python 3.2+, we use https://docs.python.org/3/library/logging.html#logging.setLogRecordFactory[`logging.setLogRecordFactory()`]
+We use https://docs.python.org/3/library/logging.html#logging.setLogRecordFactory[`logging.setLogRecordFactory()`]
 to decorate the default LogRecordFactory to automatically add new attributes to
 each LogRecord object:
 
@@ -50,25 +50,6 @@ This factory also adds these fields to a dictionary attribute,
 You can disable this automatic behavior by using the
 <<config-generic-disable-log-record-factory,`disable_log_record_factory`>> setting
 in your configuration.
-
-For Python versions <3.2, we also provide a
-https://docs.python.org/3/library/logging.html#filter-objects[filter] which will
-add the same new attributes to any filtered `LogRecord`:
-
-[source,python]
-----
-import logging
-from elasticapm.handlers.logging import LoggingFilter
-
-console = logging.StreamHandler()
-console.addFilter(LoggingFilter())
-# add the handler to the root logger
-logging.getLogger("").addHandler(console)
-----
-
-NOTE: Because https://docs.python.org/3/library/logging.html#filter-objects[filters
-are not propagated to descendent loggers], you should add the filter to each of
-your log handlers, as handlers are propagated, along with their attached filters.
 
 [float]
 [[structlog]]

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -194,6 +194,16 @@ class LoggingFilter(logging.Filter):
     automatically.
     """
 
+    def __init__(self, name=""):
+        super().__init__(name=name)
+        warnings.warn(
+            "The LoggingFilter is deprecated and will be removed in v7.0 of "
+            "the agent. On Python 3.2+ by default we Rdd a LogRecordFactory to "
+            "your root logger automatically"
+            "https://www.elastic.co/guide/en/apm/agent/python/current/logs.html",
+            PendingDeprecationWarning,
+        )
+
     def filter(self, record):
         """
         Add elasticapm attributes to `record`.

--- a/elasticapm/handlers/logging.py
+++ b/elasticapm/handlers/logging.py
@@ -198,7 +198,7 @@ class LoggingFilter(logging.Filter):
         super().__init__(name=name)
         warnings.warn(
             "The LoggingFilter is deprecated and will be removed in v7.0 of "
-            "the agent. On Python 3.2+ by default we Rdd a LogRecordFactory to "
+            "the agent. On Python 3.2+, by default we add a LogRecordFactory to "
             "your root logger automatically"
             "https://www.elastic.co/guide/en/apm/agent/python/current/logs.html",
             PendingDeprecationWarning,


### PR DESCRIPTION
## What does this pull request do?

Remove specific documentation for Python < 3.2 and deprecate the old code to be removed on next major version.

## Related issues

None
