### PR TITLE
feat: make published Docker images multi-platform, add linux/arm64 plat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
       - name: Log in to the Elastic Container registry
         uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
@@ -142,10 +145,11 @@ jobs:
             suffix=${{ contains(matrix.dockerfile, 'wolfi') && '-wolfi' || '' }}
 
       - name: Build and push image
-        id: push
+        id: docker-push
         uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c  # v6.3.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           file: ${{ matrix.dockerfile }}
           tags: ${{ steps.docker-meta.outputs.tags }}
@@ -157,7 +161,7 @@ jobs:
         uses: actions/attest-build-provenance@bdd51370e0416ac948727f861e03c2f05d32d78e  # v1.3.2
         with:
           subject-name: "${{ env.DOCKER_IMAGE_NAME }}"
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.docker-push.outputs.digest }}
           push-to-registry: true
 
   github-draft:
@@ -196,7 +200,7 @@ jobs:
         with:
           needs: ${{ toJSON(needs) }}
       - if: startsWith(github.ref, 'refs/tags')
-        uses: elastic/oblt-actions/slack/notify-result@v1.7.0
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-python"


### PR DESCRIPTION
## What does this pull request do?

Create multi-platform containers

## Related issues

Similar to https://github.com/elastic/apm-agent-dotnet/pull/2395


## Test

I created a feature branch for testing this:
- https://github.com/elastic/apm-agent-python/actions/runs/9870258582
