### PR TITLE
Add field_name to ConfigurationError messages on init

### DIFF
--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -307,9 +307,7 @@ class UnitValidator(object):
         try:
             val = int(val) * self.unit_multipliers[unit]
         except KeyError:
-            raise ConfigurationError(
-                "{}={} is not a supported unit".format(field_name, unit), field_name
-            )
+            raise ConfigurationError("{}={} is not a supported unit".format(field_name, unit), field_name)
         return val
 
 
@@ -331,9 +329,7 @@ class PrecisionValidator(object):
         try:
             value = float(value)
         except ValueError:
-            raise ConfigurationError(
-                "{}={} is not a float".format(field_name, value), field_name
-            )
+            raise ConfigurationError("{}={} is not a float".format(field_name, value), field_name)
         multiplier = 10**self.precision
         rounded = math.floor(value * multiplier + 0.5) / multiplier
         if rounded == 0 and self.minimum and value != 0:
@@ -358,9 +354,7 @@ class ExcludeRangeValidator(object):
                 "{}={} cannot be in range: {}".format(
                     field_name,
                     value,
-                    self.range_desc.format(
-                        **{"range_start": self.range_start, "range_end": self.range_end}
-                    ),
+                    self.range_desc.format(**{"range_start": self.range_start, "range_end": self.range_end}),
                 ),
                 field_name,
             )
@@ -371,17 +365,11 @@ class FileIsReadableValidator(object):
     def __call__(self, value, field_name):
         value = os.path.normpath(value)
         if not os.path.exists(value):
-            raise ConfigurationError(
-                "{}={} does not exist".format(field_name, value), field_name
-            )
+            raise ConfigurationError("{}={} does not exist".format(field_name, value), field_name)
         elif not os.path.isfile(value):
-            raise ConfigurationError(
-                "{}={} is not a file".format(field_name, value), field_name
-            )
+            raise ConfigurationError("{}={} is not a file".format(field_name, value), field_name)
         elif not os.access(value, os.R_OK):
-            raise ConfigurationError(
-                "{}={} is not readable".format(field_name, value), field_name
-            )
+            raise ConfigurationError("{}={} is not readable".format(field_name, value), field_name)
         return value
 
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -275,7 +275,14 @@ class RegexValidator(object):
         match = re.match(self.regex, value)
         if match:
             return value
-        raise ConfigurationError("{} does not match pattern {}".format(value, self.verbose_pattern), field_name)
+        raise ConfigurationError(
+            "{}={} does not match pattern {}".format(
+                field_name,
+                value,
+                self.verbose_pattern,
+            ),
+            field_name,
+        )
 
 
 class UnitValidator(object):
@@ -288,12 +295,21 @@ class UnitValidator(object):
         value = str(value)
         match = re.match(self.regex, value, re.IGNORECASE)
         if not match:
-            raise ConfigurationError("{} does not match pattern {}".format(value, self.verbose_pattern), field_name)
+            raise ConfigurationError(
+                "{}={} does not match pattern {}".format(
+                    field_name,
+                    value,
+                    self.verbose_pattern,
+                ),
+                field_name,
+            )
         val, unit = match.groups()
         try:
             val = int(val) * self.unit_multipliers[unit]
         except KeyError:
-            raise ConfigurationError("{} is not a supported unit".format(unit), field_name)
+            raise ConfigurationError(
+                "{}={} is not a supported unit".format(field_name, unit), field_name
+            )
         return val
 
 
@@ -315,7 +331,9 @@ class PrecisionValidator(object):
         try:
             value = float(value)
         except ValueError:
-            raise ConfigurationError("{} is not a float".format(value), field_name)
+            raise ConfigurationError(
+                "{}={} is not a float".format(field_name, value), field_name
+            )
         multiplier = 10**self.precision
         rounded = math.floor(value * multiplier + 0.5) / multiplier
         if rounded == 0 and self.minimum and value != 0:
@@ -337,8 +355,12 @@ class ExcludeRangeValidator(object):
     def __call__(self, value, field_name):
         if self.range_start <= value <= self.range_end:
             raise ConfigurationError(
-                "{} cannot be in range: {}".format(
-                    value, self.range_desc.format(**{"range_start": self.range_start, "range_end": self.range_end})
+                "{}={} cannot be in range: {}".format(
+                    field_name,
+                    value,
+                    self.range_desc.format(
+                        **{"range_start": self.range_start, "range_end": self.range_end}
+                    ),
                 ),
                 field_name,
             )
@@ -349,11 +371,17 @@ class FileIsReadableValidator(object):
     def __call__(self, value, field_name):
         value = os.path.normpath(value)
         if not os.path.exists(value):
-            raise ConfigurationError("{} does not exist".format(value), field_name)
+            raise ConfigurationError(
+                "{}={} does not exist".format(field_name, value), field_name
+            )
         elif not os.path.isfile(value):
-            raise ConfigurationError("{} is not a file".format(value), field_name)
+            raise ConfigurationError(
+                "{}={} is not a file".format(field_name, value), field_name
+            )
         elif not os.access(value, os.R_OK):
-            raise ConfigurationError("{} is not readable".format(value), field_name)
+            raise ConfigurationError(
+                "{}={} is not readable".format(field_name, value), field_name
+            )
         return value
 
 
@@ -384,7 +412,12 @@ class EnumerationValidator(object):
             ret = self.valid_values.get(value.lower())
         if ret is None:
             raise ConfigurationError(
-                "{} is not in the list of valid values: {}".format(value, list(self.valid_values.values())), field_name
+                "{}={} is not in the list of valid values: {}".format(
+                    field_name,
+                    value,
+                    list(self.valid_values.values()),
+                ),
+                field_name,
             )
         return ret
 


### PR DESCRIPTION
## What does this pull request do?

Make `ConfigurationError` messages more descriptive on init. This is especially useful where ENV variables are not set.

Turns this error message:

```
ERROR      {/usr/local/lib/python3.10/site-packages/elasticapm/base.py}  is not a float
```
into this:
```
ERROR      {/usr/local/lib/python3.10/site-packages/elasticapm/base.py} TRANSACTION_SAMPLE_RATE= is not a float
```

