### PR TITLE
bugfix: arn file doesn't found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         with:
           name: arn-file
-          path: ".arn-file.md"
+          path: "${{ github.workspace }}/.arn-file.md"
           if-no-files-found: error
 
   publish-docker:


### PR DESCRIPTION
## What does this pull request do?

Let's ensure the path of arn the file

## Related issues

Closes https://github.com/elastic/apm-agent-python/issues/2403
