### PR TITLE
Add Django 4.2 LTS and Django 5.0 to test matrix

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -9,12 +9,34 @@ exclude:
     FRAMEWORK: django-4.0
   - VERSION: python-3.7
     FRAMEWORK: django-4.0
+  # Django 4.2 requires Python 3.8+
+  - VERSION: python-3.6
+    FRAMEWORK: django-4.2
+  - VERSION: python-3.7
+    FRAMEWORK: django-4.2
+  # Django 5.0 requires Python 3.10+
+  - VERSION: python-3.6
+    FRAMEWORK: django-5.0
+  - VERSION: python-3.7
+    FRAMEWORK: django-5.0
+  - VERSION: python-3.8
+    FRAMEWORK: django-5.0
+  - VERSION: python-3.9
+    FRAMEWORK: django-5.0
   - VERSION: pypy-3 # current pypy-3 is compatible with Python 3.7
     FRAMEWORK: celery-5-django-4
   - VERSION: python-3.6
     FRAMEWORK: celery-5-django-4
   - VERSION: python-3.7
     FRAMEWORK: celery-5-django-4
+  - VERSION: python-3.6
+    FRAMEWORK: celery-5-django-5
+  - VERSION: python-3.7
+    FRAMEWORK: celery-5-django-5
+  - VERSION: python-3.8
+    FRAMEWORK: celery-5-django-5
+  - VERSION: python-3.9
+    FRAMEWORK: celery-5-django-5
   # Flask
   - VERSION: pypy-3
     FRAMEWORK: flask-0.11 # see https://github.com/pallets/flask/commit/6e46d0cd, 0.11.2 was never released

--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -3,10 +3,10 @@
 FRAMEWORK:
   - none
   - django-1.11
-  - django-2.0
-  - django-3.1
   - django-3.2
   - django-4.0
+  - django-4.2
+  - django-5.0
   - flask-0.12
   - flask-1.1
   - flask-2.0
@@ -18,6 +18,7 @@ FRAMEWORK:
   - celery-4-django-2.0
   - celery-5-flask-2
   - celery-5-django-4
+  - celery-5-django-5
   - requests-newest
   - boto3-newest
   - pymongo-newest

--- a/.ci/.matrix_framework_full.yml
+++ b/.ci/.matrix_framework_full.yml
@@ -10,6 +10,8 @@ FRAMEWORK:
   - django-3.1
   - django-3.2
   - django-4.0
+  - django-4.2
+  - django-5.0
     #  - django-master
   - flask-0.10
   - flask-0.11
@@ -25,6 +27,7 @@ FRAMEWORK:
   - celery-5-flask-2
   - celery-5-django-3
   - celery-5-django-4
+  - celery-5-django-5
   - opentelemetry-newest
   - opentracing-newest
   - opentracing-2.0

--- a/tests/requirements/reqs-celery-5-django-5.txt
+++ b/tests/requirements/reqs-celery-5-django-5.txt
@@ -1,0 +1,2 @@
+-r reqs-celery-5.txt
+-r reqs-django-5.0.txt

--- a/tests/requirements/reqs-django-4.2.txt
+++ b/tests/requirements/reqs-django-4.2.txt
@@ -1,0 +1,3 @@
+Django>=4.2,<5.0
+jinja2<4
+-r reqs-base.txt

--- a/tests/requirements/reqs-django-5.0.txt
+++ b/tests/requirements/reqs-django-5.0.txt
@@ -1,0 +1,3 @@
+Django>=5.0,<5.1
+jinja2<4
+-r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

Add Django 4.2 LTS and Django 5.0 to test matrix. While at it remove some tests that runs only on old and not tested versions. Remove a couple of old not LTS versions from the default test matrix to avoid making it slower.

## Related issues

Closes #1946 
