### PR TITLE
instrumentation/mysql_connector: fix connection retrieval

### DIFF
--- a/elasticapm/instrumentation/packages/mysql_connector.py
+++ b/elasticapm/instrumentation/packages/mysql_connector.py
@@ -46,9 +46,8 @@ class MySQLCursorProxy(CursorProxy):
 
     @property
     def _self_database(self) -> str:
-        # for unknown reasons, the connection is available as the `_connection` attribute on Python 3.6,
-        # and as `_cnx` on later Python versions
-        connection = getattr(self, "_cnx") or getattr(self, "_connection")
+        # it looks like the connection is available as the `_connection` or as `_cnx` depending on Python versions
+        connection = getattr(self, "_connection", None) or getattr(self, "_cnx", None)
         return connection.database if connection else ""
 
 

--- a/tests/instrumentation/mysql_connector_tests.py
+++ b/tests/instrumentation/mysql_connector_tests.py
@@ -63,9 +63,6 @@ def mysql_connector_connection(request):
     cursor.execute("DROP TABLE `test`")
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 12), reason="Perhaps related to changes in weakref in py3.12?"
-)  # TODO py3.12
 @pytest.mark.integrationtest
 def test_mysql_connector_select(instrument, mysql_connector_connection, elasticapm_client):
     cursor = mysql_connector_connection.cursor()


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

The code was not working becase there was no default on getattr calls.

## Related issues
