### PR TITLE
docs: lambda layer version may not be 1

### DIFF
--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -7,7 +7,7 @@ applies_to:
     observability:
   product:
     apm_agent_python: ga
-sub:
+subs:
   apm-lambda-ext-v: ver-1-6-0
   apm-python-v: ver-6-24-0
   apm-python-layer-v: 3

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -10,6 +10,7 @@ applies_to:
 sub:
   apm-lambda-ext-v: ver-1-6-0
   apm-python-v: ver-6-24-0
+  apm-python-layer-v: 3
 ---
 
 # Monitoring AWS Lambda Python Functions [lambda-support]
@@ -39,18 +40,16 @@ To add the layers to your Lambda function through the AWS Management Console:
 3. Choose the *Specify an ARN* radio button
 4. Copy and paste the following ARNs of the {{apm-lambda-ext}} layer and the APM agent layer in the *Specify an ARN* text input:
     * APM Extension layer:
-      ```
+      ```subs=true
       arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
       ```
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
 
     * APM agent layer:
+      ```subs=true
+      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <1>
       ```
-      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <1>
-      ```
-      1. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
-         usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
-         the exact one.
+      1. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 
     ![image of choosing a layer in AWS Console](images/choose-a-layer.png "")
 5. Click the *Add* button
@@ -59,21 +58,19 @@ To add the layers to your Lambda function through the AWS Management Console:
 ::::::{tab-item} AWS CLI
 To add the Layer ARNs of the {{apm-lambda-ext}} and the APM agent through the AWS command line interface execute the following command:
 
-```bash
+```bash subs=true
 aws lambda update-function-configuration --function-name yourLambdaFunctionName \
 --layers arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 \ <1>
-arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
+arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <2>
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
-   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
-   the exact one.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 ::::::
 
 ::::::{tab-item} SAM
 In your SAM `template.yml` file add the Layer ARNs of the {{apm-lambda-ext}} and the APM agent as follows:
 
-```yaml
+```yaml subs=true
 ...
 Resources:
   yourLambdaFunction:
@@ -82,48 +79,42 @@ Resources:
       ...
       Layers:
           - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
-          - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
+          - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <2>
 ...
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
-   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
-   the exact one.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 ::::::
 
 ::::::{tab-item} Serverless
 In your `serverless.yml` file add the Layer ARNs of the {{apm-lambda-ext}} and the APM agent to your function as follows:
 
-```yaml
+```yaml subs=true
 ...
 functions:
   yourLambdaFunction:
     handler: ...
     layers:
       - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
-      - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
+      - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <2>
 ...
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
-   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
-   the exact one.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 ::::::
 
 ::::::{tab-item} Terraform
 To add the{{apm-lambda-ext}} and the APM agent to your function add the ARNs to the `layers` property in your Terraform file:
 
-```yaml
+```yaml subs=true
 ...
 resource "aws_lambda_function" "your_lambda_function" {
   ...
-  layers = ["arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1", "arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION}"] <1>
+  layers = ["arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1", "arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}}"] <1>
 }
 ...
 ```
-1. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
-   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
-   the exact one.
+1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
 ::::::
 
 ::::::{tab-item} Container Image

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -40,13 +40,13 @@ To add the layers to your Lambda function through the AWS Management Console:
 3. Choose the *Specify an ARN* radio button
 4. Copy and paste the following ARNs of the {{apm-lambda-ext}} layer and the APM agent layer in the *Specify an ARN* text input:
     * APM Extension layer:
-      ```subs=true
+      ``` subs=true
       arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
       ```
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
 
     * APM agent layer:
-      ```subs=true
+      ``` subs=true
       arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <1>
       ```
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function.

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -7,7 +7,7 @@ applies_to:
     observability:
   product:
     apm_agent_python: ga
-subs:
+sub:
   apm-lambda-ext-v: ver-1-6-0
   apm-python-v: ver-6-24-0
   apm-python-layer-v: 3

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -8,8 +8,8 @@ applies_to:
   product:
     apm_agent_python: ga
 sub:
-  apm-lambda-ext-v: ver-1-5-7
-  apm-python-v: ver-6-23-0
+  apm-lambda-ext-v: ver-1-6-0
+  apm-python-v: ver-6-24-0
 ---
 
 # Monitoring AWS Lambda Python Functions [lambda-support]
@@ -46,9 +46,11 @@ To add the layers to your Lambda function through the AWS Management Console:
 
     * APM agent layer:
       ```
-      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:1 <1>
+      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <1>
       ```
-      1. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
+      1. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
+         usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
+         the exact one.
 
     ![image of choosing a layer in AWS Console](images/choose-a-layer.png "")
 5. Click the *Add* button
@@ -60,10 +62,12 @@ To add the Layer ARNs of the {{apm-lambda-ext}} and the APM agent through the AW
 ```bash
 aws lambda update-function-configuration --function-name yourLambdaFunctionName \
 --layers arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 \ <1>
-arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:1 <2>
+arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
+   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
+   the exact one.
 ::::::
 
 ::::::{tab-item} SAM
@@ -78,11 +82,13 @@ Resources:
       ...
       Layers:
           - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
-          - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:1 <2>
+          - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
 ...
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
+   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
+   the exact one.
 ::::::
 
 ::::::{tab-item} Serverless
@@ -95,11 +101,13 @@ functions:
     handler: ...
     layers:
       - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
-      - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:1 <2>
+      - arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION} <2>
 ...
 ```
 1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
-2. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
+2. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
+   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
+   the exact one.
 ::::::
 
 ::::::{tab-item} Terraform
@@ -109,11 +117,13 @@ To add the{{apm-lambda-ext}} and the APM agent to your function add the ARNs to 
 ...
 resource "aws_lambda_function" "your_lambda_function" {
   ...
-  layers = ["arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1", "arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:1"] <1>
+  layers = ["arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1", "arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{LAYER_VERSION}"] <1>
 }
 ...
 ```
-1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
+1. Replace `{AWS_REGION}` with the AWS region of your Lambda function. While the version of the layer `{LAYER_VERSION}`is
+   usually `1`, refer to the ARNs listed in [Github releases](https://github.com/elastic/apm-agent-python/releases) to get
+   the exact one.
 ::::::
 
 ::::::{tab-item} Container Image

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -40,11 +40,15 @@ To add the layers to your Lambda function through the AWS Management Console:
 3. Choose the *Specify an ARN* radio button
 4. Copy and paste the following ARNs of the {{apm-lambda-ext}} layer and the APM agent layer in the *Specify an ARN* text input:
     * APM Extension layer:
-      {subs}`arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1` <1>
+      ```bash subs=true
+      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
+      ```
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
 
     * APM agent layer:
-      {subs}`arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}}` <1>
+      ```bash subs=true
+      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <1>
+      ```
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 
     ![image of choosing a layer in AWS Console](images/choose-a-layer.png "")

--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -40,15 +40,11 @@ To add the layers to your Lambda function through the AWS Management Console:
 3. Choose the *Specify an ARN* radio button
 4. Copy and paste the following ARNs of the {{apm-lambda-ext}} layer and the APM agent layer in the *Specify an ARN* text input:
     * APM Extension layer:
-      ``` subs=true
-      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1 <1>
-      ```
+      {subs}`arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-extension-{{apm-lambda-ext-v}}-{ARCHITECTURE}:1` <1>
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function and `{ARCHITECTURE}` with its architecture.
 
     * APM agent layer:
-      ``` subs=true
-      arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}} <1>
-      ```
+      {subs}`arn:aws:lambda:{AWS_REGION}:267093732750:layer:elastic-apm-python-{{apm-python-v}}:{{apm-python-layer-v}}` <1>
       1. Replace `{AWS_REGION}` with the AWS region of your Lambda function.
 
     ![image of choosing a layer in AWS Console](images/choose-a-layer.png "")


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Don't hardcode the apm layer version as 1, in 6.24.0 it's 3. While at it fix vars substitution.

## Related issues