### PR TITLE
github-action: use container image for provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,10 +144,10 @@ jobs:
           build-args: |
             AGENT_DIR=./build/dist/package/python
 
-      - name: Attest image
+      - name: generate build provenance (containers)
         uses: github-early-access/generate-build-provenance@main
         with:
-          subject-name: "${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.tag }}"
+          subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false
 


### PR DESCRIPTION
## What does this pull request do?

See https://github.com/elastic/apm-agent-python/pull/2014#discussion_r1576556806


Thanks @trentm 

### Test

I created a test feature branch:
- https://github.com/elastic/apm-agent-python/actions/runs/8813326799

<img width="1290" alt="image" src="https://github.com/elastic/apm-agent-python/assets/2871786/12d64df1-9818-4c14-b47c-688433b27b77">


https://github.com/elastic/apm-agent-python/attestations/748017
