### PR TITLE
docs: document FastAPI 0.137 regression and fix in 6.26.2

### DIFF
--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -109,7 +109,7 @@ We support these Starlette versions:
 
 * >0.13.0,<1
 
-Any FastAPI version which uses a supported Starlette version should also be supported.
+Any FastAPI version which uses a supported Starlette version should also be supported. FastAPI>=0.137 requires elastic-apm>=6.26.2.
 
 
 ### GRPC [supported-grpc]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -109,7 +109,11 @@ We support these Starlette versions:
 
 * >0.13.0,<1
 
-Any FastAPI version which uses a supported Starlette version should also be supported. FastAPI>=0.137 requires elastic-apm>=6.26.2.
+Any FastAPI version which uses a supported Starlette version should also be supported.
+
+::::{note}
+`fastapi>=0.137` requires `elastic-apm>=6.26.2`.
+::::
 
 
 ### GRPC [supported-grpc]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -26,4 +26,13 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::
 
-_No known issues_
+:::{dropdown} FastAPI 0.137+ causes 500 errors on every request
+**Details**
+On 06/14/2026, a known issue was discovered that FastAPI 0.137 changed how included routers are represented internally, introducing `_IncludedRouter` wrapper objects that do not expose a `.path` attribute. The ElasticAPM Starlette/FastAPI middleware accessed `.path` unconditionally, causing an `AttributeError` and a 500 response on every HTTP request when using `app.include_router()`.
+
+**Workaround**
+Pin `fastapi<0.137` until you can upgrade to `elastic-apm>=6.26.2`.
+
+**Resolved**
+On 06/22/2026, this issue was resolved in elastic-apm [6.26.2](index.md).
+:::

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -28,11 +28,14 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} FastAPI 0.137+ causes 500 errors on every request
 **Details**
+
 On 06/19/2026, a known issue was discovered that FastAPI 0.137 changed how included routers are represented internally, introducing `_IncludedRouter` wrapper objects that do not expose a `.path` attribute. The ElasticAPM Starlette/FastAPI middleware accessed `.path` unconditionally, causing an `AttributeError` and a 500 response on every HTTP request when using `app.include_router()`.
 
 **Workaround**
+
 Pin `fastapi<0.137` until you can upgrade to `elastic-apm>=6.26.2`.
 
 **Resolved**
-On 06/22/2026, this issue was resolved in {{product.apm-agent-python}} [6.26.2](index.md#elastic-apm-python-agent-6262-release-notes).
+
+On 06/22/2026, this issue was resolved in [{{product.apm-agent-python}} 6.26.2](index.md#elastic-apm-python-agent-6262-release-notes).
 :::

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -28,11 +28,11 @@ Known issues are significant defects or limitations that may impact your impleme
 
 :::{dropdown} FastAPI 0.137+ causes 500 errors on every request
 **Details**
-On 06/14/2026, a known issue was discovered that FastAPI 0.137 changed how included routers are represented internally, introducing `_IncludedRouter` wrapper objects that do not expose a `.path` attribute. The ElasticAPM Starlette/FastAPI middleware accessed `.path` unconditionally, causing an `AttributeError` and a 500 response on every HTTP request when using `app.include_router()`.
+On 06/19/2026, a known issue was discovered that FastAPI 0.137 changed how included routers are represented internally, introducing `_IncludedRouter` wrapper objects that do not expose a `.path` attribute. The ElasticAPM Starlette/FastAPI middleware accessed `.path` unconditionally, causing an `AttributeError` and a 500 response on every HTTP request when using `app.include_router()`.
 
 **Workaround**
 Pin `fastapi<0.137` until you can upgrade to `elastic-apm>=6.26.2`.
 
 **Resolved**
-On 06/22/2026, this issue was resolved in elastic-apm [6.26.2](index.md).
+On 06/22/2026, this issue was resolved in {{product.apm-agent-python}} [6.26.2](index.md#elastic-apm-python-agent-6262-release-notes).
 :::


### PR DESCRIPTION
## Summary

- Adds a known-issues entry for the FastAPI 0.137 `_IncludedRouter` `AttributeError` regression (issue https://github.com/elastic/apm-agent-python/issues/2681), including a `pin fastapi<0.137` workaround and resolved version (6.26.2, 2026-06-22)
- Updates the Starlette/FastAPI section in supported technologies to note that FastAPI>=0.137 requires elastic-apm>=6.26.2

Closes https://github.com/elastic/docs-content/issues/7084

## Generative AI disclosure

Did you use a generative AI (GenAI) tool to assist in creating this contribution?
- [x] Yes
- [ ] No

If you answered Yes to the previous question, please specify the tool(s) and model(s) used (e.g., Google Gemini, OpenAI ChatGPT-4, etc.).
Tool(s) and model(s) used: Claude Opus 4.8