### PR TITLE
tests/requirements: bump jinja2 to 3.1.5

### DIFF
--- a/tests/requirements/reqs-asgi-2.txt
+++ b/tests/requirements/reqs-asgi-2.txt
@@ -1,6 +1,6 @@
 quart==0.6.13
 MarkupSafe<2.1
-jinja2==3.1.4
+jinja2==3.1.5
 async-asgi-testclient
 asgiref
 -r reqs-base.txt

--- a/tests/requirements/reqs-base.txt
+++ b/tests/requirements/reqs-base.txt
@@ -8,7 +8,7 @@ coverage[toml]==6.3 ; python_version == '3.7'
 coverage==7.3.1 ; python_version > '3.7'
 pytest-cov==4.0.0 ; python_version < '3.8'
 pytest-cov==4.1.0 ; python_version > '3.7'
-jinja2==3.1.4 ; python_version == '3.7'
+jinja2==3.1.5 ; python_version == '3.7'
 pytest-localserver==0.5.0
 pytest-mock==3.6.1 ; python_version == '3.6'
 pytest-mock==3.10.0 ; python_version > '3.6'


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump jinja2 in a couple of tests requirements files to please dependabot warnings.

## Related issues
