### PR TITLE
tests: enable transports tests poking with request_size for Python 3.12+

### DIFF
--- a/tests/transports/test_base.py
+++ b/tests/transports/test_base.py
@@ -157,24 +157,26 @@ def test_api_request_time_dynamic(mock_send, caplog, elasticapm_client):
     assert mock_send.call_count == 0
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Failing locally on 3.12.0rc1")  # TODO py3.12
+def _cleanup_flush_mock_buffers(mock_flush):
+    args, kwargs = mock_flush.call_args
+    buffer = args[0]
+    buffer.close()
+
+
 @mock.patch("elasticapm.transport.base.Transport._flush")
 def test_api_request_size_dynamic(mock_flush, caplog, elasticapm_client):
-    elasticapm_client.config.update(version="1", api_request_size="100b")
+    elasticapm_client.config.update(version="1", api_request_size="9b")
     transport = Transport(client=elasticapm_client, queue_chill_count=1)
     transport.start_thread()
     try:
         with caplog.at_level("DEBUG", "elasticapm.transport"):
-            # we need to add lots of uncompressible data to fill up the gzip-internal buffer
-            for i in range(12):
-                transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
+            transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
             transport._flushed.wait(timeout=0.1)
+        _cleanup_flush_mock_buffers(mock_flush)
         assert mock_flush.call_count == 1
         elasticapm_client.config.update(version="1", api_request_size="1mb")
         with caplog.at_level("DEBUG", "elasticapm.transport"):
-            # we need to add lots of uncompressible data to fill up the gzip-internal buffer
-            for i in range(12):
-                transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
+            transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
             transport._flushed.wait(timeout=0.1)
         # Should be unchanged because our buffer limit is much higher.
         assert mock_flush.call_count == 1
@@ -182,18 +184,16 @@ def test_api_request_size_dynamic(mock_flush, caplog, elasticapm_client):
         transport.close()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason="Failing locally on 3.12.0rc1")  # TODO py3.12
 @mock.patch("elasticapm.transport.base.Transport._flush")
-@pytest.mark.parametrize("elasticapm_client", [{"api_request_size": "100b"}], indirect=True)
+@pytest.mark.parametrize("elasticapm_client", [{"api_request_size": "9b"}], indirect=True)
 def test_flush_time_size(mock_flush, caplog, elasticapm_client):
     transport = Transport(client=elasticapm_client, queue_chill_count=1)
     transport.start_thread()
     try:
         with caplog.at_level("DEBUG", "elasticapm.transport"):
-            # we need to add lots of uncompressible data to fill up the gzip-internal buffer
-            for i in range(12):
-                transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
+            transport.queue("error", "".join(random.choice(string.ascii_letters) for i in range(2000)))
             transport._flushed.wait(timeout=0.1)
+        _cleanup_flush_mock_buffers(mock_flush)
         assert mock_flush.call_count == 1
     finally:
         transport.close()


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

I don't know if python 3.12 changed gzip compression or what but we get a flush call for each message we send so since our message is compressed to 10 bytes lower the limit to 9 bytes to pass the check deciding to flush the buffer.

## Related issues