### PR TITLE
Add an item about bumping versions in lambda doc to release checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,3 +200,4 @@ If you have commit access, the process is as follows:
 1. Edit and publish the [draft Github release](https://github.com/elastic/apm-agent-python/releases)
    created by Github Actions. Substitute the generated changelog with one hand written into the body of the
    release.
+1. Update substitutions variables in `docs/reference/lambda-support.md`.


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Once a new version is released we need to bump the substitution variables we have in the lambda documentation so they are up to date.

## Related issues
