### PR TITLE
Implement defensive programming techniques for setting spans in ContextVars

### DIFF
--- a/elasticapm/context/contextvars.py
+++ b/elasticapm/context/contextvars.py
@@ -78,7 +78,7 @@ class ContextVarsContext(BaseContext):
 
         The previously-activated span will be saved to be re-activated later.
         """
-        spans = self.elasticapm_spans_var.get()
+        spans: tuple = self.elasticapm_spans_var.get() or ()
         self.elasticapm_spans_var.set(spans + (span,))
 
     def unset_span(self, clear_all: bool = False) -> "elasticapm.traces.Span":

--- a/tests/context/test_context.py
+++ b/tests/context/test_context.py
@@ -30,10 +30,13 @@
 
 import sys
 
+import mock
 import pytest
 
 import elasticapm.context
+from elasticapm.context.contextvars import ContextVarsContext
 from elasticapm.context.threadlocal import ThreadLocalContext
+from elasticapm.traces import Span
 
 
 def test_execution_context_backing():
@@ -63,3 +66,12 @@ def test_execution_context_monkeypatched(monkeypatch):
 
     # Should always use ThreadLocalContext when thread local is monkey patched
     assert isinstance(execution_context, ThreadLocalContext)
+
+
+def test_none_spans_should_not_raise_a_type_error_on_set_span():
+    context = ContextVarsContext()
+    context.elasticapm_spans_var.set(None)
+
+    context.set_span(mock.MagicMock(spec=Span))
+
+    assert context.get_span() is not None


### PR DESCRIPTION
to avoid accidentally trying to merge a None with a tuple of Spans


## What does this pull request do?

Simply adds a safe fallback in case the existing tuple of spans is None

Unfortunately I wasn't able to find the root cause of it, so I only treated the symptoms

## Related issues

Closes #2056