### PR TITLE
Revert "ci: pin actions to specific commits"

### DIFF
--- a/.github/actions/build-distribution/action.yml
+++ b/.github/actions/build-distribution/action.yml
@@ -6,7 +6,7 @@ description: Run the build distribution
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 
@@ -14,7 +14,7 @@ runs:
       run: ./dev-utils/make-distribution.sh
       shell: bash
 
-    - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+    - uses: actions/upload-artifact@v4
       with:
         name: build-distribution
         path: ./build/

--- a/.github/actions/packages/action.yml
+++ b/.github/actions/packages/action.yml
@@ -6,7 +6,7 @@ description: Run the packages
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
     - name: Override the version if there is no tag release.
@@ -19,7 +19,7 @@ runs:
       run: ./dev-utils/make-packages.sh
       shell: bash
     - name: Upload Packages
-      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-build.yml@99b12f8bf7a82107ffcf59dacd199d00a965e9db # main
+    uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
     with:
       path-pattern: docs/**
     permissions:

--- a/.github/workflows/docs-cleanup.yml
+++ b/.github/workflows/docs-cleanup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs-preview:
-    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@99b12f8bf7a82107ffcf59dacd199d00a965e9db # main
+    uses: elastic/docs-builder/.github/workflows/preview-cleanup.yml@main
     permissions:
       contents: none
       id-token: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -26,18 +26,18 @@ jobs:
             "members": "read"
           }
     - name: Add agent-python label
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+      uses: actions-ecosystem/action-add-labels@v1
       with:
         labels: agent-python
     - id: is_elastic_member
-      uses: elastic/oblt-actions/github/is-member-of@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+      uses: elastic/oblt-actions/github/is-member-of@v1
       with:
         github-org: "elastic"
         github-user: ${{ github.actor }}
         github-token: ${{ steps.get_token.outputs.token }}
     - name: Add community and triage labels
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-observability-automation[bot]'
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+      uses: actions-ecosystem/action-add-labels@v1
       with:
         labels: |
           community

--- a/.github/workflows/matrix-command.yml
+++ b/.github/workflows/matrix-command.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Is comment allowed?
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        uses: actions/github-script@v7
         with:
           script: |
             const actorPermission = (await github.rest.repos.getCollaboratorPermissionLevel({

--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Run microbenchmark
-        uses: elastic/oblt-actions/buildkite/run@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
           pipeline: "apm-agent-microbenchmark"
           token: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -20,5 +20,5 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/packages

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/packages
       - name: generate build provenance
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2  # v2.2.3
@@ -40,8 +40,8 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: packages
           path: dist
@@ -63,7 +63,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-distribution
       - name: generate build provenance
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2  # v2.2.3
@@ -78,12 +78,12 @@ jobs:
       - build-distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: build-distribution
           path: ./build
-      - uses: elastic/oblt-actions/aws/auth@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+      - uses: elastic/oblt-actions/aws/auth@v1
         with:
           aws-account-id: "267093732750"
       - name: Publish lambda layers to AWS
@@ -94,7 +94,7 @@ jobs:
           VERSION=${VERSION//./-}
 
           ELASTIC_LAYER_NAME="elastic-apm-python-${VERSION}" .ci/publish-aws.sh
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+      - uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags')
         with:
           name: arn-file
@@ -116,7 +116,7 @@ jobs:
     env:
       DOCKER_IMAGE_NAME: docker.elastic.co/observability/apm-agent-python
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -128,7 +128,7 @@ jobs:
           username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
           password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
 
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+      - uses: actions/download-artifact@v4
         with:
           name: build-distribution
           path: ./build
@@ -172,8 +172,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: arn-file
       - name: Create GitHub Draft Release
@@ -196,11 +196,11 @@ jobs:
       - github-draft
     steps:
       - id: check
-        uses: elastic/oblt-actions/check-dependent-jobs@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
           jobs: ${{ toJSON(needs) }}
       - if: startsWith(github.ref, 'refs/tags')
-        uses: elastic/oblt-actions/slack/notify-result@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-python"

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -21,20 +21,20 @@ jobs:
       matrix:
         include: ${{ fromJSON(inputs.include) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - name: Run tests
         run: ./tests/scripts/docker/run_tests.sh ${{ matrix.version }} ${{ matrix.framework }}
         env:
           LOCALSTACK_VOLUME_DIR: localstack_data
       - if: success() || failure()
         name: Upload JUnit Test Results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.framework }}-${{ matrix.version }}
           path: "**/*-python-agent-junit.xml"
       - if: success() || failure()
         name: Upload Coverage Reports
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-${{ matrix.framework }}-${{ matrix.version }}
           path: "**/.coverage*"

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -36,7 +36,7 @@ jobs:
           ENDOFFILE
       - if: success() || failure()
         name: Upload JUnit Test Results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-docs
           path: "docs-python-agent-junit.xml"

--- a/.github/workflows/test-fips.yml
+++ b/.github/workflows/test-fips.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       matrix: ${{ steps.generate.outputs.matrix }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - id: generate
-        uses: elastic/oblt-actions/version-framework@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/version-framework@v1
         with:
           versions-file: .ci/.matrix_python_fips.yml
           frameworks-file: .ci/.matrix_framework_fips.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 10
       matrix: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - name: check that python has fips mode enabled
         run: |
           python3 -c 'import _hashlib; assert _hashlib.get_fips_mode() == 1'
@@ -57,12 +57,12 @@ jobs:
     needs: test-fips
     steps:
       - id: check
-        uses: elastic/oblt-actions/check-dependent-jobs@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
           jobs: ${{ toJSON(needs) }}
       - name: Notify in Slack
         if: steps.check.outputs.status == 'failure'
-        uses: elastic/oblt-actions/slack/notify-result@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           status: ${{ steps.check.outputs.status }}

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -17,7 +17,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/oblt-actions/test-report@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+      - uses: elastic/oblt-actions/test-report@v1
         with:
           artifact: /test-results(.*)/
           name: 'Test Report $1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
   build-distribution:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-distribution
 
 
@@ -48,11 +48,11 @@ jobs:
       data: ${{ steps.split.outputs.data }}
       chunks: ${{ steps.split.outputs.chunks }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
       - id: generate
-        uses: elastic/oblt-actions/version-framework@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/version-framework@v1
         with:
           # Use .ci/.matrix_python_full.yml if it's a scheduled workflow, otherwise use .ci/.matrix_python.yml
           versions-file: .ci/.matrix_python${{ (github.event_name == 'schedule' || github.event_name == 'push' || inputs.full-matrix) && '_full' || '' }}.yml
@@ -131,10 +131,10 @@ jobs:
       FRAMEWORK: ${{ matrix.framework }}
       ASYNCIO: ${{ matrix.asyncio }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
           cache: pip
@@ -145,14 +145,14 @@ jobs:
         run: .\scripts\run-tests.bat
       - if: success() || failure()
         name: Upload JUnit Test Results
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.framework }}-${{ matrix.version }}-asyncio-${{ matrix.asyncio }}
           path: "**/*-python-agent-junit.xml"
           retention-days: 1
       - if: success() || failure()
         name: Upload Coverage Reports
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-reports-${{ matrix.framework }}-${{ matrix.version }}-asyncio-${{ matrix.asyncio }}
           path: "**/.coverage*"
@@ -171,12 +171,12 @@ jobs:
       - windows
     steps:
       - id: check
-        uses: elastic/oblt-actions/check-dependent-jobs@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/check-dependent-jobs@v1
         with:
           jobs: ${{ toJSON(needs) }}
       - run: ${{ steps.check.outputs.is-success }}
       - if: failure() && (github.event_name == 'schedule' || github.event_name == 'push')
-        uses: elastic/oblt-actions/slack/notify-result@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/slack/notify-result@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           status: ${{ steps.check.outputs.status }}
@@ -188,18 +188,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@v5
         with:
           # Use latest Python, so it understands all syntax.
           python-version: 3.11
 
       - run: python -Im pip install --upgrade coverage[toml]
 
-      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4
+      - uses: actions/download-artifact@v4
         with:
           pattern: coverage-reports-*
           merge-multiple: true
@@ -216,10 +216,10 @@ jobs:
           python -Im coverage report --fail-under=84
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: html-coverage-report
           path: htmlcov
-      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
+      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # 5.1.0
         with:
           name: coverage-reports-*

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@v4
 
       - name: Get token
         id: get_token
@@ -35,14 +35,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: elastic/oblt-actions/updatecli/run@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose diff
           version-file: .tool-versions
         env:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
-      - uses: elastic/oblt-actions/updatecli/run@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
           command: --experimental compose apply
           version-file: .tool-versions
@@ -50,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: failure()
-        uses: elastic/oblt-actions/slack/send@31e93d1dfb82adc106fc7820f505db1afefe43b1 # v1
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: "#apm-agent-python"


### PR DESCRIPTION
Reverts elastic/apm-agent-python#2236

I prefer that we don't pin versions coming from the `actions` for now.

Let's agree on this. At the moment, it requires some manual actions in our end to validate change for something we follow the GH security hardening:
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
