### PR TITLE
instrumentation/kafka: fix handling consumer iteration if transaction not sampled

### DIFF
--- a/elasticapm/instrumentation/packages/kafka.py
+++ b/elasticapm/instrumentation/packages/kafka.py
@@ -143,7 +143,8 @@ class KafkaInstrumentation(AbstractInstrumentedModule):
                     try:
                         result = wrapped(*args, **kwargs)
                     except StopIteration:
-                        span.cancel()
+                        if span:
+                            span.cancel()
                         raise
                     if span and not isinstance(span, DroppedSpan):
                         topic = result[0]


### PR DESCRIPTION
## What does this pull request do?

Handle the case where if the transaction is not sampled capture_span will return None instead of a span.
While at it fix handling of checking for KAFKA_HOST in tests.

## Related issues

Closes #2073