### PR TITLE
ci: move from dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS.yml
+++ b/.github/CODEOWNERS.yml
@@ -1,0 +1,3 @@
+*  @elastic/apm-agent-python
+/.github/actions/  @elastic/apm-agent-python @elastic/observablt-ci
+/.github/workflows/  @elastic/apm-agent-python @elastic/observablt-ci

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,6 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
-    reviewers:
-      - "elastic/apm-agent-python"
     ignore:
       - dependency-name: "urllib3" # ignore until lambda runtimes use OpenSSL 1.1.1+
         versions: [">=2.0.0"]
@@ -28,8 +26,6 @@ updates:
     directories:
       - '/'
       - '/.github/actions/*'
-    reviewers:
-      - "elastic/observablt-ci"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -42,8 +38,6 @@ updates:
   - package-ecosystem: "docker"
     directories:
       - '/'
-    reviewers:
-      - "elastic/apm-agent-python"
     registries: "*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
After https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Hat tip to @trentm 