### PR TITLE
Relaxed wrapt-dependency to only blacklist 1.15.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = false
 install_requires =
     urllib3!=2.0.0,<3.0.0
     certifi
-    wrapt>=1.14.1,<1.15.0  # https://github.com/elastic/apm-agent-python/issues/1894
+    wrapt>=1.14.1,!=1.15.0  # https://github.com/elastic/apm-agent-python/issues/1894
     ecs_logging
 test_suite=tests
 

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -29,7 +29,7 @@ mock
 pytz
 ecs_logging
 structlog
-wrapt>=1.14.1,<1.15.0
+wrapt>=1.14.1,!=1.15.0
 
 pytest-asyncio==0.21.0 ; python_version >= '3.7'
 asynctest==0.13.0 ; python_version >= '3.7'


### PR DESCRIPTION
## What does this pull request do?
This is an attempt to solve #1894 . I simply relaxed the wrapt dependency to only blacklist the known broken 1.15.0. 

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

Closes #1894 