### PR TITLE
ci: use v3 artifact APIs for build-distribution

### DIFF
--- a/.github/actions/build-distribution/action.yml
+++ b/.github/actions/build-distribution/action.yml
@@ -14,7 +14,7 @@ runs:
       run: ./dev-utils/make-distribution.sh
       shell: bash
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: build-distribution
         path: ./build/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           secrets: |
             secret/observability-team/ci/service-account/apm-agent-python access_key_id | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/service-account/apm-agent-python secret_access_key | AWS_SECRET_ACCESS_KEY
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: build-distribution
           path: ./build
@@ -128,7 +128,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: build-distribution
           path: ./build


### PR DESCRIPTION

## What does this pull request do?

Hopefully fix:

```
The lambda layer can be published as follows for dev work:
    aws lambda --output json publish-layer-version --layer-name 'runner-dev-elastic-apm-python' --description 'runner dev Elastic APM Python agent lambda layer' --zip-file 'fileb://build/dist/elastic-apm-python-lambda-layer.zip'
Run actions/upload-artifact@v4
  with:
    name: build-distribution
    path: ./build/
    if-no-files-found: error
    compression-level: 6
    overwrite: false
  env:
    ...
With the provided path, there will be 636 files uploaded Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

## Related issues

None
