### PR TITLE
Add official support for Python 3.14

### DIFF
--- a/.ci/.matrix_python.yml
+++ b/.ci/.matrix_python.yml
@@ -1,3 +1,3 @@
 VERSION:
   - python-3.6
-  - python-3.13
+  - python-3.14

--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -51,7 +51,7 @@ for region in $ALL_AWS_REGIONS; do
     --layer-name="${FULL_LAYER_NAME}" \
     --description="AWS Lambda Extension Layer for the Elastic APM Python Agent" \
     --license-info="BSD-3-Clause" \
-    --compatible-runtimes python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13\
+    --compatible-runtimes python3.6 python3.7 python3.8 python3.9 python3.10 python3.11 python3.12 python3.13 python3.14\
     --zip-file="fileb://${zip_file}"); then
     echo "WARNING: Failed to publish to ${region}"
     failed_regions+=("${region}")

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -41,6 +41,7 @@ The following Python versions are supported:
 * 3.11
 * 3.12
 * 3.13
+* 3.14
 
 
 ### Django [supported-django]

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
## Summary

Declares official Python 3.14 support, mirroring #2265 (3.13).

Python 3.14 is already tested in the nightly/full CI matrix (#2531) with framework exclusions in place. This PR updates the remaining metadata and PR CI wiring:

- Add PyPI classifier `Programming Language :: Python :: 3.14` in `setup.cfg`
- Document 3.14 in `docs/reference/supported-technologies.md`
- Bump PR matrix newest Python from `python-3.13` to `python-3.14` in `.ci/.matrix_python.yml`
- Add `python3.14` to Lambda `--compatible-runtimes` in `.ci/publish-aws.sh`

Closes #2687

## Test plan

- [x] `make test` with `tests/requirements/reqs-none.txt` on Python 3.14 — 769 passed locally
- [x] pre-commit on changed files
- [ ] CI subset matrix (includes 3.14 after this PR)

Made with [Cursor](https://cursor.com)