### PR TITLE
tests/metrics: relax assertion on cpu percentage read from psutil

### DIFF
--- a/tests/metrics/cpu_psutil_tests.py
+++ b/tests/metrics/cpu_psutil_tests.py
@@ -47,8 +47,10 @@ def test_cpu_mem_from_psutil(elasticapm_client):
     # we can't really test any specific values here as it depends on the system state.
     # Mocking is also not really a viable choice, as we would then lose the "integration testing"
     # nature of this test with different versions of psutil
-    assert 0 < data["samples"]["system.cpu.total.norm.pct"]["value"] < 1
-    assert 0 < data["samples"]["system.process.cpu.total.norm.pct"]["value"] < 1
+    # Please note that cpu percentage may be > 1 on multi-threading applications using more
+    # than one core
+    assert data["samples"]["system.cpu.total.norm.pct"]["value"] > 0
+    assert data["samples"]["system.process.cpu.total.norm.pct"]["value"] > 0
 
     assert data["samples"]["system.memory.total"]["value"] > 0
     assert data["samples"]["system.memory.actual.free"]["value"] > 0


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

From psutil documentation [1]:
Return a float representing the process CPU utilization as a percentage which can also be > 100.0 in case of a process running multiple threads on different CPUs.

[1]https://psutil.readthedocs.io/stable/#psutil.Process.cpu_percent

## Related issues

Closes #2612
