### PR TITLE
[Azure Tables] Check if request body exists before trying to convert it to JSON

### DIFF
--- a/elasticapm/instrumentation/packages/azure.py
+++ b/elasticapm/instrumentation/packages/azure.py
@@ -316,7 +316,7 @@ def handle_azuretable(request, hostname, path, query_params, service, service_ty
     }
 
     operation_name = "Unknown"
-    if method.lower() == "put":
+    if method.lower() == "put" or method.lower() == "patch":
         operation_name = "Update"
         if "properties" in query_params.get("comp", []):
             operation_name = "SetProperties"

--- a/elasticapm/instrumentation/packages/azure.py
+++ b/elasticapm/instrumentation/packages/azure.py
@@ -300,9 +300,12 @@ def handle_azuretable(request, hostname, path, query_params, service, service_ty
     account_name = hostname.split(".")[0]
     method = request.method
     body = request.body
-    try:
-        body = json.loads(body)
-    except json.decoder.JSONDecodeError:  # str not bytes
+    if body:
+        try:
+            body = json.loads(body)
+        except json.decoder.JSONDecodeError:  # str not bytes
+            body = {}
+    else:
         body = {}
     # /tablename(PartitionKey='<partition-key>',RowKey='<row-key>')
     resource_name = path.split("/", 1)[1] if "/" in path else path

--- a/tests/contrib/serverless/azurefunctions/azure_functions_tests.py
+++ b/tests/contrib/serverless/azurefunctions/azure_functions_tests.py
@@ -29,7 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
 
-azure = pytest.importorskip("azure-functions")
+azure = pytest.importorskip("azure.functions")
 
 import datetime
 import os

--- a/tests/contrib/serverless/azurefunctions/azure_functions_tests.py
+++ b/tests/contrib/serverless/azurefunctions/azure_functions_tests.py
@@ -29,7 +29,7 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
 
-azure = pytest.importorskip("azure")
+azure = pytest.importorskip("azure-functions")
 
 import datetime
 import os

--- a/tests/instrumentation/azure_tests.py
+++ b/tests/instrumentation/azure_tests.py
@@ -43,8 +43,8 @@ azuredatatable = pytest.importorskip("azure.data.tables")
 azurefile = pytest.importorskip("azure.storage.fileshare")
 pytestmark = [pytest.mark.azurestorage]
 
-from azure.data.tables import TableServiceClient as DataTableServiceClient
 from azure.cosmosdb.table.tableservice import TableService
+from azure.data.tables import TableServiceClient as DataTableServiceClient
 from azure.storage.blob import BlobServiceClient
 from azure.storage.fileshare import ShareClient
 from azure.storage.queue import QueueClient
@@ -213,6 +213,7 @@ def test_data_table_create(instrument, elasticapm_client):
     assert span["subtype"] == "azuretable"
     assert span["action"] == "Create"
 
+
 def test_table_create(instrument, elasticapm_client):
     table_name = "apmagentpythonci" + str(uuid.uuid4().hex)
     table_service = TableService(connection_string=CONNECTION_STRING)
@@ -228,6 +229,7 @@ def test_table_create(instrument, elasticapm_client):
     assert span["type"] == "storage"
     assert span["subtype"] == "azuretable"
     assert span["action"] == "Create"
+
 
 def test_data_table(instrument, elasticapm_client, data_table_service):
     table_name = data_table_service.table_name
@@ -263,6 +265,7 @@ def test_data_table(instrument, elasticapm_client, data_table_service):
     assert span["type"] == "storage"
     assert span["subtype"] == "azuretable"
     assert span["action"] == "Delete"
+    
 
 def test_table(instrument, elasticapm_client, table_service):
     table_name = table_service.table_name

--- a/tests/instrumentation/azure_tests.py
+++ b/tests/instrumentation/azure_tests.py
@@ -265,7 +265,6 @@ def test_data_table(instrument, elasticapm_client, data_table_service):
     assert span["type"] == "storage"
     assert span["subtype"] == "azuretable"
     assert span["action"] == "Delete"
-    
 
 def test_table(instrument, elasticapm_client, table_service):
     table_name = table_service.table_name

--- a/tests/instrumentation/azure_tests.py
+++ b/tests/instrumentation/azure_tests.py
@@ -39,9 +39,11 @@ from elasticapm.conf import constants
 azureblob = pytest.importorskip("azure.storage.blob")
 azurequeue = pytest.importorskip("azure.storage.queue")
 azuretable = pytest.importorskip("azure.cosmosdb.table")
+azuredatatable = pytest.importorskip("azure.data.tables")
 azurefile = pytest.importorskip("azure.storage.fileshare")
 pytestmark = [pytest.mark.azurestorage]
 
+from azure.data.tables import TableServiceClient as DataTableServiceClient
 from azure.cosmosdb.table.tableservice import TableService
 from azure.storage.blob import BlobServiceClient
 from azure.storage.fileshare import ShareClient
@@ -81,6 +83,18 @@ def queue_client():
 
     queue_client.delete_queue()
 
+
+@pytest.fixture()
+def data_table_service():
+    table_name = "apmagentpythonci" + str(uuid.uuid4().hex)
+    data_table_service_client = DataTableServiceClient.from_connection_string(conn_str=CONNECTION_STRING)
+    data_table_service = data_table_service_client.get_table_client(table_name)
+    data_table_service.create_table()
+    data_table_service.table_name = table_name
+
+    yield data_table_service
+
+    data_table_service.delete_table()
 
 @pytest.fixture()
 def table_service():
@@ -182,6 +196,23 @@ def test_queue(instrument, elasticapm_client, queue_client):
     assert span["action"] == "delete"
 
 
+def test_data_table_create(instrument, elasticapm_client):
+    table_name = "apmagentpythonci" + str(uuid.uuid4().hex)
+    data_table_service_client = DataTableServiceClient.from_connection_string(conn_str=CONNECTION_STRING)
+    data_table_service = data_table_service_client.get_table_client(table_name)
+
+    elasticapm_client.begin_transaction("transaction.test")
+    data_table_service.create_table()
+    data_table_service.delete_table()
+    elasticapm_client.end_transaction("MyView")
+
+    span = elasticapm_client.events[constants.SPAN][0]
+
+    assert span["name"] == "AzureTable Create {}".format(table_name)
+    assert span["type"] == "storage"
+    assert span["subtype"] == "azuretable"
+    assert span["action"] == "Create"
+
 def test_table_create(instrument, elasticapm_client):
     table_name = "apmagentpythonci" + str(uuid.uuid4().hex)
     table_service = TableService(connection_string=CONNECTION_STRING)
@@ -198,6 +229,40 @@ def test_table_create(instrument, elasticapm_client):
     assert span["subtype"] == "azuretable"
     assert span["action"] == "Create"
 
+def test_data_table(instrument, elasticapm_client, data_table_service):
+    table_name = data_table_service.table_name
+    elasticapm_client.begin_transaction("transaction.test")
+    task = {"PartitionKey": "tasksSeattle", "RowKey": "001", "description": "Take out the trash", "priority": 200}
+    data_table_service.create_entity(task)
+    task = {"PartitionKey": "tasksSeattle", "RowKey": "001", "description": "Take out the garbage", "priority": 250}
+    data_table_service.update_entity(task)
+    task = data_table_service.get_entity("tasksSeattle", "001")
+    data_table_service.delete_entity("tasksSeattle", "001")
+    elasticapm_client.end_transaction("MyView")
+
+    span = elasticapm_client.events[constants.SPAN][0]
+    assert span["name"] == "AzureTable Insert {}".format(table_name)
+    assert span["type"] == "storage"
+    assert span["subtype"] == "azuretable"
+    assert span["action"] == "Insert"
+
+    span = elasticapm_client.events[constants.SPAN][1]
+    assert span["name"] == "AzureTable Update {}(PartitionKey='tasksSeattle',RowKey='001')".format(table_name)
+    assert span["type"] == "storage"
+    assert span["subtype"] == "azuretable"
+    assert span["action"] == "Update"
+
+    span = elasticapm_client.events[constants.SPAN][2]
+    assert span["name"] == "AzureTable Query {}(PartitionKey='tasksSeattle',RowKey='001')".format(table_name)
+    assert span["type"] == "storage"
+    assert span["subtype"] == "azuretable"
+    assert span["action"] == "Query"
+
+    span = elasticapm_client.events[constants.SPAN][3]
+    assert span["name"] == "AzureTable Delete {}(PartitionKey='tasksSeattle',RowKey='001')".format(table_name)
+    assert span["type"] == "storage"
+    assert span["subtype"] == "azuretable"
+    assert span["action"] == "Delete"
 
 def test_table(instrument, elasticapm_client, table_service):
     table_name = table_service.table_name

--- a/tests/requirements/reqs-azure-newest.txt
+++ b/tests/requirements/reqs-azure-newest.txt
@@ -1,0 +1,5 @@
+azure-storage-blob
+azure-storage-queue
+azure-data-tables
+azure-storage-file-share
+-r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

Checks existence of body payload in request to Azure Table service before trying to convert it into JSON, thus avoiding `TypeError`

## Related issues

Closes #2118
