### PR TITLE
ci: switch build-distribution downloadArtifact to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           secrets: |
             secret/observability-team/ci/service-account/apm-agent-python access_key_id | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/service-account/apm-agent-python secret_access_key | AWS_SECRET_ACCESS_KEY
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: build-distribution
           path: ./build
@@ -84,7 +84,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: build-distribution
           path: ./build


### PR DESCRIPTION
## What does this pull request do?

Switch build-distribution downloadArtifact to v3 since v4 can't find artifacts if uploaded with uploadArtifact v3.

## Related issues

https://github.com/elastic/apm-agent-python/actions/runs/8195374788/
