### PR TITLE
Add ability to override default serialization

### DIFF
--- a/elasticapm/base.py
+++ b/elasticapm/base.py
@@ -155,7 +155,8 @@ class Client(object):
             "processors": self.load_processors(),
         }
         if config.transport_json_serializer:
-            transport_kwargs["json_serializer"] = config.transport_json_serializer
+            json_serializer_func = import_string(config.transport_json_serializer)
+            transport_kwargs["json_serializer"] = json_serializer_func
 
         self._api_endpoint_url = urllib.parse.urljoin(
             self.config.server_url if self.config.server_url.endswith("/") else self.config.server_url + "/",

--- a/elasticapm/utils/json_encoder.py
+++ b/elasticapm/utils/json_encoder.py
@@ -31,12 +31,8 @@
 
 import datetime
 import decimal
+import json
 import uuid
-
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 
 class BetterJSONEncoder(json.JSONEncoder):

--- a/tests/client/client_tests.py
+++ b/tests/client/client_tests.py
@@ -48,6 +48,11 @@ from pytest_localserver.https import DEFAULT_CERTIFICATE
 import elasticapm
 from elasticapm.base import Client
 from elasticapm.conf.constants import ERROR
+
+try:
+    from elasticapm.utils.simplejson_encoder import dumps as simplejson_dumps
+except ImportError:
+    simplejson_dumps = None
 from tests.fixtures import DummyTransport, TempStoreClient
 from tests.utils import assert_any_record_contains
 
@@ -226,6 +231,14 @@ def test_config_non_string_types():
 @pytest.mark.parametrize("elasticapm_client", [{"transport_class": "tests.fixtures.DummyTransport"}], indirect=True)
 def test_custom_transport(elasticapm_client):
     assert isinstance(elasticapm_client._transport, DummyTransport)
+
+
+@pytest.mark.skipIf(simplejson_dumps is None)
+@pytest.mark.parametrize(
+    "elasticapm_client", [{"transport_json_serializer": "elasticapm.utils.simplejson_encoder.dumps"}], indirect=True
+)
+def test_custom_transport_json_serializer(elasticapm_client):
+    assert elasticapm_client._transport._json_serializer == simplejson_dumps
 
 
 @pytest.mark.parametrize("elasticapm_client", [{"processors": []}], indirect=True)

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -30,6 +30,7 @@ pytz
 ecs_logging
 structlog
 wrapt>=1.14.1,<1.15.0
+simplejson
 
 pytest-asyncio==0.21.0 ; python_version >= '3.7'
 asynctest==0.13.0 ; python_version >= '3.7'

--- a/tests/utils/json_utils/tests_simplejson.py
+++ b/tests/utils/json_utils/tests_simplejson.py
@@ -30,15 +30,15 @@
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import absolute_import
-
 import datetime
 import decimal
 import uuid
 
 import pytest
 
-from elasticapm.utils import json_encoder as json
+simplejson = pytest.importorskip("simplejson")
+
+from elasticapm.utils import simplejson_encoder as json
 
 
 def test_uuid():
@@ -73,7 +73,12 @@ def test_decimal():
 
 @pytest.mark.parametrize("res", [float("nan"), float("+inf"), float("-inf")])
 def test_float_invalid_json(res):
-    assert json.dumps(res) != "null"
+    assert json.dumps(res) == "null"
+
+
+def test_float():
+    res = 1.0
+    assert json.dumps(res) == "1.0"
 
 
 def test_unsupported():


### PR DESCRIPTION
## What does this pull request do?

This PR introduces a new JSON serialization using simplejson that does a stricter serialization encoding floats like nan, +inf and -inf to null.
Then it makes the json serialization configurable from outside. 

## Related issues

Refs #1886