### PR TITLE
elasticapm: introduce ELASTIC_APM_SKIP_SERVER_INFO

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -969,6 +969,23 @@ If set to `True`, the agent will intercept the default `sys.excepthook`, which a
 Whether each transaction should have the process arguments attached. Disabled by default to save disk space.
 
 
+### `skip_server_info` [config-skip-server-info]
+
+| Environment | Django/Flask | Default |
+| --- | --- | --- |
+| `ELASTIC_APM_SKIP_SERVER_INFO` | `SKIP_SERVER_INFO` | `False` |
+
+Whether we should skip the server info check to save some latency on constrained environments like AWS Lambda. Disabled by default.
+
+::::{warning}
+This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+::::
+
+::::{warning}
+This requires sending data to an APM Server newer than 8.7.0 in order to work properly.
+::::
+
+
 ## Django-specific configuration [config-django-specific]
 
 

--- a/elasticapm/conf/__init__.py
+++ b/elasticapm/conf/__init__.py
@@ -743,6 +743,7 @@ class Config(_ConfigBase):
         default=TRACE_CONTINUATION_STRATEGY.CONTINUE,
     )
     include_process_args = _BoolConfigValue("INCLUDE_PROCESS_ARGS", default=False)
+    skip_server_info = _BoolConfigValue("SKIP_SERVER_INFO", default=False)
 
     @property
     def is_recording(self):

--- a/elasticapm/transport/http.py
+++ b/elasticapm/transport/http.py
@@ -203,7 +203,11 @@ class Transport(HTTPTransportBase):
 
     def _process_queue(self) -> None:
         if not self.client.server_version:
-            self.fetch_server_info()
+            # this is useful on aws lambda environments where this call incurs in unwanted latency
+            if self.client.config.skip_server_info:
+                logger.debug("Skipping to fetch server info")
+            else:
+                self.fetch_server_info()
         super()._process_queue()
 
     def fetch_server_info(self) -> None:


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Introduce this option in order to avoid fetch the apm server info to get its version, off by default.
Calling that endpoint with the aws lambda extension incurs in a measurable latency on AWS Lambda.
Enabling this issue requires the receiving APM server version to be greater than 8.7.0.

Option is still in technical preview.

## Related issues
