### PR TITLE
github-actions: replace third-party actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,6 +14,9 @@ permissions:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    env:
+      NUMBER: ${{ github.event.issue.number }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Get token
       id: get_token
@@ -26,9 +29,7 @@ jobs:
             "members": "read"
           }
     - name: Add agent-python label
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: agent-python
+      run: gh issue edit "$NUMBER" --add-label "agent-python"
     - id: is_elastic_member
       uses: elastic/oblt-actions/github/is-member-of@v1
       with:
@@ -36,9 +37,4 @@ jobs:
         github-user: ${{ github.actor }}
         github-token: ${{ steps.get_token.outputs.token }}
     - name: Add community and triage labels
-      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-observability-automation[bot]'
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: |
-          community
-          triage
+      run: gh issue edit "$NUMBER" --add-label "community,triage"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -37,4 +37,5 @@ jobs:
         github-user: ${{ github.actor }}
         github-token: ${{ steps.get_token.outputs.token }}
     - name: Add community and triage labels
+      if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-observability-automation[bot]'
       run: gh issue edit "$NUMBER" --add-label "community,triage"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,4 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
+    - uses: elastic/oblt-actions/pre-commit@v1


### PR DESCRIPTION
## What does this pull request do?

Use `gh` cli to add labels
Use our pre-commit composite action: https://github.com/elastic/oblt-actions/tree/main/pre-commit

## Related issues

See https://github.com/elastic/apm-agent-python/pull/2254#issuecomment-2767309968
