### PR TITLE
Fix arn table file generation file path

### DIFF
--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -8,7 +8,7 @@ set -o pipefail
 
 AWS_FOLDER=${AWS_FOLDER?:No aws folder provided}
 # Get the repository root directory (where .git is located)
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(realpath $(dirname "${BASH_SOURCE[0]}")/..)"
 ARN_FILE="${REPO_ROOT}/.arn-file.md"
 
 {


### PR DESCRIPTION
## What does this pull request do?

Ensure the arn table file is being generated in the github workspace

## Related issues

Closes https://github.com/elastic/apm-agent-python/issues/2403
