### PR TITLE
ci: fix upload of codecov data

### DIFF
--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           name: coverage-reports
           path: "**/.coverage*"
+          include-hidden-files: true


### PR DESCRIPTION
## What does this pull request do?

From latest release upload artifact will ignore hidden files by default, configure to don't ignore them when uploading coverage data.

Should fix:

```
Run actions/download-artifact@v3
Starting download for coverage-reports
Error: Unable to find an artifact with the name: coverage-reports
```
