### PR TITLE
#2114 repeating query in django view

### DIFF
--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import
 import django
 from django.conf import settings as django_settings
 from django.db import DatabaseError
-from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
 try:
@@ -196,14 +195,6 @@ class DjangoClient(Client):
 
         return result
 
-    @staticmethod
-    def _disable_querysets_evaluation(var):
-        """Overriding queryset result cache to avoid making any queries"""
-        if isinstance(var, QuerySet):
-            var._result_cache = []
-        return var
-
-
     def _get_stack_info_for_trace(
         self,
         frames,
@@ -214,13 +205,6 @@ class DjangoClient(Client):
     ):
         """If the stacktrace originates within the elasticapm module, it will skip
         frames until some other module comes up."""
-
-        # Overriding processor func for django to avoid making queries to db through QuerySet objects
-        if locals_processor_func is not None:
-            locals_processor_func = lambda v: self._disable_querysets_evaluation(locals_processor_func(v))
-        else:
-            locals_processor_func = lambda v: self._disable_querysets_evaluation(v)
-
         return list(
             iterate_with_template_sources(
                 frames,

--- a/elasticapm/contrib/django/client.py
+++ b/elasticapm/contrib/django/client.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import django
 from django.conf import settings as django_settings
 from django.db import DatabaseError
+from django.db.models.query import QuerySet
 from django.http import HttpRequest
 
 try:
@@ -195,6 +196,14 @@ class DjangoClient(Client):
 
         return result
 
+    @staticmethod
+    def _disable_querysets_evaluation(var):
+        """Overriding queryset result cache to avoid making any queries"""
+        if isinstance(var, QuerySet):
+            var._result_cache = []
+        return var
+
+
     def _get_stack_info_for_trace(
         self,
         frames,
@@ -205,6 +214,13 @@ class DjangoClient(Client):
     ):
         """If the stacktrace originates within the elasticapm module, it will skip
         frames until some other module comes up."""
+
+        # Overriding processor func for django to avoid making queries to db through QuerySet objects
+        if locals_processor_func is not None:
+            locals_processor_func = lambda v: self._disable_querysets_evaluation(locals_processor_func(v))
+        else:
+            locals_processor_func = lambda v: self._disable_querysets_evaluation(v)
+
         return list(
             iterate_with_template_sources(
                 frames,

--- a/elasticapm/utils/encoding.py
+++ b/elasticapm/utils/encoding.py
@@ -36,6 +36,7 @@ import itertools
 import uuid
 from decimal import Decimal
 
+from django.db.models import QuerySet
 from elasticapm.conf.constants import KEYWORD_MAX_LENGTH, LABEL_RE, LABEL_TYPES, LONG_FIELD_MAX_LENGTH
 
 PROTECTED_TYPES = (int, type(None), float, Decimal, datetime.datetime, datetime.date, datetime.time)
@@ -144,6 +145,9 @@ def transform(value, stack=None, context=None):
         ret = float(value)
     elif isinstance(value, int):
         ret = int(value)
+    elif isinstance(value, QuerySet):
+        value._result_cache = []
+        ret = repr(value)
     elif value is not None:
         try:
             ret = transform(repr(value))

--- a/tests/contrib/django/testapp/urls.py
+++ b/tests/contrib/django/testapp/urls.py
@@ -62,6 +62,7 @@ urlpatterns = (
     re_path(r"^trigger-500-ioerror$", views.raise_ioerror, name="elasticapm-raise-ioerror"),
     re_path(r"^trigger-500-decorated$", views.decorated_raise_exc, name="elasticapm-raise-exc-decor"),
     re_path(r"^trigger-500-django$", views.django_exc, name="elasticapm-django-exc"),
+    re_path(r"^trigger-500-django-orm-exc$", views.django_queryset_error, name="elasticapm-django-orm-exc"),
     re_path(r"^trigger-500-template$", views.template_exc, name="elasticapm-template-exc"),
     re_path(r"^trigger-500-log-request$", views.logging_request_exc, name="elasticapm-log-request-exc"),
     re_path(r"^streaming$", views.streaming_view, name="elasticapm-streaming-view"),

--- a/tests/contrib/django/testapp/views.py
+++ b/tests/contrib/django/testapp/views.py
@@ -37,6 +37,8 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.views import View
+from django.db.models import QuerySet
+from django.db import DatabaseError
 
 import elasticapm
 
@@ -69,6 +71,18 @@ def fake_login(request):
 def django_exc(request):
     return get_object_or_404(MyException, pk=1)
 
+
+def django_queryset_error(request):
+    """Simulation of django ORM timeout"""
+    class CustomQuerySet(QuerySet):
+        def all(self):
+            raise DatabaseError()
+        
+        def __repr__(self) -> str:
+            return str(self._result_cache)
+
+    qs = CustomQuerySet()
+    list(qs.all())
 
 def raise_exc(request):
     raise MyException(request.GET.get("message", "view exception"))


### PR DESCRIPTION
## What does this pull request do?

In this PR i add another condition to `elif` statement in `utils.encoding.transform` function to handle displaying representation of django QuerySet object in custom way. We need to do it because if we try to execute `repr` function on unexecuted `QuerySet` which causes Timeout on database, it will execute by `utils.encoding.transform` function.

I also added a simple test simulating database Timeout.

By overwriting `_result_cache` on django QuerySet object we ensure that django will not try to execute any query to db.

## Related issues

Closes #2114
