### PR TITLE
github-actions: use ephemeral tokens

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,6 +15,16 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read"
+          }
     - name: Add agent-python label
       uses: actions-ecosystem/action-add-labels@v1
       with:
@@ -24,7 +34,7 @@ jobs:
       with:
         github-org: "elastic"
         github-user: ${{ github.actor }}
-        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        github-token: ${{ steps.get_token.outputs.token }}
     - name: Add community and triage labels
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'apmmachine'
       uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
## What does this pull request do?

Use GH app for creating ephemeral tokens instead of using a finer-grained token
## Related issues

Closes #ISSUE
