### PR TITLE
ci: add Flask 2.1+ and 3.0 to matrix

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -40,6 +40,18 @@ exclude:
   # Flask
   - VERSION: pypy-3
     FRAMEWORK: flask-0.11 # see https://github.com/pallets/flask/commit/6e46d0cd, 0.11.2 was never released
+  - VERSION: python-3.6
+    FRAMEWORK: flask-2.1
+  - VERSION: python-3.6
+    FRAMEWORK: flask-2.2
+  - VERSION: python-3.6
+    FRAMEWORK: flask-2.3
+  - VERSION: python-3.6
+    FRAMEWORK: flask-3.0
+  - VERSION: python-3.7
+    FRAMEWORK: flask-2.3
+  - VERSION: python-3.7
+    FRAMEWORK: flask-3.0
   # Python 3.10 removed a bunch of classes from collections, now in collections.abc
   - VERSION: python-3.10
     FRAMEWORK: django-1.11

--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -8,8 +8,8 @@ FRAMEWORK:
   - django-4.2
   - django-5.0
   - flask-0.12
-  - flask-1.1
-  - flask-2.0
+  - flask-2.3
+  - flask-3.0
   - jinja2-3
   - opentelemetry-newest
   - opentracing-newest

--- a/.ci/.matrix_framework_full.yml
+++ b/.ci/.matrix_framework_full.yml
@@ -19,6 +19,10 @@ FRAMEWORK:
   - flask-1.0
   - flask-1.1
   - flask-2.0
+  - flask-2.1
+  - flask-2.2
+  - flask-2.3
+  - flask-3.0
   - jinja2-2
   - jinja2-3
   - celery-4-flask-1.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.egg
 *.db
 *.pid
+*.swp
 .coverage*
 .DS_Store
 .idea

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -59,6 +59,10 @@ We support these Flask versions:
  * 1.0
  * 1.1
  * 2.0
+ * 2.1
+ * 2.2
+ * 2.3
+ * 3.0
 
 [float]
 [[supported-aiohttp]]

--- a/tests/requirements/reqs-flask-2.1.txt
+++ b/tests/requirements/reqs-flask-2.1.txt
@@ -1,4 +1,4 @@
-Flask>=2.0,<2.1
+Flask>=2.1,<2.2
 blinker>=1.1
 itsdangerous
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-2.2.txt
+++ b/tests/requirements/reqs-flask-2.2.txt
@@ -1,4 +1,4 @@
-Flask>=2.0,<2.1
+Flask>=2.2,<2.3
 blinker>=1.1
 itsdangerous
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-2.3.txt
+++ b/tests/requirements/reqs-flask-2.3.txt
@@ -1,4 +1,4 @@
-Flask>=2.0,<2.1
+Flask>=2.3,<3
 blinker>=1.1
 itsdangerous
 -r reqs-base.txt

--- a/tests/requirements/reqs-flask-3.0.txt
+++ b/tests/requirements/reqs-flask-3.0.txt
@@ -1,4 +1,3 @@
-Flask>=2.0,<2.1
-blinker>=1.1
+Flask>=3.0,<3.1
 itsdangerous
 -r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

Add flask 2.1+ and 3.0 to matrix

## Related issues

None
