### PR TITLE
requirements/sanic: stick with older tracerite for older python versions

### DIFF
--- a/tests/requirements/reqs-sanic-newest.txt
+++ b/tests/requirements/reqs-sanic-newest.txt
@@ -1,3 +1,4 @@
 sanic
 sanic-testing
+tracerite==1.1.1 ; python_version < '3.8'
 -r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Use an older version of `tracerite` that is importable on older python versions.

## Related issues

See https://github.com/elastic/apm-agent-python/actions/runs/15839769440/attempts/2