### PR TITLE
tests: require Werkzeug < 3 for flask 2.0 tests

### DIFF
--- a/tests/requirements/reqs-flask-2.0.txt
+++ b/tests/requirements/reqs-flask-2.0.txt
@@ -1,4 +1,5 @@
 Flask>=2.0,<2.1
+Werkzeug<3
 blinker>=1.1
 itsdangerous
 -r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

Add missing constraint on werkzeug version that does not make flask working

## Related issues

Hopefully fix red tests
