### PR TITLE
github-action: add attestations scope

### DIFF
--- a/.github/actions/packages/action.yml
+++ b/.github/actions/packages/action.yml
@@ -25,7 +25,3 @@ runs:
         path: |
           dist/*.whl
           dist/*tar.gz
-    - name: generate build provenance
-      uses: github-early-access/generate-build-provenance@main
-      with:
-        subject-path: "${{ github.workspace }}/dist/*"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,9 +18,6 @@ permissions:
 
 jobs:
   build:
-    permissions:
-      id-token: write
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,17 @@ jobs:
 
   packages:
     permissions:
+      attestations: write
       id-token: write
       contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/packages
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: "${{ github.workspace }}/dist/*"
 
   publish-pypi:
     needs:
@@ -53,6 +58,7 @@ jobs:
 
   build-distribution:
     permissions:
+      attestations: write
       id-token: write
       contents: write
     runs-on: ubuntu-latest
@@ -103,6 +109,7 @@ jobs:
       - build-distribution
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       id-token: write
       contents: write
     env:


### PR DESCRIPTION
## What does this pull request do?

> The attestations permission is necessary to persist the attestation.

As per [docs](https://github.com/github-early-access/generate-build-provenance?tab=readme-ov-file#usage)

GitHub scope for forked repositories won't have write access to anything.

