### PR TITLE
ci: use docker/metadata-action to gather tags/labels 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
             type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
-            type=ref,event=tag,prefix=,suffix=
+            type=semver,pattern={{version}}
 
       - name: Build and push image
         id: push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,31 +123,29 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
+
       - uses: actions/download-artifact@v4
         with:
           name: build-distribution
           path: ./build
-      - id: setup-docker
-        name: Set up docker variables
-        run: |-
-          if [ "${{ startsWith(github.ref, 'refs/tags') }}" == "false" ] ; then
-            # for testing purposes
-            echo "tag=test" >> "${GITHUB_OUTPUT}"
-            echo "latest=test-latest" >> "${GITHUB_OUTPUT}"
-          else
-            # version without v prefix (e.g. 1.2.3)
-            echo "tag=${GITHUB_REF_NAME/v/}" >> "${GITHUB_OUTPUT}"
-            echo "latest=latest" >> "${GITHUB_OUTPUT}"
-          fi
+
+      - name: Extract metadata (tags, labels)
+        id: docker-meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        with:
+          images: ${{ env.DOCKER_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
+            type=ref,event=tag,prefix=,suffix=
+
       - name: Build and push image
         id: push
-        uses: docker/build-push-action@v5.3.0
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
         with:
           context: .
           push: true
-          tags: |
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.tag }}
-            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.setup-docker.outputs.latest }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
           build-args: |
             AGENT_DIR=./build/dist/package/python
 
@@ -156,7 +154,7 @@ jobs:
         with:
           subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: false
+          push-to-registry: true
 
   github-draft:
     permissions:


### PR DESCRIPTION
## What does this pull request do?

Use https://github.com/docker/metadata-action/tree/8e5442c4ef9f78752691e2d8f8d19755c6f78e81/?tab=readme-ov-file#typeref to get the tags/annotations/labels

Use sha commit for the github action related to docker.

### Test

See https://github.com/elastic/apm-agent-python/actions/runs/8879068667


```
tags: docker.elastic.co/observability/apm-agent-python:test-latest
    labels: org.opencontainers.image.created=2024-04-29T13:04:44.8[6](https://github.com/elastic/apm-agent-python/actions/runs/8879068667/job/24375994029#step:6:6)6Z
  org.opencontainers.image.description=Official Python agent for Elastic APM
  org.opencontainers.image.licenses=BSD-3-Clause
  org.opencontainers.image.revision=[7](https://github.com/elastic/apm-agent-python/actions/runs/8879068667/job/24375994029#step:6:7)ea253bd5942e0e0782449edba9ee78f01a8c64a
  org.opencontainers.image.source=https://github.com/elastic/apm-agent-python
  org.opencontainers.image.title=apm-agent-python
  org.opencontainers.image.url=https://github.com/elastic/apm-agent-python
  org.opencontainers.image.version=test-latest
    build-args: AGENT_DIR=./build/dist/package/python
```

## Related issues


https://github.com/elastic/apm-agent-nodejs/pull/3998