### PR TITLE
elasticapm/transport: specific shutdown handling for http transport

### DIFF
--- a/elasticapm/transport/base.py
+++ b/elasticapm/transport/base.py
@@ -292,7 +292,8 @@ class Transport(ThreadManager):
         if not self._flushed.wait(timeout=self._max_flush_time_seconds):
             logger.error("Closing the transport connection timed out.")
 
-    stop_thread = close
+    def stop_thread(self) -> None:
+        self.close()
 
     def flush(self):
         """


### PR DESCRIPTION
## What does this pull request do?

We have a race condition at http transport shutdown where our atexit handler is racing against urllib3 ConnectionPool weakref finalizer. Having the urllib3 finalizer called before atexit would lead to have our thread hang waiting for send any eventual queued data via urllib3 pools that are closed.
Force the creation of a new PoolManager so that we are always able to flush.

## Related issues

Closes #1975
