### PR TITLE
contrib/serverless/azure: fix client_class and metrics sets invocation

### DIFF
--- a/.ci/.matrix_framework.yml
+++ b/.ci/.matrix_framework.yml
@@ -56,3 +56,4 @@ FRAMEWORK:
   - aiobotocore-newest
   - kafka-python-newest
   - grpc-newest
+  - azurefunctions-newest

--- a/.ci/.matrix_framework_full.yml
+++ b/.ci/.matrix_framework_full.yml
@@ -92,3 +92,4 @@ FRAMEWORK:
   - kafka-python-newest
   - grpc-newest
   #- grpc-1.24 # This appears to have problems with python>3.6?
+  - azurefunctions-newest

--- a/elasticapm/contrib/serverless/azure.py
+++ b/elasticapm/contrib/serverless/azure.py
@@ -96,7 +96,7 @@ class ElasticAPMExtension(AppExtensionBase):
         if not client:
             kwargs["metrics_interval"] = "0ms"
             kwargs["breakdown_metrics"] = "false"
-            if "metric_sets" not in kwargs and "ELASTIC_APM_METRICS_SETS" not in os.environ:
+            if "metrics_sets" not in kwargs and "ELASTIC_APM_METRICS_SETS" not in os.environ:
                 # Allow users to override metrics sets
                 kwargs["metrics_sets"] = []
             kwargs["central_config"] = "false"
@@ -114,7 +114,7 @@ class ElasticAPMExtension(AppExtensionBase):
                 and "AZURE_FUNCTIONS_ENVIRONMENT" in os.environ
             ):
                 kwargs["environment"] = os.environ["AZURE_FUNCTIONS_ENVIRONMENT"]
-            client = AzureFunctionsClient(**kwargs)
+            client = client_class(**kwargs)
         cls.client = client
 
     @classmethod

--- a/tests/requirements/reqs-azurefunctions-newest.txt
+++ b/tests/requirements/reqs-azurefunctions-newest.txt
@@ -1,0 +1,2 @@
+azure-functions
+-r reqs-base.txt


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Fix extension handling of client_class that was ignored and typo in metrics_sets arg that was mistyped.

While at it fix also a broken tests and add testing in the matrix.

## Related issues

Closes #2256
