### PR TITLE
ci: remove celery 4 testing

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -57,20 +57,12 @@ exclude:
     FRAMEWORK: django-1.11
   - VERSION: python-3.10
     FRAMEWORK: django-2.0
-  - VERSION: python-3.10
-    FRAMEWORK: celery-4-django-2.0
-  - VERSION: python-3.10
-    FRAMEWORK: celery-4-django-1.11
-  - VERSION: python-3.11 # cannot import name 'formatargspec' from 'inspect'
-    FRAMEWORK: celery-4-flask-1.0
   - VERSION: python-3.11 # https://github.com/celery/billiard/issues/377
     FRAMEWORK: celery-5-flask-2
   - VERSION: python-3.11 # https://github.com/celery/billiard/issues/377
     FRAMEWORK: celery-5-django-3
   - VERSION: python-3.11 # https://github.com/celery/billiard/issues/377
     FRAMEWORK: celery-5-django-4
-  - VERSION: python-3.12 # cannot import name 'formatargspec' from 'inspect'
-    FRAMEWORK: celery-4-flask-1.0
   - VERSION: python-3.12 # https://github.com/celery/billiard/issues/377
     FRAMEWORK: celery-5-flask-2
   - VERSION: python-3.12 # https://github.com/celery/billiard/issues/377
@@ -94,10 +86,6 @@ exclude:
   - VERSION: python-3.11
     FRAMEWORK: django-2.1
   - VERSION: python-3.11
-    FRAMEWORK: celery-4-django-2.0
-  - VERSION: python-3.11
-    FRAMEWORK: celery-4-django-1.11
-  - VERSION: python-3.11
     FRAMEWORK: graphene-2
   - VERSION: python-3.11
     FRAMEWORK: aiohttp-3.0
@@ -113,10 +101,6 @@ exclude:
     FRAMEWORK: django-2.0
   - VERSION: python-3.12
     FRAMEWORK: django-2.1
-  - VERSION: python-3.12
-    FRAMEWORK: celery-4-django-2.0
-  - VERSION: python-3.12
-    FRAMEWORK: celery-4-django-1.11
   - VERSION: python-3.12
     FRAMEWORK: graphene-2
   - VERSION: python-3.12
@@ -294,8 +278,6 @@ exclude:
     FRAMEWORK: flask-1.1
   - VERSION: python-3.7
     FRAMEWORK: jinja2-2
-  - VERSION: python-3.7
-    FRAMEWORK: celery-4-flask-1.0
   # TODO py3.12
   - VERSION: python-3.12
     FRAMEWORK: sanic-20.12  # no wheels available yet

--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -14,8 +14,6 @@ FRAMEWORK:
   - opentelemetry-newest
   - opentracing-newest
   - twisted-newest
-  - celery-4-flask-1.0
-  - celery-4-django-2.0
   - celery-5-flask-2
   - celery-5-django-4
   - celery-5-django-5

--- a/.ci/.matrix_framework_full.yml
+++ b/.ci/.matrix_framework_full.yml
@@ -25,9 +25,6 @@ FRAMEWORK:
   - flask-3.0
   - jinja2-2
   - jinja2-3
-  - celery-4-flask-1.0
-  - celery-4-django-1.11
-  - celery-4-django-2.0
   - celery-5-flask-2
   - celery-5-django-3
   - celery-5-django-4

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -128,8 +128,8 @@ The Python APM agent comes with automatic instrumentation of various 3rd party m
 
 We support these Celery versions:
 
-* 3.x
-* 4.x
+* 4.x (deprecated)
+* 5.x
 
 Celery tasks will be recorded automatically with Django and Flask only.
 

--- a/tests/requirements/reqs-celery-4-django-1.11.txt
+++ b/tests/requirements/reqs-celery-4-django-1.11.txt
@@ -1,2 +1,0 @@
--r reqs-celery-4.txt
--r reqs-django-1.11.txt

--- a/tests/requirements/reqs-celery-4-django-2.0.txt
+++ b/tests/requirements/reqs-celery-4-django-2.0.txt
@@ -1,2 +1,0 @@
--r reqs-celery-4.txt
--r reqs-django-2.0.txt

--- a/tests/requirements/reqs-celery-4-flask-1.0.txt
+++ b/tests/requirements/reqs-celery-4-flask-1.0.txt
@@ -1,2 +1,0 @@
--r reqs-celery-4.txt
--r reqs-flask-1.0.txt

--- a/tests/requirements/reqs-celery-4.txt
+++ b/tests/requirements/reqs-celery-4.txt
@@ -1,4 +1,0 @@
-celery>4.0,<5
-# including future as it was missing in celery 4.4.4, see https://github.com/celery/celery/issues/6145
-future>=0.18.0
-importlib-metadata<5.0; python_version<"3.8"


### PR DESCRIPTION
## What does this pull request do?

With latest pip 24.1 Celery 4 is not installable anymore because the latest release version in 2020 contains an invalid metadata:

```
WARNING: Ignoring version 4.4.7 of celery since it has invalid metadata: Requested celery<5,>4.0 from celery-4.4.7-py2.py3-none-any.whl (from -r tests/requirements/reqs-celery-4.txt (line 1)) has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    pytz (>dev)
         ~^
Please use pip<24.1 if you need to use this version.
```

The alternative would be to upgrade pip to a fixed version (24.0) but celery 5 is out since 2020 so hopefully there's not many users left.

## Related issues

None
