### PR TITLE
tornado: handle behaviour change in request.headers in-protocol

### DIFF
--- a/elasticapm/instrumentation/packages/tornado.py
+++ b/elasticapm/instrumentation/packages/tornado.py
@@ -71,7 +71,9 @@ class TornadoRequestExecuteInstrumentation(TornadoBaseInstrumentedModule, AsyncA
         client = instance.application.elasticapm_client
         should_ignore = client.should_ignore_url(request.path)
         if not should_ignore:
-            trace_parent = TraceParent.from_headers(request.headers)
+            # In tornado 6.5.3 the __in__ protocol for the headers is case-sensitive so we need to normalize them
+            normalized_headers = {k.lower(): v for k, v in request.headers.items()}
+            trace_parent = TraceParent.from_headers(normalized_headers)
             client.begin_transaction("request", trace_parent=trace_parent)
             elasticapm.set_context(
                 lambda: get_data_from_request(instance, request, client.config, constants.TRANSACTION), "request"

--- a/tests/contrib/asyncio/tornado/tornado_tests.py
+++ b/tests/contrib/asyncio/tornado/tornado_tests.py
@@ -177,7 +177,7 @@ async def test_traceparent_handling(app, base_url, http_client):
 
     assert transaction["trace_id"] == "0af7651916cd43dd8448eb211c80319c"
     assert transaction["parent_id"] == "b7ad6b7169203331"
-    assert "foo=bar,bar=baz,baz=bazzinga" == wrapped_from_string.call_args[0][0]["TraceState"]
+    assert "foo=bar,bar=baz,baz=bazzinga" == wrapped_from_string.call_args[0][0]["tracestate"]
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

In 6.5.3 tornado made the in-protocol for the request headers case sensitive. Problem is that the code extracting the traceparent header name is using a lowercase string for the header name. So start normalizing all the headers keys to lowercase so that we are able to get the traceparent again.

## Related issues
