### PR TITLE
ci: make lambda layer publication resilient to AWS regions failure

### DIFF
--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -21,13 +21,18 @@ ALL_AWS_REGIONS=$(aws ec2 describe-regions --output json --no-cli-pager | jq -r 
 rm -rf "${AWS_FOLDER}"
 mkdir -p "${AWS_FOLDER}"
 
+failed_regions=()
+
 # Delete previous layers
 for region in $ALL_AWS_REGIONS; do
-  layer_versions=$(aws lambda list-layer-versions --region="${region}" --layer-name="${ELASTIC_LAYER_NAME}" | jq '.LayerVersions[].Version')
+  layer_versions=$(aws --cli-connect-timeout 30 lambda list-layer-versions --region="${region}" --layer-name="${ELASTIC_LAYER_NAME}" | jq '.LayerVersions[].Version') || {
+    echo "WARNING: Could not list layer versions in ${region}, skipping deletion"
+    continue
+  }
   echo "Found layer versions for ${FULL_LAYER_NAME} in ${region}: ${layer_versions:-none}"
   for version_number in $layer_versions; do
     echo "- Deleting ${FULL_LAYER_NAME}:${version_number} in ${region}"
-    aws lambda delete-layer-version \
+    aws --cli-connect-timeout 30 lambda delete-layer-version \
         --region="${region}" \
         --layer-name="${FULL_LAYER_NAME}" \
         --version-number="${version_number}"
@@ -39,7 +44,7 @@ zip_file="./build/dist/elastic-apm-python-lambda-layer.zip"
 
 for region in $ALL_AWS_REGIONS; do
   echo "Publish ${FULL_LAYER_NAME} in ${region}"
-  publish_output=$(aws lambda \
+  if ! publish_output=$(aws --cli-connect-timeout 30 lambda \
     --output json \
     publish-layer-version \
     --region="${region}" \
@@ -47,11 +52,15 @@ for region in $ALL_AWS_REGIONS; do
     --description="AWS Lambda Extension Layer for the Elastic APM Python Agent" \
     --license-info="BSD-3-Clause" \
     --compatible-runtimes python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13\
-    --zip-file="fileb://${zip_file}")
+    --zip-file="fileb://${zip_file}"); then
+    echo "WARNING: Failed to publish to ${region}"
+    failed_regions+=("${region}")
+    continue
+  fi
   echo "${publish_output}" > "${AWS_FOLDER}/${region}"
   layer_version=$(echo "${publish_output}" | jq '.Version')
   echo "Grant public layer access ${FULL_LAYER_NAME}:${layer_version} in ${region}"
-  grant_access_output=$(aws lambda \
+  if ! grant_access_output=$(aws --cli-connect-timeout 30 lambda \
   		--output json \
   		add-layer-version-permission \
   		--region="${region}" \
@@ -59,8 +68,17 @@ for region in $ALL_AWS_REGIONS; do
   		--action="lambda:GetLayerVersion" \
   		--principal='*' \
   		--statement-id="${FULL_LAYER_NAME}" \
-  		--version-number="${layer_version}")
+  		--version-number="${layer_version}"); then
+    echo "WARNING: Failed to grant public access in ${region}"
+    failed_regions+=("${region}")
+    continue
+  fi
   echo "${grant_access_output}" > "${AWS_FOLDER}/.${region}-public"
 done
 
 sh -c "./.ci/create-arn-table.sh"
+
+if [ ${#failed_regions[@]} -gt 0 ]; then
+  echo "WARNING: Failed to publish to the following regions: ${failed_regions[*]}"
+  echo "WARNING: The layer is not available in those regions. Please publish manually or investigate connectivity."
+fi


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Currently me-south-1 is unavailable and won't come back shortly.

This is a port of:
https://github.com/elastic/apm-aws-lambda/pull/776/changes

Assisted-by: Cursor

## Related issues
