### PR TITLE
docs: bump AWS lambda layers version

### DIFF
--- a/docs/reference/lambda-support.md
+++ b/docs/reference/lambda-support.md
@@ -8,8 +8,8 @@ applies_to:
   product:
     apm_agent_python: ga
 sub:
-  apm-lambda-ext-v: ver-1-6-0
-  apm-python-v: ver-6-25-0
+  apm-lambda-ext-v: ver-1-7-1
+  apm-python-v: ver-6-26-1
   apm-python-layer-v: 1
 ---
 


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Bump our agent layer to 6.26.1 and the lambda layer to latest 1.7.1 as well.

## Related issues