### PR TITLE
github-action: run buildkite action with GH secrets

### DIFF
--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -16,32 +16,16 @@ permissions:
 jobs:
   microbenchmark:
     runs-on: ubuntu-latest
-    # wait up to 1 hour
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
-      - id: buildkite
-        name: Run buildkite pipeline
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+      - name: Run microbenchmark
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-microbenchmark
-          waitFor: true
-          printBuildLogs: true
-          buildEnvVars: |
+          pipeline: "apm-agent-microbenchmark"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: false
+          env-vars: |
             script=.ci/bench.sh
             repo=apm-agent-python
             sha=${{ github.sha }}
             BRANCH_NAME=${{ github.ref_name }}
-
-      - if: ${{ failure() }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-python"
-          message: |
-            :ghost: [${{ github.repository }}] microbenchmark *${{ github.ref_name }}* failed to run in Buildkite.
-            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)


### PR DESCRIPTION
## What does this pull request do?

Run the Buildkite pipeline for the microbenchmarks without waiting for. 

There is no need to wait for, since it uses a different CI - logs can be accessed through the UI, the GitHub action will provide the link to it.

## Related issues

Closes #ISSUE
