### PR TITLE
tests: bump MongoDB latest to 4.2

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -46,12 +46,12 @@ services:
     volumes:
       - pymongodata36:/data/db
 
-  mongodb40:
-    image: mongo:4.0
+  mongodb42:
+    image: mongo:4.2
     ports:
       - "27017:27017"
     volumes:
-      - pymongodata40:/data/db
+      - pymongodata42:/data/db
 
   memcached:
     image: memcached
@@ -205,7 +205,7 @@ volumes:
     driver: local
   pymongodata36:
     driver: local
-  pymongodata40:
+  pymongodata42:
     driver: local
   pyesdata7:
     driver: local

--- a/tests/scripts/envs/pymongo-newest.sh
+++ b/tests/scripts/envs/pymongo-newest.sh
@@ -1,3 +1,3 @@
 export PYTEST_MARKER="-m mongodb"
-export DOCKER_DEPS="mongodb40"
-export MONGODB_HOST="mongodb40"
+export DOCKER_DEPS="mongodb42"
+export MONGODB_HOST="mongodb42"


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Because latest client uses a newer wire protocol.

## Related issues
