### PR TITLE
github: use docker github secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,13 +120,13 @@ jobs:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-python
     steps:
       - uses: actions/checkout@v4
-      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+
+      - name: Log in to the Elastic Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
         with:
-          registry: docker.elastic.co
-          secret: secret/observability-team/ci/docker-registry/prod
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+          username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+          password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## What does this pull request do?

Does what it says in the tin, no more vault secrets to connect to docker

## Related issues

Closes #ISSUE
