### PR TITLE
github-action: add artifact-metadata permission for attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@ permissions:
 jobs:
   build-distribution:
     permissions:
+      artifact-metadata: write
       attestations: write
-      id-token: write
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -35,9 +36,10 @@ jobs:
 
   packages:
     permissions:
+      artifact-metadata: write
       attestations: write
-      id-token: write
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -108,9 +110,10 @@ jobs:
       - build-distribution
     runs-on: ubuntu-latest
     permissions:
+      artifact-metadata: write
       attestations: write
-      id-token: write
       contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

The attestations permission is necessary to persist the attestation. 
The artifact-metadata permission is required to generate artifact metadata storage records.

This change adds `artifact-metadata: write` permission to workflows that have 
`attestations: write` permission, as required by the actions/attest-build-provenance action.

See:
* https://github.com/marketplace/actions/attest-build-provenance#usage
* https://github.blog/changelog/2026-01-20-strengthen-your-supply-chain-with-code-to-cloud-traceability-and-slsa-build-level-3-security/

If there are any questions, please reach out to the @elastic/observablt-ci
