### PR TITLE
flask: avoid warnings reading recent flask versions

### DIFF
--- a/elasticapm/contrib/flask/__init__.py
+++ b/elasticapm/contrib/flask/__init__.py
@@ -123,7 +123,11 @@ class ElasticAPM(object):
 
             if "framework_name" not in defaults:
                 defaults["framework_name"] = "flask"
-                defaults["framework_version"] = getattr(flask, "__version__", "<0.7")
+                try:
+                    flask_version = __import__("importlib.metadata").metadata.version("flask")
+                except ImportError:
+                    flask_version = getattr(flask, "__version__", "<0.7")
+                defaults["framework_version"] = flask_version
 
             self.client = self.client_cls(config, **defaults)
 

--- a/tests/contrib/flask/flask_tests.py
+++ b/tests/contrib/flask/flask_tests.py
@@ -266,6 +266,7 @@ def test_framework_name(flask_app):
     assert apm.client.config.framework_name == "flask"
     app_info = apm.client.get_service_info()
     assert app_info["framework"]["name"] == "flask"
+    assert app_info["framework"]["version"]
     apm.client.close()
 
     # Cleanup -- we don't use the flask_apm_client fixture here because it uses


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Before accessing `flask.__version__` try to read the version from the metadata.

## Related issues

Closes #2626
