### PR TITLE
contrib/serverless: remove aws reference from azure implementation

### DIFF
--- a/elasticapm/contrib/serverless/azure.py
+++ b/elasticapm/contrib/serverless/azure.py
@@ -43,8 +43,6 @@ from elasticapm.utils import get_url_dict
 from elasticapm.utils.disttracing import TraceParent
 from elasticapm.utils.logging import get_logger
 
-SERVERLESS_HTTP_REQUEST = ("api", "elb")
-
 logger = get_logger("elasticapm.serverless")
 
 _AnnotatedFunctionT = TypeVar("_AnnotatedFunctionT")


### PR DESCRIPTION
## What does this pull request do?

Remove unused variable from azure implementation.

## Related issues

None
