### PR TITLE
tests: pick mysql image tagged as 8.0

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       - pymssqldata:/var/opt/mssql
 
   mysql:
-    image: mysql
+    image: mysql:8.0
     command: --default-authentication-plugin=mysql_native_password --log_error_verbosity=3
     environment:
       - MYSQL_DATABASE=eapm_tests


### PR DESCRIPTION

## What does this pull request do?

Pin mysql image in tests docker-compose at 8.0 because 8.4.0 does not appear to work out of the box.

Current mysql image:

```
Waiting for mysql:3306
mysql: forward host lookup failed: Host name lookup failure
```

## Related issues

