### PR TITLE
ci: revert to actions/upload-artifact@v3 in build-distribution workflow

### DIFF
--- a/.github/workflows/build-distribution.yml
+++ b/.github/workflows/build-distribution.yml
@@ -13,7 +13,7 @@ jobs:
           python-version: "3.10"
       - name: Build lambda layer zip
         run: ./dev-utils/make-distribution.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: build-distribution
           path: ./build/


### PR DESCRIPTION
## What does this pull request do?

It looks like since v4 only one upload for the same dir will work. See:
https://github.com/actions/upload-artifact/issues/478#issuecomment-1860038048

In the meantime we sort this out revert to v3.

Should fix:
https://github.com/elastic/apm-agent-python/actions/runs/8191161913/job/22399752533

## Related issues

None
