### PR TITLE
ci: run tests on windows-2022

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
 
   windows:
     name: "windows (version: ${{ matrix.version }}, framework: ${{ matrix.framework }}, asyncio: ${{ matrix.asyncio }})"
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION


## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->
Since windows-2019 images has been removed.

## Related issues
