### PR TITLE
docs: update options to enable with uwsgi

### DIFF
--- a/docs/reference/django-support.md
+++ b/docs/reference/django-support.md
@@ -24,7 +24,7 @@ For apm-server 6.2+, make sure you use version 2.0 or higher of `elastic-apm`.
 
 
 ::::{note}
-If you use Django with uwsgi, make sure to [enable threads](http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads).
+If you use Django with uwsgi, make sure to [enable threads](http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads) (enabled by default since 2.0.27) and [py-call-uwsgi-fork-hooks](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#py-call-uwsgi-fork-hooks).
 ::::
 
 

--- a/docs/reference/flask-support.md
+++ b/docs/reference/flask-support.md
@@ -24,7 +24,7 @@ For apm-server 6.2+, make sure you use version 2.0 or higher of `elastic-apm`.
 
 
 ::::{note}
-If you use Flask with uwsgi, make sure to [enable threads](http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads).
+If you use Flask with uwsgi, make sure to [enable threads](http://uwsgi-docs.readthedocs.org/en/latest/Options.html#enable-threads) (enabled by default since 2.0.27) and [py-call-uwsgi-fork-hooks](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#py-call-uwsgi-fork-hooks).
 ::::
 
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

We need to have py-call-uwsgi-fork-hooks set in order to have proper handling of our threads.
While at it say that threads are enabled by default since a few releases.

## Related issues

Closes #2304
