### PR TITLE
Make server certificate verification mandatory in fips mode

### DIFF
--- a/tests/config/tests.py
+++ b/tests/config/tests.py
@@ -460,7 +460,7 @@ def test_config_all_upper_case():
 
 
 def test_regex_validator_without_match():
-    validator = RegexValidator("\d")
+    validator = RegexValidator(r"\d")
     with pytest.raises(ConfigurationError) as e:
         validator("foo", "field")
     assert "does not match pattern" in e.value.args[0]
@@ -474,7 +474,7 @@ def test_unit_validator_without_match():
 
 
 def test_unit_validator_with_unsupported_unit():
-    validator = UnitValidator("(\d+)(s)", "secs", {})
+    validator = UnitValidator(r"(\d+)(s)", "secs", {})
     with pytest.raises(ConfigurationError) as e:
         validator("10s", "field")
     assert "is not a supported unit" in e.value.args[0]


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Block disabling server certificate validation via `ELASTIC_APM_VERIFY_SERVER_CERT` in fips mode

This requires to add validation support to _BoolConfigValue

## Related issues

Closes #2228
