### PR TITLE
fix: only set ELASTIC_CI_POST_VERSION when needed (Closes #2015)

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,10 +16,6 @@ on:
 permissions:
   contents: read
 
-# Override the version if there is no tag release.
-env:
-  ELASTIC_CI_POST_VERSION: ${{ startsWith(github.ref, 'refs/tags') && '' || github.run_id }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,6 +24,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+      - name: Override the version if there is no tag release.
+        run: |
+          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
+            echo "ELASTIC_CI_POST_VERSION=${{ github.run_id }}" >> "${GITHUB_ENV}"
+          fi
       - name: Install wheel
         run: pip install --user wheel
       - name: Building universal wheel
@@ -41,4 +42,3 @@ jobs:
           path: |
             dist/*.whl
             dist/*tar.gz
-


### PR DESCRIPTION
## What is the change being made?

* Set ELASTIC_CI_POST_VERSION only when needed.

## Why is the change being made?

* The literal value `''` is coerced to false and, as a result, the environment variable is always set on tag release.

## Related Issues

Closes #2015
