### PR TITLE
[docs] Replace placeholder URLs

### DIFF
--- a/docs/reference/sanic-support.md
+++ b/docs/reference/sanic-support.md
@@ -42,7 +42,7 @@ To configure the agent using initialization arguments and Sanic’s Configuratio
 ```python
 # Create a file named external_config.py in your application
 # If you want this module based configuration to be used for APM, prefix them with ELASTIC_APM_
-ELASTIC_APM_SERVER_URL = "https://serverurl.apm.com:443"
+ELASTIC_APM_SERVER_URL = "https://serverurl.example.com:443"
 ELASTIC_APM_SECRET_TOKEN = "sometoken"
 ```
 


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1734, https://github.com/elastic/docs-content/issues/1801

Replaces placeholder URLs with those reserved by the Internet Engineering Task Force (IETF) in RFC 2606 and RFC 6761 (e.g. `example.com`, `example.net`, `example.org`, `example.edu`,  `.example`).