### PR TITLE
Use docker compose subcommand instead of docker-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ that is a fixture which is defined
 #### Adding new instrumentations to the matrix build
 
 For tests that require external dependencies like databases, or for testing different versions of the same library,
-we use a matrix build that leverages Docker and docker-compose.
+we use a matrix build that leverages Docker.
 
 The setup requires a little bit of boilerplate to get started.
 In this example, we will create an instrumentation for the "foo" database, by instrumenting its Python driver, `foodriver`.
@@ -153,7 +153,7 @@ In this example, we will create an instrumentation for the "foo" database, by in
              image: foobase:latest
 
     You'll also have to add a `DOCKER_DEPS` environment variable to `tests/scripts/envs/foo.sh` which tells the matrix
-    to spin up the given docker-compose service before running your tests.
+    to spin up the given Docker compose service before running your tests.
     You may also need to add things like hostname configuration here.
 
         DOCKER_DEPS="foo"

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -2,7 +2,7 @@
 set -ex
 
 function cleanup {
-    PYTHON_VERSION=${1} docker-compose down -v
+    PYTHON_VERSION=${1} docker compose down -v
 
     if [[ $CODECOV_TOKEN ]]; then
         cd ..
@@ -42,7 +42,7 @@ echo "Running tests for ${1}/${2}"
 
 if [[ -n $DOCKER_DEPS ]]
 then
-    PYTHON_VERSION=${1} docker-compose up -d ${DOCKER_DEPS}
+    PYTHON_VERSION=${1} docker compose up -d ${DOCKER_DEPS}
 fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
@@ -57,7 +57,7 @@ if ! ${CI}; then
     .
 fi
 
-PYTHON_VERSION=${1} docker-compose run \
+PYTHON_VERSION=${1} docker compose run \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \
   -e LOCAL_GROUP_ID=$LOCAL_GROUP_ID \


### PR DESCRIPTION
## What does this pull request do?

Use the subcommand instead of docker-compose script that for some reason it's not found anymore in ci. See https://github.com/elastic/apm-agent-python/actions/runs/8524954266/job/23350786476