### PR TITLE
github-actions: use v1 for the oblt-actions

### DIFF
--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run microbenchmark
-        uses: elastic/oblt-actions/buildkite/run@v1.5.0
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
           pipeline: "apm-agent-microbenchmark"
           token: ${{ secrets.BUILDKITE_TOKEN }}


### PR DESCRIPTION


## What does this pull request do?

dependabot does not bump version for githubactions using semver and 'v1', see https://github.com/dependabot/dependabot-core/issues/10924

## Related issues

Closes #ISSUE
