### PR TITLE
tests/docker-compose: limit localstack image to version 4

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       - mysqldata:/var/lib/mysql
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4
     ports:
       - "4566:4566"
       - "4571:4571"


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

2026.3.0 made an auth or CI token mandatory.

## Related issues

