### PR TITLE
Fix sanic cookies headers serialization

### DIFF
--- a/.ci/.matrix_exclude.yml
+++ b/.ci/.matrix_exclude.yml
@@ -217,6 +217,8 @@ exclude:
     FRAMEWORK: sanic-20.12
   - VERSION: python-3.6
     FRAMEWORK: sanic-newest
+  - VERSION: python-3.8
+    FRAMEWORK: sanic-newest
   - VERSION: pypy-3
     # aioredis
     FRAMEWORK: aioredis-newest

--- a/elasticapm/contrib/sanic/utils.py
+++ b/elasticapm/contrib/sanic/utils.py
@@ -33,7 +33,7 @@ from typing import Dict
 
 from sanic import Sanic
 from sanic import __version__ as version
-from sanic.cookies import CookieJar
+from sanic.cookies import Cookie, CookieJar
 from sanic.request import Request
 from sanic.response import HTTPResponse
 
@@ -120,7 +120,14 @@ async def get_response_info(config: Config, response: HTTPResponse, event_type: 
         result["status_code"] = response.status
 
     if config.capture_headers:
-        result["headers"] = dict(response.headers)
+
+        def normalize(v):
+            # we are getting entries for Set-Cookie headers as Cookie instances
+            if isinstance(v, Cookie):
+                return str(v)
+            return v
+
+        result["headers"] = {k: normalize(v) for k, v in response.headers.items()}
 
     if config.capture_body in ("all", event_type) and "octet-stream" not in response.content_type:
         result["body"] = response.body.decode("utf-8")

--- a/tests/contrib/sanic/fixtures.py
+++ b/tests/contrib/sanic/fixtures.py
@@ -158,7 +158,10 @@ def sanic_elastic_app(elasticapm_client):
         @app.get("/add-cookies")
         async def add_cookies(request):
             response = json({"data": "message"}, headers={"sessionid": 1234555})
-            response.add_cookie("some", "cookie")
+            if hasattr(response, "add_cookie"):
+                response.add_cookie("some", "cookie")
+            else:
+                response.cookies["some"] = "cookie"
             return response
 
         try:

--- a/tests/contrib/sanic/sanic_tests.py
+++ b/tests/contrib/sanic/sanic_tests.py
@@ -199,6 +199,7 @@ def test_cookies_normalization(sanic_elastic_app, elasticapm_client):
     _, resp = sanic_app.test_client.get(
         "/add-cookies",
     )
+    assert resp.status_code == 200
     assert len(apm._client.events[constants.TRANSACTION]) == 1
     transaction = apm._client.events[constants.TRANSACTION][0]
     assert transaction["context"]["response"]["cookies"] == {"some": {"value": "cookie", "path": "/"}}


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

This is a follow up of #2190 that fixes the full matrix.

We are getting a Cookie instance from Sanic that by default get translated to a dict that is not a proper type for an header. Instead convert it to its string representation.

Also use a syntax for setting cookies that work on older versions.