### PR TITLE
contrib/serverless: capture_serverless is already called by the APM layer

### DIFF
--- a/elasticapm/contrib/serverless/aws.py
+++ b/elasticapm/contrib/serverless/aws.py
@@ -71,6 +71,9 @@ def capture_serverless(func: Optional[callable] = None, **kwargs) -> callable:
         @capture_serverless
         def handler(event, context):
             return {"statusCode": r.status_code, "body": "Success!"}
+
+    Please note that when using the APM Layer and setting AWS_LAMBDA_EXEC_WRAPPER this is not required and
+    the handler would be instrumented automatically.
     """
     if not func:
         # This allows for `@capture_serverless()` in addition to


### PR DESCRIPTION
## What does this pull request do?

Add a small note in capture_serverless docstring that with the APM layer it is already been called and adding it manually will result in instrumenting the handler twice.
