### PR TITLE
github-action: use elastic/oblt-actions/version-framework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
       - id: generate
-        uses: elastic/apm-pipeline-library/.github/actions/version-framework@current
+        uses: elastic/oblt-actions/version-framework@v1
         with:
           # Use .ci/.matrix_python_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_python.yml
-          versionsFile: .ci/.matrix_python${{ (github.event_name == 'schedule' || github.event_name == 'push' || inputs.full-matrix) && '_full' || '' }}.yml
+          versions-file: .ci/.matrix_python${{ (github.event_name == 'schedule' || github.event_name == 'push' || inputs.full-matrix) && '_full' || '' }}.yml
           # Use .ci/.matrix_framework_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_framework.yml
-          frameworksFile: .ci/.matrix_framework${{ (github.event_name == 'schedule' || github.event_name == 'push' || inputs.full-matrix) && '_full' || '' }}.yml
-          excludedFile: .ci/.matrix_exclude.yml
+          frameworks-file: .ci/.matrix_framework${{ (github.event_name == 'schedule' || github.event_name == 'push' || inputs.full-matrix) && '_full' || '' }}.yml
+          excluded-file: .ci/.matrix_exclude.yml
       - name: Split matrix
         shell: python
         id: split


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been archived. 
https://github.com/elastic/oblt-actions is the new repository for the github actions.

Requires https://github.com/elastic/oblt-actions/pull/150 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
