### PR TITLE
contrib/starlette: fix outcome for 500 responses without exception

### DIFF
--- a/elasticapm/contrib/asgi.py
+++ b/elasticapm/contrib/asgi.py
@@ -50,6 +50,7 @@ def wrap_send(send, middleware):
             await set_context(lambda: middleware.get_data_from_response(message, constants.TRANSACTION), "response")
             result = "HTTP {}xx".format(message["status"] // 100)
             elasticapm.set_transaction_result(result, override=False)
+            elasticapm.set_transaction_outcome(http_status_code=message["status"], override=False)
         await send(message)
 
     return wrapped_send

--- a/elasticapm/contrib/starlette/__init__.py
+++ b/elasticapm/contrib/starlette/__init__.py
@@ -147,6 +147,7 @@ class ElasticAPM:
                 )
                 result = "HTTP {}xx".format(message["status"] // 100)
                 elasticapm.set_transaction_result(result, override=False)
+                elasticapm.set_transaction_outcome(http_status_code=message["status"], override=False)
             await send(message)
 
         _mocked_receive = None

--- a/tests/contrib/asgi/app.py
+++ b/tests/contrib/asgi/app.py
@@ -59,3 +59,8 @@ async def boom() -> None:
 @app.route("/body")
 async def json():
     return jsonify({"hello": "world"})
+
+
+@app.route("/500", methods=["GET"])
+async def error():
+    return "KO", 500


### PR DESCRIPTION
## What does this pull request do?

Set the outcome based on the status code of the http.response.start ASGI message instead of relying only on the raise of an exception both in asgi and starlette integrations.

## Related issues

None
