### PR TITLE
github-actions: support gh issues and prs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     env:
-      NUMBER: ${{ github.event.issue.number }}
+      NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Get token

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -29,7 +29,7 @@ jobs:
             "members": "read"
           }
     - name: Add agent-python label
-      run: gh issue edit "$NUMBER" --add-label "agent-python"
+      run: gh issue edit "$NUMBER" --add-label "agent-python" --repo "${{ github.repository }}"
     - id: is_elastic_member
       uses: elastic/oblt-actions/github/is-member-of@v1
       with:
@@ -38,4 +38,4 @@ jobs:
         github-token: ${{ steps.get_token.outputs.token }}
     - name: Add community and triage labels
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-observability-automation[bot]'
-      run: gh issue edit "$NUMBER" --add-label "community,triage"
+      run: gh issue edit "$NUMBER" --add-label "community,triage" --repo "${{ github.repository }}"


### PR DESCRIPTION
## What does this pull request do?

Fixes a couple of regressions, the GH action supports issues and prs and running gh outside of the workspace.

see https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request and https://docs.github.com/en/webhooks/webhook-events-and-payloads#issues


## Related issues

see https://github.com/elastic/apm-agent-python/pull/2257#discussion_r2028617989