### PR TITLE
ci: add missing full-matrix input when using test workflow in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
+    with:
+      full-matrix: true
 
   packages:
     uses: ./.github/workflows/packages.yml


### PR DESCRIPTION
## What does this pull request do?

Should fix the following error when tagging a release:

The workflow is not valid. .github/workflows/release.yml (Line: 13, Col: 11):
 Input full-matrix is required, but not provided while calling.

See https://github.com/elastic/apm-agent-python/actions/runs/8179350148/workflow

## Related issues

None
