### PR TITLE
tests: revert bumping jinja2 in flask 1.0 tests

### DIFF
--- a/tests/requirements/reqs-flask-1.0.txt
+++ b/tests/requirements/reqs-flask-1.0.txt
@@ -1,4 +1,4 @@
-jinja2<3.2.0
+jinja2<3.1.0
 Werkzeug<2.1.0
 Flask>=1.0,<1.1
 MarkupSafe<2.1


### PR DESCRIPTION
## What does this pull request do?

Unfortunately flask 1.0 does not work with jinja 3.1.x:

```
venv/lib/python3.10/site-packages/flask/__init__.py:19: in <module>
    from jinja2 import Markup, escape

E   ImportError: cannot import name 'Markup' from 'jinja2'
```

## Related issues

