### PR TITLE
ci: update issue labeler

### DIFF
--- a/.github/community-label.yml
+++ b/.github/community-label.yml
@@ -1,5 +1,0 @@
-# add 'community' label to all new issues and PRs created by the community
-community:
-  - '.*'
-triage:
-  - '.*'

--- a/.github/labeler-config.yml
+++ b/.github/labeler-config.yml
@@ -1,3 +1,0 @@
-# add 'agent-python' label to all new issues
-agent-python:
-  - '.*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,43 +4,29 @@ on:
     types: [opened]
   pull_request_target:
     types: [opened]
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+
+# 'issues: write' for https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#add-labels-to-an-issue
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
     - name: Add agent-python label
-      uses: AlexanderWert/issue-labeler@v2.3
+      uses: actions-ecosystem/action-add-labels@v1
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/labeler-config.yml
-        enable-versioned-regex: 0
-    - name: Check team membership for user
-      uses: elastic/get-user-teams-membership@1.1.0
-      id: checkUserMember
+        labels: agent-python
+    - id: is_elastic_member
+      uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
       with:
         username: ${{ github.actor }}
-        team: 'apm'
-        usernamesToExclude: |
-          apmmachine
-          dependabot
-        GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
-    - name: Show team membership
-      run: |
-        echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
-        echo "::debug::isExcluded: ${{ steps.checkUserMember.outputs.isExcluded }}"
-    - name: Add community and triage lables
-      if: steps.checkUserMember.outputs.isTeamMember != 'true' && steps.checkUserMember.outputs.isExcluded != 'true'
-      uses: AlexanderWert/issue-labeler@v2.3
+        token: ${{ secrets.APM_TECH_USER_TOKEN }}
+    - name: Add community and triage labels
+      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'apmmachine'
+      uses: actions-ecosystem/action-add-labels@v1
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/community-label.yml
-        enable-versioned-regex: 0
-    - name: Assign new internal pull requests to project
-      uses: elastic/assign-one-project-github-action@1.2.2
-      if: (steps.checkUserMember.outputs.isTeamMember == 'true' || steps.checkUserMember.outputs.isExcluded == 'true') && github.event.pull_request
-      with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'In Progress'
+        labels:
+          - community
+          - triage

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   triage:


### PR DESCRIPTION
## What does this pull request do?

Stop using the apm group and custom github action to check if issues are from internal members or not.

## Related issues

Closes #2001
