### PR TITLE
tests: bump setuptools to latest in the script running tests

### DIFF
--- a/tests/scripts/run_tests.sh
+++ b/tests/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 set -e
 
 export PATH=${HOME}/.local/bin:${PATH}
-python -m pip install --user -U pip --cache-dir "${PIP_CACHE}"
+python -m pip install --user -U pip setuptools --cache-dir "${PIP_CACHE}"
 python -m pip install --user -r "tests/requirements/reqs-${FRAMEWORK}.txt" --cache-dir "${PIP_CACHE}"
 
 export PYTHON_VERSION=$(python -c "import platform; pv=platform.python_version_tuple(); print('pypy' + ('' if pv[0] == 2 else str(pv[0])) if platform.python_implementation() == 'PyPy' else '.'.join(map(str, platform.python_version_tuple()[:2])))")


### PR DESCRIPTION
## What does this pull request do?

For some reason twisted tests are now failing with not so recent setuptools versions: 56.0 fails but 59.6.0 works.

Twisted fails to install with:

```
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2456, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ModuleNotFoundError: No module named 'setuptools.command.build'
```

## Related issues

See https://github.com/elastic/apm-agent-python/actions/runs/10107295945
