### PR TITLE
elasticapm/utils: match the specs better in build_name_with_http_meth…

### DIFF
--- a/elasticapm/utils/__init__.py
+++ b/elasticapm/utils/__init__.py
@@ -94,7 +94,8 @@ def get_name_from_func(func: FunctionType) -> str:
 
 
 def build_name_with_http_method_prefix(name, request):
-    return " ".join((request.method, name)) if name else name
+    name = name or "unknown route"
+    return "{} {}".format(request.method, name) if hasattr(request, "method") else name
 
 
 def is_master_process() -> bool:

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -37,6 +37,7 @@ import pytest
 import elasticapm.utils
 from elasticapm.conf import constants
 from elasticapm.utils import (
+    build_name_with_http_method_prefix,
     get_name_from_func,
     get_url_dict,
     getfqdn,
@@ -263,3 +264,19 @@ def test_getfqdn(invalidate_fqdn_cache):
 def test_getfqdn_caches(invalidate_fqdn_cache):
     elasticapm.utils.fqdn = "foo"
     assert getfqdn() == "foo"
+
+
+class Request:
+    method: "str" = "GET"
+
+
+@pytest.mark.parametrize(
+    "http_request,name,expected",
+    [
+        ("", None, "unknown route"),
+        (Request, None, "GET unknown route"),
+        (Request, "/foo", "GET /foo"),
+    ],
+)
+def test_build_name_with_http_method_prefix(http_request, name, expected):
+    assert build_name_with_http_method_prefix(name, http_request) == expected


### PR DESCRIPTION
…od_prefix

In case the route name is not available we should use `unknown route` as route name.
While at it handle the case where the request does not have a method attribute. Mostly theorical since the current users, flask and django, requests have it.

Specs:
https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-http.md

## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

## Related issues

Closes #ISSUE
