### PR TITLE
Automate collapsing ARN table in release notes

### DIFF
--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -10,7 +10,7 @@ AWS_FOLDER=${AWS_FOLDER?:No aws folder provided}
 ARN_FILE=".arn-file.md"
 
 {
-  echo "<details>"
+	echo "<details>"
 	echo "<summary>Elastic APM Python agent layer ARNs</summary>"
 	echo ''
 	echo '|Region|ARN|'
@@ -24,7 +24,7 @@ for f in $(ls "${AWS_FOLDER}"); do
 done
 
 {
-  echo ''
-  echo '</details>'
-  echo ''
+	echo ''
+	echo '</details>'
+	echo ''
 } >> "${ARN_FILE}"

--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -10,7 +10,8 @@ AWS_FOLDER=${AWS_FOLDER?:No aws folder provided}
 ARN_FILE=".arn-file.md"
 
 {
-	echo "### Elastic APM Python agent layer ARNs"
+  echo "<details>"
+	echo "<summary>Elastic APM Python agent layer ARNs</summary>"
 	echo ''
 	echo '|Region|ARN|'
 	echo '|------|---|'
@@ -22,4 +23,8 @@ for f in $(ls "${AWS_FOLDER}"); do
 	echo "|${f}|${LAYER_VERSION_ARN}|" >> "${ARN_FILE}"
 done
 
-echo '' >> "${ARN_FILE}"
+{
+  echo ''
+  echo '</details>'
+  echo ''
+} >> "${ARN_FILE}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,4 +198,4 @@ If you have commit access, the process is as follows:
 1. After tests pass, Github Actions will automatically build and push the new release to PyPI.
 1. Edit and publish the [draft Github release](https://github.com/elastic/apm-agent-python/releases)
    created by Github Actions. Substitute the generated changelog with one hand written into the body of the
-   release and move the agent layer ARNs under a `<details>` block with a `summary`.
+   release.


### PR DESCRIPTION
## What does this pull request do?

Automate the details block step described in https://github.com/elastic/apm-agent-python/blob/main/CONTRIBUTING.md#releasing (last step)

> Edit and publish the [draft Github release](https://github.com/elastic/apm-agent-python/releases) created by Github Actions. Substitute the generated changelog with one hand written into the body of the release and move the agent layer ARNs under a `<details>` block with a summary.

The manual editing of the draft is causing a malformed markdown table

![image](https://github.com/elastic/apm-agent-python/assets/16325797/b340de54-da63-4698-abb7-4be897cdc386)

Source: https://github.com/elastic/apm-agent-python/releases/tag/v6.22.3

## Related issues

Closes #ISSUE
