### PR TITLE
renovate: enable only for chainguard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "local>elastic/renovate-config",
         "github>elastic/renovate-config:only-chainguard"
     ]
 }


### PR DESCRIPTION
## What does this pull request do?

As far as I know, we use Dependabot for all the dependencies and Renovate only for the chainguard. See https://github.com/elastic/apm-agent-nodejs/pull/4151/commits/5083fd0598a602753fa4cf7dcbdf75e7fe4e9e66

## Related issues

Closes #ISSUE
