### PR TITLE
tests/requirements: limits kafka-newest to < 3

### DIFF
--- a/tests/requirements/reqs-kafka-python-newest.txt
+++ b/tests/requirements/reqs-kafka-python-newest.txt
@@ -1,1 +1,1 @@
-kafka-python
+kafka-python<3


### PR DESCRIPTION
## What does this pull request do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

Looks like kafka-python 3.0 requires a newer server so limit to <3

## Related issues

