### PR TITLE
Use build to create distributions

### DIFF
--- a/dev-utils/make-packages.sh
+++ b/dev-utils/make-packages.sh
@@ -3,14 +3,10 @@
 # Make a Python APM agent distribution
 #
 
-echo "::group::Install wheel"
-pip install --user wheel
+echo "::group::Install build"
+pip install --user build
 echo "::endgroup::"
 
-echo "::group::Building universal wheel"
-python setup.py bdist_wheel
-echo "::endgroup::"
-
-echo "::group::Building source distribution"
-python setup.py sdist
+echo "::group::Building packages"
+python -m build
 echo "::endgroup::"


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Instead of calling setup.py. This fixes the name of built distributions to match pep625, i.e. elastic_apm instead of elastic-apm.

## Related issues

Closes #2159
