### PR TITLE
Drop `setup.py test`

### DIFF
--- a/scripts/run-tests.bat
+++ b/scripts/run-tests.bat
@@ -9,14 +9,12 @@
 set VENV_PYTHON=%cd%\venv\Scripts\
 
 set COVERAGE_FILE=.coverage.windows.%VERSION%.%FRAMEWORK%.%ASYNCIO%
-set IGNORE_PYTHON3_WITH_PYTHON2=
-if "%VERSION%" == "2.7" set IGNORE_PYTHON3_WITH_PYTHON2=--ignore-glob="*\py3_*.py"
 
 set PYTEST_JUNIT="--junitxml=.\tests\windows-%VERSION%-%FRAMEWORK%-%ASYNCIO%-python-agent-junit.xml"
 if "%ASYNCIO%" == "true" (
-    %VENV_PYTHON%\python.exe -m pytest %PYTEST_JUNIT% %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
+    %VENV_PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
 )
 if "%ASYNCIO%" == "false" (
-    %VENV_PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" %IGNORE_PYTHON3_WITH_PYTHON2% --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
+    %VENV_PYTHON%\python.exe -m pytest %PYTEST_JUNIT% --ignore-glob="*\asyncio*\*" --cov --cov-context=test --cov-branch --cov-config=setup.cfg -m "not integrationtest" || exit /b 1
 )
 call %VENV_PYTHON%\python.exe setup.py bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -43,12 +43,9 @@ full out-of-the-box support for many of the popular frameworks, including
 import ast
 import codecs
 import os
-import sys
-from distutils.command.build_ext import build_ext
-from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 
 import pkg_resources
-from setuptools import Extension, setup
+from setuptools import setup
 
 pkg_resources.require("setuptools>=39.2")
 

--- a/setup.py
+++ b/setup.py
@@ -40,16 +40,6 @@ full out-of-the-box support for many of the popular frameworks, including
 #  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
-# in multiprocessing/util.py _exit_function when running `python
-# setup.py test` (see
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
-for m in ("multiprocessing", "billiard"):
-    try:
-        __import__(m)
-    except ImportError:
-        pass
-
 import ast
 import codecs
 import os
@@ -59,29 +49,8 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 
 import pkg_resources
 from setuptools import Extension, setup
-from setuptools.command.test import test as TestCommand
 
 pkg_resources.require("setuptools>=39.2")
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to py.test")]
-
-    def initialize_options(self) -> None:
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self) -> None:
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self) -> None:
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 
 def get_version():
@@ -108,4 +77,4 @@ def get_version():
     return "unknown"
 
 
-setup(cmdclass={"test": PyTest}, version=get_version())
+setup(version=get_version())


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Remove the support for `python setup.py test` for compatibility with setuptools>=72 that removed the test command.
See https://github.com/pypa/setuptools/issues/931

While at it remove some python 2 relics from windows scripts.

## Related issues

CI failures
```
   × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      <string>:60: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-t48opgw9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-t48opgw9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-t48opgw9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-t48opgw9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 62, in <module>
      ModuleNotFoundError: No module named 'setuptools.command.test'
      [end of output]
```