### PR TITLE
tests/requirements: limit starlette tests to <1

### DIFF
--- a/tests/requirements/reqs-starlette-newest.txt
+++ b/tests/requirements/reqs-starlette-newest.txt
@@ -1,4 +1,4 @@
-starlette>=0.15
+starlette>0.15,<1
 aiofiles
 httpx
 flask


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Starlette 1.0 changed the way exceptions are configured, for now limit tests to starlette < 1.0.

## Related issues
