### PR TITLE
ci: build and push Docker image based on Chainguard base image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
       attestations: write
       id-token: write
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile: [ 'Dockerfile', 'Dockerfile.wolfi' ]
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-python
     steps:
@@ -137,6 +141,8 @@ jobs:
           tags: |
             type=raw,value=latest,prefix=test-,enable={{is_default_branch}}
             type=semver,pattern={{version}}
+          flavor: |
+            suffix=${{ contains(matrix.dockerfile, 'wolfi') && '-wolfi' || '' }}
 
       - name: Build and push image
         id: push
@@ -144,6 +150,7 @@ jobs:
         with:
           context: .
           push: true
+          file: ${{ matrix.dockerfile }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           build-args: |

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/wolfi/chainguard-base@sha256:9f940409f96296ef56140bcc4665c204dd499af4c32c96cc00e792558097c3f1
+ARG AGENT_DIR
+COPY ${AGENT_DIR} /opt/python


### PR DESCRIPTION
## What does this pull request do?

Release two flavours of Docker images:
- the one we always do
- the one based on [Wolfi](https://www.chainguard.dev/unchained/introducing-wolfi-the-first-linux-un-distro) from [Chainguard](https://edu.chainguard.dev/chainguard/chainguard-images/overview/) 

Please note that we are going to preserve the current `Dockerfile`, so that users will still be able to build their own custom images based on `Alpine`: this is needed because `docker.elastic.co/wolfi/chainguard-base` is not a public base image, so docker build would fail for unauthenticated users.

## Tests

I created a feature branch `test/docker-images-wolfi`:
- https://github.com/elastic/apm-agent-python/tree/test/docker-images-wolfi

Then I can test the release workflow without pushing any changes in production but generating docker images with the prefix `test-` and suffix if `-wolfi`

See https://github.com/elastic/apm-agent-python/actions/runs/9018252392

### Docker images

#### The ones we usually release

<img width="868" alt="image" src="https://github.com/elastic/apm-agent-python/assets/2871786/6953a1d1-4f59-4220-9cf0-6af406749fb9">


#### Wolfi docker images

<img width="1015" alt="image" src="https://github.com/elastic/apm-agent-python/assets/2871786/24213256-a41b-41a2-9281-fcbcff9e9009">


`docker pull docker.elastic.co/observability/apm-agent-python:test-latest-wolfi`

