### PR TITLE
github-actions: use GitHub container registry

### DIFF
--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -2,7 +2,7 @@
 
 Utility script for building and pushing the images based on `.ci/.matrix_python_full.yml`.
 
-> :information_source: This script is mainly used in [publish-docker-images](https://github.com/elastic/apm-agent-java/actions/workflows/build-images.yml) workflow,
+> :information_source: This script is mainly used in [publish-docker-images](https://github.com/elastic/apm-agent-python/actions/workflows/build-images.yml) workflow,
 which can be triggered safely at any time.
 
 ## Options

--- a/.ci/docker/README.md
+++ b/.ci/docker/README.md
@@ -2,7 +2,7 @@
 
 Utility script for building and pushing the images based on `.ci/.matrix_python_full.yml`.
 
-> :information_source: This script is mainly used in [publish-docker-images](https://github.com/elastic/apm-pipeline-library/actions/workflows/publish-docker-images.yml) workflow,
+> :information_source: This script is mainly used in [publish-docker-images](https://github.com/elastic/apm-agent-java/actions/workflows/build-images.yml) workflow,
 which can be triggered safely at any time.
 
 ## Options

--- a/.ci/docker/util.sh
+++ b/.ci/docker/util.sh
@@ -44,6 +44,7 @@ for version in $versions; do
   case $ACTION in
   build)
     DOCKER_BUILDKIT=1 docker build \
+        --progress=plain \
         --cache-from="${full_image_name}" \
         -f "${project_root}/tests/Dockerfile" \
         --build-arg PYTHON_IMAGE="${version/-/:}" \

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
       - run: ./util.sh --action build --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -8,6 +8,7 @@ env:
   DOCKER_BUILDKIT: 1
 
 permissions:
+  packages: write
   contents: read
 
 jobs:
@@ -17,20 +18,13 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
-          
-      - name: Login to docker.elastic.co
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
-          username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
-          password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
 
-      - name: Login to dockerhub
+      - name: Login to ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          registry: ${{ secrets.DOCKERHUB_REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - run: ./util.sh --action build
         working-directory: .ci/docker

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,9 +28,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
       - run: ./util.sh --action build --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,7 +2,6 @@
 name: build-images
 
 on:
-  pull_request: ~
   workflow_dispatch: ~
 
 env:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,10 +1,9 @@
 ---
-# This workflow publishes docker images base on .ci/.docker-images.yml`.
-# See docs/INTERNAL_DOCKER_IMAGES.md for further information.
-name: publish-docker-images
+name: build-images
 
 on:
-  workflow_dispatch:
+  pull_request: ~
+  workflow_dispatch: ~
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,41 @@
+---
+# This workflow publishes docker images base on .ci/.docker-images.yml`.
+# See docs/INTERNAL_DOCKER_IMAGES.md for further information.
+name: publish-docker-images
+
+on:
+  workflow_dispatch:
+
+env:
+  DOCKER_BUILDKIT: 1
+
+permissions:
+  contents: read
+
+jobs:
+
+  build-test-push:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+          
+      - name: Login to docker.elastic.co
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+          username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+          password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
+
+      - name: Login to dockerhub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ secrets.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - run: ./util.sh --action build
+        working-directory: .ci/docker
+
+      #- run: ./util.sh --action push
+      # working-directory: .ci/docker

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -28,8 +28,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: ./util.sh --action build --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
+      - run: ./util.sh --action build --registry ${{ env.REGISTRY }} --name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker
 
-      - run: ./util.sh --action push --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
+      - run: ./util.sh --action push --registry ${{ env.REGISTRY }} --name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,17 +4,19 @@ name: build-images
 on:
   workflow_dispatch: ~
 
-env:
-  DOCKER_BUILDKIT: 1
-
 permissions:
-  packages: write
   contents: read
 
 jobs:
 
-  build-test-push:
+  build-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/apm-agent-python-testing
     steps:
 
       - uses: actions/checkout@v4
@@ -22,12 +24,12 @@ jobs:
       - name: Login to ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: ./util.sh --action build
+      - run: ./util.sh --action build --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker
 
-      - run: ./util.sh --action push
+      - run: ./util.sh --action push --registry ${{ env.REGISTRY }} --image-name ${{ env.IMAGE_NAME }}
         working-directory: .ci/docker

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -35,5 +35,5 @@ jobs:
       - run: ./util.sh --action build
         working-directory: .ci/docker
 
-      #- run: ./util.sh --action push
-      # working-directory: .ci/docker
+      - run: ./util.sh --action push
+        working-directory: .ci/docker

--- a/.github/workflows/run-matrix.yml
+++ b/.github/workflows/run-matrix.yml
@@ -20,6 +20,10 @@ jobs:
       max-parallel: 10
       matrix:
         include: ${{ fromJSON(inputs.include) }}
+    env:
+      # These env variables are used in the docker-compose.yml and the run_tests.sh script.
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/apm-agent-python-testing
     steps:
       - uses: actions/checkout@v4
       - name: Run tests

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -44,4 +44,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 WORKDIR /app
 
+# configure the label to help with the GitHub container registry
+LABEL org.opencontainers.image.source https://github.com/elastic/apm-agent-python
+
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       - zookeeper
 
   run_tests:
-    image: elasticobservability/apm-agent-python-testing:${PYTHON_VERSION}
+    image: ${REGISTRY:-elasticobservability}/${IMAGE_NAME:-apm-agent-python-testing}:${PYTHON_VERSION}
     environment:
       ES_8_URL: 'http://elasticsearch8:9200'
       ES_7_URL: 'http://elasticsearch7:9200'

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -60,7 +60,7 @@ if ! ${CI}; then
     .
 fi
 
-PYTHON_VERSION=${1} docker compose run \
+PYTHON_VERSION=${1} docker compose run --quiet-pull \
   -e PYTHON_FULL_VERSION=${1} \
   -e LOCAL_USER_ID=$LOCAL_USER_ID \
   -e LOCAL_GROUP_ID=$LOCAL_GROUP_ID \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -2,7 +2,7 @@
 set -ex
 
 function cleanup {
-    PYTHON_VERSION=${1} docker compose down -v
+    PYTHON_VERSION=${1} REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} docker compose down -v
 
     if [[ $CODECOV_TOKEN ]]; then
         cd ..
@@ -21,6 +21,8 @@ docker_pip_cache="/tmp/cache/pip"
 TEST="${1}/${2}"
 LOCAL_USER_ID=${LOCAL_USER_ID:=$(id -u)}
 LOCAL_GROUP_ID=${LOCAL_GROUP_ID:=$(id -g)}
+IMAGE_NAME=${IMAGE_NAME:-"apm-agent-python-testing"}
+REGISTRY=${REGISTRY:-"elasticobservability"}
 
 cd tests
 
@@ -42,18 +44,19 @@ echo "Running tests for ${1}/${2}"
 
 if [[ -n $DOCKER_DEPS ]]
 then
-    PYTHON_VERSION=${1} docker compose up -d ${DOCKER_DEPS}
+    PYTHON_VERSION=${1} REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} docker compose up -d ${DOCKER_DEPS}
 fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,
 # as this can take several minutes
 
 if ! ${CI}; then
+  full_image_name="${REGISTRY}/${IMAGE_NAME}:${1}"
   DOCKER_BUILDKIT=1 docker build \
     --progress=plain \
-    --cache-from="elasticobservability/apm-agent-python-testing:${1}" \
+    --cache-from="${full_image_name}" \
     --build-arg PYTHON_IMAGE="${1/-/:}" \
-    --tag "elasticobservability/apm-agent-python-testing:${1}" \
+    --tag "${full_image_name}" \
     .
 fi
 
@@ -67,6 +70,8 @@ PYTHON_VERSION=${1} docker compose run \
   -e WITH_COVERAGE=true \
   -e CASS_DRIVER_NO_EXTENSIONS=1 \
   -e PYTEST_JUNIT="--junitxml=/app/tests/docker-${1}-${2}-python-agent-junit.xml" \
+  -e REGISTRY=${REGISTRY} \
+  -e IMAGE_NAME=${IMAGE_NAME} \
   -v ${pip_cache}:$(dirname ${docker_pip_cache}) \
   -v "$(dirname $(pwd))":/app \
   --rm run_tests \

--- a/tests/scripts/docker/run_tests.sh
+++ b/tests/scripts/docker/run_tests.sh
@@ -40,11 +40,11 @@ else
     fi
 fi
 
-echo "Running tests for ${1}/${2}"
+echo "Running tests for ${TEST}"
 
 if [[ -n $DOCKER_DEPS ]]
 then
-    PYTHON_VERSION=${1} REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} docker compose up -d ${DOCKER_DEPS}
+    PYTHON_VERSION=${1} REGISTRY=${REGISTRY} IMAGE_NAME=${IMAGE_NAME} docker compose up --quiet-pull -d ${DOCKER_DEPS}
 fi
 
 # CASS_DRIVER_NO_EXTENSIONS is set so we don't build the Cassandra C-extensions,


### PR DESCRIPTION
### What

1. The workflow will create the docker images on demand and store in the [GitHub container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
2. Packages are now accessible at https://github.com/elastic/apm-agent-python/pkgs/container/apm-agent-python%2Fapm-agent-python-testing
3. Use the new container images
4. Less verbose docker pull output

### Tests

See https://github.com/elastic/apm-agent-python/actions/runs/14772579891/job/41475033985