### PR TITLE
add target in case there is no host in target

### DIFF
--- a/elasticapm/instrumentation/packages/grpc.py
+++ b/elasticapm/instrumentation/packages/grpc.py
@@ -54,7 +54,7 @@ class GRPCClientInstrumentation(AbstractInstrumentedModule):
             except ValueError:
                 port = None
         else:
-            host, port = None, None
+            host, port = target, None
         return grpc.intercept_channel(result, _ClientInterceptor(host, port, secure=method == "secure_channel"))
 
 


### PR DESCRIPTION
The current grpc instrumentation expects host value with a port that may not always be true. In our project, we usean  internal host without a port value

```
target = kwargs.get("target") or args[0]
if ":" in target:
    host, port = target.split(":")
    try:
        port = int(port)
    except ValueError:
        port = None
else:
    host, port = None, None
```
This results in span showing None value and we cannot track the external host value. All grpc hosts are clubbed together under https://none value

The proposal is to keep the target value as is in case there is no ':' in the host and keep the port as None