### PR TITLE
setup: keep checking for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,15 @@ import os
 
 from setuptools import setup
 
+try:
+    import importlib.metadata
+
+    importlib.metadata.requires("setuptools")
+except ImportError:
+    import pkg_resources
+
+    pkg_resources.require("setuptools")
+
 
 def get_version():
     """


### PR DESCRIPTION


## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Use importlib.metadata if available otherwise fallback to pkg_resources. This partly reverts 2a483aa27822ce8a905902c897bf766bb1b7b776.

## Related issues

Refs #2341  
